### PR TITLE
feat: add animated number counters to analytics metric cards

### DIFF
--- a/frontend/app/analytics/page.tsx
+++ b/frontend/app/analytics/page.tsx
@@ -33,6 +33,7 @@ import { NETWORK_NAME } from "../../constants";
 import { getAllInvoices, Invoice } from "../../utils/soroban";
 import AmountHistogram from "../../components/charts/AmountHistogram";
 import { ExportButton } from "../../components/ExportButton";
+import AnimatedNumber from "../../components/AnimatedNumber";
 
 // ─── Metadata (static export — works for server components; kept here for
 //     documentation purposes since this is a "use client" file) ───────────────
@@ -224,6 +225,26 @@ function formatTime(d: Date): string {
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
+// ─── Formatter functions for AnimatedNumber ───────────────────────────────────
+
+/**
+ * Formats USDC values with $ prefix and M/K suffix on completion
+ * Used by AnimatedNumber for animated currency display
+ */
+function formatUsdcAnimated(value: number): string {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(2)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+  return `$${Math.round(value).toLocaleString()}`;
+}
+
+/**
+ * Formats percentage values with one decimal place
+ * Used by AnimatedNumber for animated percentage display
+ */
+function formatPercentAnimated(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
 /** A single KPI summary card */
@@ -234,13 +255,17 @@ function MetricCard({
   value,
   sub,
   accent = false,
+  animatedValue,
+  valueFormatter,
 }: {
   id: string;
   icon: string;
   label: string;
-  value: string;
+  value: string | number;
   sub?: string;
   accent?: boolean;
+  animatedValue?: number;
+  valueFormatter?: (value: number) => string;
 }) {
   return (
     <div
@@ -266,7 +291,15 @@ function MetricCard({
         </span>
       </div>
       <p className={`font-headline text-3xl font-bold ${accent ? "text-primary" : "text-on-surface"}`}>
-        {value}
+        {animatedValue !== undefined && valueFormatter ? (
+          <AnimatedNumber
+            value={animatedValue}
+            duration={1500}
+            formatter={valueFormatter}
+          />
+        ) : (
+          value
+        )}
       </p>
       {sub && <p className="text-xs text-on-surface-variant">{sub}</p>}
     </div>
@@ -472,6 +505,8 @@ export default function AnalyticsPage() {
                 icon="description"
                 label="Total invoices submitted"
                 value={summary.total_invoices_submitted.toLocaleString()}
+                animatedValue={summary.total_invoices_submitted}
+                valueFormatter={(v) => Math.round(v).toLocaleString()}
                 sub="All-time across all statuses"
               />
               <MetricCard
@@ -479,6 +514,8 @@ export default function AnalyticsPage() {
                 icon="payments"
                 label="Total invoices funded"
                 value={summary.total_invoices_funded.toLocaleString()}
+                animatedValue={summary.total_invoices_funded}
+                valueFormatter={(v) => Math.round(v).toLocaleString()}
                 sub="Invoices that received LP capital"
                 accent
               />
@@ -487,6 +524,8 @@ export default function AnalyticsPage() {
                 icon="attach_money"
                 label="Total USDC volume funded"
                 value={formatUsdc(summary.total_usdc_volume_funded)}
+                animatedValue={summary.total_usdc_volume_funded}
+                valueFormatter={formatUsdcAnimated}
                 sub="Gross USDC disbursed to freelancers"
                 accent
               />
@@ -495,6 +534,8 @@ export default function AnalyticsPage() {
                 icon="trending_up"
                 label="Total yield paid to LPs"
                 value={formatUsdc(summary.total_yield_paid_to_lps)}
+                animatedValue={summary.total_yield_paid_to_lps}
+                valueFormatter={formatUsdcAnimated}
                 sub="Cumulative LP earnings from discount"
               />
               <MetricCard
@@ -502,6 +543,8 @@ export default function AnalyticsPage() {
                 icon="hourglass_empty"
                 label="Active invoices"
                 value={summary.active_invoices.toLocaleString()}
+                animatedValue={summary.active_invoices}
+                valueFormatter={(v) => Math.round(v).toLocaleString()}
                 sub="Funded, awaiting settlement"
               />
               <MetricCard
@@ -509,6 +552,12 @@ export default function AnalyticsPage() {
                 icon="report_problem"
                 label="Default rate"
                 value={defaultRate}
+                animatedValue={
+                  summary.total_invoices_funded > 0
+                    ? (summary.total_defaulted / summary.total_invoices_funded) * 100
+                    : 0
+                }
+                valueFormatter={formatPercentAnimated}
                 sub={`${summary.total_defaulted} defaulted / ${summary.total_invoices_funded} funded`}
               />
             </div>

--- a/frontend/components/AnimatedNumber.tsx
+++ b/frontend/components/AnimatedNumber.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+
+/**
+ * Easing function: ease-out cubic
+ * Provides a smooth deceleration effect as the animation completes
+ */
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+export interface AnimatedNumberProps {
+  /** The target value to animate to */
+  value: number;
+  /** Animation duration in milliseconds (default: 1500) */
+  duration?: number;
+  /** Optional formatter function to transform the animated value */
+  formatter?: (value: number) => string;
+  /** CSS class name for styling */
+  className?: string;
+  /** Whether to re-animate when value changes (default: true) */
+  reanimateOnChange?: boolean;
+}
+
+/**
+ * AnimatedNumber component that counts from 0 to a target value
+ * using requestAnimationFrame for smooth 60fps animation.
+ *
+ * Features:
+ * - Smooth ease-out cubic easing
+ * - Respects prefers-reduced-motion
+ * - Re-animates on value changes
+ * - Custom formatter support
+ * - No layout shift during animation
+ */
+const AnimatedNumber: React.FC<AnimatedNumberProps> = ({
+  value,
+  duration = 1500,
+  formatter,
+  className,
+  reanimateOnChange = true,
+}) => {
+  const [displayValue, setDisplayValue] = useState<number>(0);
+  const animationFrameRef = useRef<number | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const previousValueRef = useRef<number>(0);
+  const reducedMotionRef = useRef<boolean>(false);
+
+  // Check for reduced motion preference on mount
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+      reducedMotionRef.current = mediaQuery.matches;
+
+      const handleChange = (e: MediaQueryListEvent) => {
+        reducedMotionRef.current = e.matches;
+      };
+
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+  }, []);
+
+  // Animation function
+  const animate = (timestamp: number) => {
+    if (!startTimeRef.current) {
+      startTimeRef.current = timestamp;
+    }
+
+    const elapsed = timestamp - startTimeRef.current;
+    const progress = Math.min(elapsed / duration, 1);
+    const easedProgress = easeOutCubic(progress);
+
+    const currentValue = previousValueRef.current + (value - previousValueRef.current) * easedProgress;
+    setDisplayValue(currentValue);
+
+    if (progress < 1) {
+      animationFrameRef.current = requestAnimationFrame(animate);
+    } else {
+      // Ensure we land exactly on the target value
+      setDisplayValue(value);
+      startTimeRef.current = null;
+    }
+  };
+
+  // Start animation when value changes
+  useEffect(() => {
+    // Cancel any existing animation
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+    }
+
+    // If reduced motion is preferred, jump straight to the value
+    if (reducedMotionRef.current) {
+      setDisplayValue(value);
+      return;
+    }
+
+    // Store the current display value as the starting point for smooth transitions
+    previousValueRef.current = displayValue;
+    startTimeRef.current = null;
+    animationFrameRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [value, reanimateOnChange]);
+
+  // Format the display value
+  const formattedValue = formatter ? formatter(displayValue) : displayValue.toLocaleString();
+
+  return (
+    <span className={className} data-testid="animated-number">
+      {formattedValue}
+    </span>
+  );
+};
+
+export default AnimatedNumber;

--- a/frontend/components/__tests__/AnimatedNumber.test.tsx
+++ b/frontend/components/__tests__/AnimatedNumber.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * @file AnimatedNumber.test.tsx
+ *
+ * Tests for the AnimatedNumber component, which animates numeric values
+ * from 0 to a target value using requestAnimationFrame.
+ *
+ * Test coverage:
+ * - Renders with correct initial state
+ * - Applies custom formatter function
+ * - Respects prefers-reduced-motion preference
+ * - Re-animates when value prop changes
+ * - Applies custom className
+ */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import AnimatedNumber from "../AnimatedNumber";
+
+// ─── Mock requestAnimationFrame ──────────────────────────────────────────────
+
+beforeEach(() => {
+  // Mock requestAnimationFrame to use setTimeout
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+    return setTimeout(cb, 16) as unknown as number;
+  });
+
+  // Mock cancelAnimationFrame
+  vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id: number) => {
+    clearTimeout(id);
+  });
+
+  // Mock matchMedia for reduced motion (default: no reduced motion)
+  vi.spyOn(window, 'matchMedia').mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as MediaQueryList));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("AnimatedNumber", () => {
+  it("renders with initial value of 0", () => {
+    render(<AnimatedNumber value={100} duration={10} />);
+    expect(screen.getByTestId("animated-number").textContent).toBe("0");
+  });
+
+  it("animates to target value after duration", async () => {
+    render(<AnimatedNumber value={100} duration={50} />);
+
+    // Wait for animation to complete
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-number").textContent).toBe("100");
+    }, { timeout: 500 });
+  });
+
+  it("formats large numbers with locale separators", async () => {
+    render(<AnimatedNumber value={1247} duration={50} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-number").textContent).toBe("1,247");
+    }, { timeout: 500 });
+  });
+
+  it("applies custom formatter function", async () => {
+    const formatter = vi.fn((v) => `$${v.toFixed(0)}`);
+    render(<AnimatedNumber value={500} duration={50} formatter={formatter} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-number").textContent).toBe("$500");
+    }, { timeout: 500 });
+    
+    expect(formatter).toHaveBeenCalled();
+  });
+
+  it("formats USDC values with $ prefix and M/K suffix", async () => {
+    const formatUsdc = (v: number): string => {
+      if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(2)}M`;
+      if (v >= 1_000) return `$${(v / 1_000).toFixed(1)}K`;
+      return `$${Math.round(v).toLocaleString()}`;
+    };
+
+    // Test millions
+    const { rerender } = render(
+      <AnimatedNumber value={1500000} duration={50} formatter={formatUsdc} />
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-number").textContent).toBe("$1.50M");
+    }, { timeout: 500 });
+
+    // Test thousands
+    rerender(
+      <AnimatedNumber value={5000} duration={50} formatter={formatUsdc} />
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-number").textContent).toBe("$5.0K");
+    }, { timeout: 500 });
+
+    // Test hundreds
+    rerender(
+      <AnimatedNumber value={500} duration={50} formatter={formatUsdc} />
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-number").textContent).toBe("$500");
+    }, { timeout: 500 });
+  });
+
+  it("formats percentage values with one decimal place", async () => {
+    const formatPercent = (v: number): string => `${v.toFixed(1)}%`;
+
+    render(<AnimatedNumber value={3.2} duration={50} formatter={formatPercent} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-number").textContent).toBe("3.2%");
+    }, { timeout: 500 });
+  });
+
+  it("respects prefers-reduced-motion by immediately showing final value", () => {
+    // Mock matchMedia to simulate reduced motion preference
+    vi.spyOn(window, 'matchMedia').mockImplementation(query => ({
+      matches: true, // Simulate reduced motion enabled
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as MediaQueryList));
+
+    render(<AnimatedNumber value={100} duration={1000} />);
+
+    // Should immediately show final value without animation
+    expect(screen.getByTestId("animated-number").textContent).toBe("100");
+  });
+
+  it("re-animates when value prop changes", async () => {
+    const { rerender } = render(<AnimatedNumber value={50} duration={50} />);
+
+    // First animation completes
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-number").textContent).toBe("50");
+    }, { timeout: 500 });
+
+    // Change value
+    rerender(<AnimatedNumber value={100} duration={50} />);
+
+    // Second animation completes
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-number").textContent).toBe("100");
+    }, { timeout: 500 });
+  });
+
+  it("applies custom className", () => {
+    render(<AnimatedNumber value={100} className="test-class font-bold" />);
+    expect(screen.getByTestId("animated-number")).toHaveClass("test-class", "font-bold");
+  });
+
+  it("uses default duration of 1500ms", async () => {
+    render(<AnimatedNumber value={100} />);
+
+    // Should start at 0
+    expect(screen.getByTestId("animated-number").textContent).toBe("0");
+
+    // Wait for default animation to complete (1500ms + buffer)
+    await waitFor(() => {
+      expect(screen.getByTestId("animated-number").textContent).toBe("100");
+    }, { timeout: 2000 });
+  });
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+
+// Mock matchMedia for testing components that use prefers-reduced-motion
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(), // deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});


### PR DESCRIPTION
Implements animated number counters for the analytics page metric cards. Numbers now count up from 0 to their target value on page load with smooth ease-out cubic easing over 1.5 seconds.

Features:
- New reusable AnimatedNumber component with requestAnimationFrame
- Ease-out cubic easing for smooth deceleration effect
- Respects prefers-reduced-motion accessibility setting
- Re-animates when value prop changes (data refresh)
- Custom formatter support for USDC ($, M/K suffix) and percentages
- Comprehensive test coverage for animation and accessibility

Closes #165