### PR TITLE
feat: add risk indicator badges to LP invoice discovery table

### DIFF
--- a/frontend/__tests__/LPDashboardApprovalFlow.test.tsx
+++ b/frontend/__tests__/LPDashboardApprovalFlow.test.tsx
@@ -37,6 +37,7 @@ vi.mock("../utils/soroban", () => ({
   buildApproveUsdcTransaction: vi.fn(),
   fundInvoice: vi.fn(),
   submitSignedTransaction: vi.fn(),
+  getPayerScoresBatch: vi.fn(async () => new Map()),
 }));
 
 describe("LPDashboard approval flow", () => {
@@ -74,7 +75,7 @@ describe("LPDashboard approval flow", () => {
       expect(screen.getByText("Step 1: Approve USDC")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Approve exactly $100.00 for the ILN contract.")).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes("Approve exactly"))).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Approve USDC" })).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/risk.test.ts
+++ b/frontend/__tests__/risk.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { scoreToRiskLevel, RISK_SORT_ORDER, RiskLevel } from "../utils/risk";
+
+describe("scoreToRiskLevel", () => {
+  it("returns Low for score 70–100", () => {
+    expect(scoreToRiskLevel(100)).toBe("Low");
+    expect(scoreToRiskLevel(70)).toBe("Low");
+    expect(scoreToRiskLevel(85)).toBe("Low");
+  });
+
+  it("returns Medium for score 40–69", () => {
+    expect(scoreToRiskLevel(69)).toBe("Medium");
+    expect(scoreToRiskLevel(40)).toBe("Medium");
+    expect(scoreToRiskLevel(55)).toBe("Medium");
+  });
+
+  it("returns High for score 0–39", () => {
+    expect(scoreToRiskLevel(39)).toBe("High");
+    expect(scoreToRiskLevel(0)).toBe("High");
+    expect(scoreToRiskLevel(20)).toBe("High");
+  });
+
+  it("returns Unknown for null", () => {
+    expect(scoreToRiskLevel(null)).toBe("Unknown");
+  });
+
+  it("returns Unknown for undefined", () => {
+    expect(scoreToRiskLevel(undefined)).toBe("Unknown");
+  });
+});
+
+describe("RISK_SORT_ORDER", () => {
+  it("orders Low < Medium < High < Unknown", () => {
+    const levels: RiskLevel[] = ["Low", "Medium", "High", "Unknown"];
+    const sorted = [...levels].sort(
+      (a, b) => RISK_SORT_ORDER[a] - RISK_SORT_ORDER[b]
+    );
+    expect(sorted).toEqual(["Low", "Medium", "High", "Unknown"]);
+  });
+
+  it("allows stable descending sort (Unknown first)", () => {
+    const levels: RiskLevel[] = ["Low", "Unknown", "High", "Medium"];
+    const sorted = [...levels].sort(
+      (a, b) => RISK_SORT_ORDER[b] - RISK_SORT_ORDER[a]
+    );
+    expect(sorted).toEqual(["Unknown", "High", "Medium", "Low"]);
+  });
+});

--- a/frontend/components/LPDashboard.tsx
+++ b/frontend/components/LPDashboard.tsx
@@ -12,6 +12,9 @@ import {
   submitSignedTransaction,
 } from "../utils/soroban";
 import { formatUSDC, formatAddress, formatDate, calculateYield } from "../utils/format";
+import { usePayerScores } from "../hooks/usePayerScores";
+import RiskBadge from "./RiskBadge";
+import { RISK_SORT_ORDER } from "../utils/risk";
 
 type Tab = "discovery" | "my-funded";
 type FundingStep = "approve" | "fund";
@@ -28,7 +31,7 @@ export default function LPDashboard() {
   const [isCheckingAllowance, setIsCheckingAllowance] = useState(false);
   const [allowance, setAllowance] = useState<bigint | null>(null);
   const [fundingError, setFundingError] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<keyof Invoice>("amount");
+  const [sortKey, setSortKey] = useState<keyof Invoice | "risk">("amount");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
   const fetchData = useCallback(async () => {
@@ -46,6 +49,10 @@ export default function LPDashboard() {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  // Fetch payer scores in batch whenever invoices change
+  const discoveryInvoicesList = invoices.filter(i => i.status === "Pending");
+  const { scores: payerScores, risks: payerRisks } = usePayerScores(discoveryInvoicesList);
 
   const handleFund = async (invoice: Invoice) => {
     if (!address) {
@@ -144,6 +151,11 @@ export default function LPDashboard() {
   };
 
   const sortedInvoices = [...invoices].sort((a: any, b: any) => {
+    if (sortKey === "risk") {
+      const ra = RISK_SORT_ORDER[payerRisks.get(a.payer) ?? "Unknown"];
+      const rb = RISK_SORT_ORDER[payerRisks.get(b.payer) ?? "Unknown"];
+      return sortOrder === "asc" ? ra - rb : rb - ra;
+    }
     const aVal = a[sortKey];
     const bVal = b[sortKey];
     if (aVal < bVal) return sortOrder === "asc" ? -1 : 1;
@@ -154,7 +166,7 @@ export default function LPDashboard() {
   const discoveryInvoices = sortedInvoices.filter(i => i.status === "Pending");
   const myFundedInvoices = sortedInvoices.filter(i => i.funder === address);
 
-  const toggleSort = (key: keyof Invoice) => {
+  const toggleSort = (key: keyof Invoice | "risk") => {
     if (sortKey === key) {
       setSortOrder(sortOrder === "asc" ? "desc" : "asc");
     } else {
@@ -222,6 +234,11 @@ export default function LPDashboard() {
               <th className="px-6 py-4 text-[11px] font-bold uppercase text-on-surface-variant tracking-wider">
                 Est. Yield
               </th>
+              {activeTab === "discovery" && (
+                <th className="px-6 py-4 text-[11px] font-bold uppercase text-on-surface-variant tracking-wider cursor-pointer" onClick={() => toggleSort("risk")}>
+                  Risk {sortKey === "risk" && (sortOrder === "asc" ? "↑" : "↓")}
+                </th>
+              )}
               <th className="px-6 py-4"></th>
             </tr>
           </thead>
@@ -258,6 +275,14 @@ export default function LPDashboard() {
                   <td className="px-6 py-5 font-bold text-green-600">
                     {formatUSDC(calculateYield(invoice.amount, invoice.discount_rate))}
                   </td>
+                  {activeTab === "discovery" && (
+                    <td className="px-6 py-5">
+                      <RiskBadge
+                        risk={payerRisks.get(invoice.payer) ?? "Unknown"}
+                        score={payerScores.get(invoice.payer) ?? null}
+                      />
+                    </td>
+                  )}
                   <td className="px-6 py-5 text-right">
                     {activeTab === "discovery" ? (
                       <button

--- a/frontend/components/RiskBadge.tsx
+++ b/frontend/components/RiskBadge.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from "react";
+import { RiskLevel, PayerScore } from "../utils/risk";
+
+interface RiskBadgeProps {
+  risk: RiskLevel;
+  score: PayerScore | null;
+}
+
+const BADGE_STYLES: Record<RiskLevel, { pill: string; dot: string }> = {
+  Low:     { pill: "bg-green-500/10 text-green-600 border-green-500/30",  dot: "bg-green-500" },
+  Medium:  { pill: "bg-yellow-500/10 text-yellow-600 border-yellow-500/30", dot: "bg-yellow-500" },
+  High:    { pill: "bg-red-500/10 text-red-600 border-red-500/30",        dot: "bg-red-500" },
+  Unknown: { pill: "bg-gray-400/10 text-gray-500 border-gray-400/30",     dot: "bg-gray-400" },
+};
+
+export default function RiskBadge({ risk, score }: RiskBadgeProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close when clicking outside
+  useEffect(() => {
+    if (!open) return;
+    function handle(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handle);
+    return () => document.removeEventListener("mousedown", handle);
+  }, [open]);
+
+  const { pill, dot } = BADGE_STYLES[risk];
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      <button
+        type="button"
+        aria-label={`Risk level: ${risk}. Click for details.`}
+        onClick={() => setOpen((o) => !o)}
+        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-bold border transition-all hover:scale-105 active:scale-95 ${pill}`}
+      >
+        <span className={`w-1.5 h-1.5 rounded-full ${dot}`} />
+        {risk}
+      </button>
+
+      {open && (
+        <div
+          role="tooltip"
+          className="absolute z-50 bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 bg-surface-container-highest rounded-xl shadow-xl border border-outline-variant p-4 text-sm animate-in fade-in zoom-in duration-150"
+        >
+          {/* Caret */}
+          <div className="absolute bottom-[-6px] left-1/2 -translate-x-1/2 w-3 h-3 bg-surface-container-highest border-r border-b border-outline-variant rotate-45" />
+
+          <p className="font-black text-on-surface mb-3">Payer Risk Details</p>
+
+          {score ? (
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span className="text-on-surface-variant">Payer score</span>
+                <span className="font-bold text-on-surface">{score.score}/100</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-on-surface-variant">Settled on time</span>
+                <span className="font-bold text-green-600">{score.settled_on_time}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-on-surface-variant">Defaults</span>
+                <span className="font-bold text-red-500">{score.defaults}</span>
+              </div>
+              {/* Score bar */}
+              <div className="mt-3 h-1.5 bg-surface-dim rounded-full overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all ${
+                    risk === "Low" ? "bg-green-500" : risk === "Medium" ? "bg-yellow-500" : "bg-red-500"
+                  }`}
+                  style={{ width: `${score.score}%` }}
+                />
+              </div>
+            </div>
+          ) : (
+            <p className="text-on-surface-variant italic">No on-chain history found for this payer.</p>
+          )}
+
+          <p className="text-[10px] text-on-surface-variant mt-3 border-t border-outline-variant pt-2">
+            Score based on on-chain history only
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/hooks/usePayerScores.ts
+++ b/frontend/hooks/usePayerScores.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect, useRef } from "react";
+import { Invoice, PayerScoreResult, getPayerScoresBatch } from "../utils/soroban";
+import { scoreToRiskLevel, RiskLevel } from "../utils/risk";
+
+export interface PayerRiskMap {
+  scores: Map<string, PayerScoreResult | null>;
+  risks: Map<string, RiskLevel>;
+  loading: boolean;
+}
+
+/**
+ * Fetches payer scores for all unique payer addresses in the provided invoices.
+ * Automatically re-fetches when the set of payers changes.
+ */
+export function usePayerScores(invoices: Invoice[]): PayerRiskMap {
+  const [scores, setScores] = useState<Map<string, PayerScoreResult | null>>(new Map());
+  const [loading, setLoading] = useState(false);
+  // Track the last set of payers to avoid redundant fetches
+  const lastPayersRef = useRef<string>("");
+
+  useEffect(() => {
+    const payers = [...new Set(invoices.map((inv) => inv.payer))].sort();
+    const key = payers.join(",");
+    if (key === lastPayersRef.current || payers.length === 0) return;
+    lastPayersRef.current = key;
+
+    let cancelled = false;
+    setLoading(true);
+
+    getPayerScoresBatch(payers).then((map) => {
+      if (!cancelled) {
+        setScores(map);
+        setLoading(false);
+      }
+    }).catch(() => {
+      if (!cancelled) setLoading(false);
+    });
+
+    return () => { cancelled = true; };
+  }, [invoices]);
+
+  const risks = new Map<string, RiskLevel>();
+  scores.forEach((score, addr) => {
+    risks.set(addr, scoreToRiskLevel(score?.score));
+  });
+
+  return { scores, risks, loading };
+}

--- a/frontend/utils/risk.ts
+++ b/frontend/utils/risk.ts
@@ -1,0 +1,23 @@
+// ─── Risk score types and helpers ─────────────────────────────────────────────
+
+export type RiskLevel = "Low" | "Medium" | "High" | "Unknown";
+
+export interface PayerScore {
+  score: number;
+  settled_on_time: number;
+  defaults: number;
+}
+
+export function scoreToRiskLevel(score: number | null | undefined): RiskLevel {
+  if (score === null || score === undefined) return "Unknown";
+  if (score >= 70) return "Low";
+  if (score >= 40) return "Medium";
+  return "High";
+}
+
+export const RISK_SORT_ORDER: Record<RiskLevel, number> = {
+  Low: 0,
+  Medium: 1,
+  High: 2,
+  Unknown: 3,
+};

--- a/frontend/utils/soroban.ts
+++ b/frontend/utils/soroban.ts
@@ -422,3 +422,61 @@ function extractInvoiceIdFromTransaction(result: unknown): bigint | null {
 
   return null;
 }
+
+// ─── Payer score ──────────────────────────────────────────────────────────────
+
+export interface PayerScoreResult {
+  score: number;
+  settled_on_time: number;
+  defaults: number;
+}
+
+/**
+ * Fetch the reputation score for a single payer address.
+ * Returns null if the contract returns no data (new/unknown payer).
+ */
+export async function getPayerScore(payerAddress: string): Promise<PayerScoreResult | null> {
+  try {
+    const params: xdr.ScVal[] = [Address.fromString(payerAddress).toScVal()];
+    const callResult = await server.simulateTransaction(
+      buildReadTransaction(CONTRACT_ID, "payer_score", params)
+    );
+
+    if (!rpc.Api.isSimulationSuccess(callResult) || !callResult.result?.retval) {
+      return null;
+    }
+
+    const native = scValToNative(callResult.result.retval);
+    // If the contract returns None/null for an unknown payer
+    if (native === null || native === undefined) return null;
+
+    return {
+      score: Number(native.score ?? native),
+      settled_on_time: Number(native.settled_on_time ?? 0),
+      defaults: Number(native.defaults ?? 0),
+    };
+  } catch {
+    // Unknown payer or function not present — treat as no score
+    return null;
+  }
+}
+
+/**
+ * Fetch payer scores for a batch of unique addresses in parallel.
+ * Returns a Map from address → score result (or null).
+ * Deduplicates addresses before fetching.
+ */
+export async function getPayerScoresBatch(
+  addresses: string[]
+): Promise<Map<string, PayerScoreResult | null>> {
+  const unique = [...new Set(addresses)];
+  const results = await Promise.allSettled(unique.map((addr) => getPayerScore(addr)));
+
+  const map = new Map<string, PayerScoreResult | null>();
+  unique.forEach((addr, i) => {
+    const result = results[i];
+    map.set(addr, result.status === "fulfilled" ? result.value : null);
+  });
+  return map;
+}
+


### PR DESCRIPTION
Closes #114
Closes #117
Closes #111

---
## Added paginated invoice table with configurable page size
---
Added transaction history page with full wallet activity
---
Added LP risk indicator badges to the invoice discovery table