### PR TITLE
feat: add per-token yield analytics to LP portfolio

### DIFF
--- a/frontend/components/LPDashboard.tsx
+++ b/frontend/components/LPDashboard.tsx
@@ -519,6 +519,8 @@ export default function LPDashboard() {
           isLoading={loading}
           onClaimDefault={handleClaimDefault}
           claimingInvoiceId={claimingInvoiceId}
+          tokenMap={tokenMap}
+          defaultToken={defaultToken}
         />
       ) : (
         <div className="overflow-x-auto">

--- a/frontend/components/LPPortfolio.tsx
+++ b/frontend/components/LPPortfolio.tsx
@@ -1,16 +1,23 @@
 "use client";
 
+import { useState, useMemo } from "react";
 import { formatAddress, formatDate, formatUSDC, calculateYield } from "../utils/format";
 import type { Invoice } from "../utils/soroban";
+import type { ApprovedToken } from "../hooks/useApprovedTokens";
 import InvoiceTable, { ColumnDefinition } from "./InvoiceTable";
 import { EmptyState } from "./EmptyState";
 import { LPPortfolioEmptyIllustration } from "./illustrations/EmptyIllustrations";
+import LPTokenMetricsCards from "./LPTokenMetricsCards";
+import WeeklyYieldChart from "./WeeklyYieldChart";
+import { calculatePerTokenMetrics } from "../utils/per-token-yield";
 
 interface LPPortfolioProps {
   invoices: Invoice[];
   isLoading: boolean;
   onClaimDefault: (invoice: Invoice) => Promise<void>;
   claimingInvoiceId: string | null;
+  tokenMap?: Map<string, ApprovedToken>;
+  defaultToken?: ApprovedToken | null;
 }
 
 export default function LPPortfolio({
@@ -18,8 +25,18 @@ export default function LPPortfolio({
   isLoading,
   onClaimDefault,
   claimingInvoiceId,
+  tokenMap = new Map(),
+  defaultToken = null,
 }: LPPortfolioProps) {
+  const [showUSDEquivalent, setShowUSDEquivalent] = useState(false);
   const now = Date.now();
+
+  // Calculate per-token metrics
+  const perTokenMetrics = useMemo(
+    () => calculatePerTokenMetrics(invoices, tokenMap, defaultToken),
+    [invoices, tokenMap, defaultToken],
+  );
+
   const totalYieldEarned = invoices
     .filter((invoice) => invoice.status === "Paid")
     .reduce((total, invoice) => total + calculateYield(invoice.amount, invoice.discount_rate), 0n);
@@ -111,12 +128,32 @@ export default function LPPortfolio({
   ];
 
   return (
-    <div className="space-y-4 p-6">
+    <div className="space-y-6 p-6">
+      {/* Total Yield Card (Legacy) */}
       <div className="rounded-xl border border-green-200 bg-green-50 p-4">
         <p className="text-xs font-semibold uppercase tracking-wide text-green-700">Total Yield Earned</p>
         <p className="mt-1 text-2xl font-bold text-green-700">{formatUSDC(totalYieldEarned)}</p>
       </div>
 
+      {/* Per-Token Metrics Cards */}
+      {perTokenMetrics.length > 0 && (
+        <LPTokenMetricsCards
+          metrics={perTokenMetrics}
+          showUSDEquivalent={showUSDEquivalent}
+          onToggleUSD={() => setShowUSDEquivalent(!showUSDEquivalent)}
+        />
+      )}
+
+      {/* Weekly Yield Chart */}
+      {perTokenMetrics.length > 0 && (
+        <WeeklyYieldChart
+          invoices={invoices}
+          metrics={perTokenMetrics}
+          showUSDEquivalent={showUSDEquivalent}
+        />
+      )}
+
+      {/* Portfolio Table */}
       <InvoiceTable
         tableId="lp_portfolio_table"
         data={invoices}

--- a/frontend/components/LPTokenMetricsCards.tsx
+++ b/frontend/components/LPTokenMetricsCards.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import React, { useState } from "react";
+import { TokenYieldMetrics, TESTNET_EXCHANGE_RATES, convertToUSD } from "../utils/per-token-yield";
+import { formatTokenAmount } from "../utils/format";
+import AnimatedNumber from "./AnimatedNumber";
+
+interface LPTokenMetricsCardsProps {
+  metrics: TokenYieldMetrics[];
+  showUSDEquivalent: boolean;
+  onToggleUSD: () => void;
+}
+
+export default function LPTokenMetricsCards({
+  metrics,
+  showUSDEquivalent,
+  onToggleUSD,
+}: LPTokenMetricsCardsProps) {
+  if (metrics.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* USD Toggle */}
+      <div className="flex items-center justify-between rounded-lg bg-surface-container-low p-4">
+        <div className="flex items-center gap-3">
+          <label
+            htmlFor="usd-toggle"
+            className="text-sm font-semibold text-on-surface cursor-pointer"
+          >
+            Show in USD equivalent (Testnet Rates)
+          </label>
+          <span className="text-xs text-on-surface-variant italic">
+            Approximate rates: {Object.entries(TESTNET_EXCHANGE_RATES)
+              .map(([token, rate]) => `1 ${token} = ${rate} USD`)
+              .join(", ")}
+          </span>
+        </div>
+        <button
+          id="usd-toggle"
+          onClick={onToggleUSD}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+            showUSDEquivalent ? "bg-primary" : "bg-surface-container"
+          }`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-on-primary transition-transform ${
+              showUSDEquivalent ? "translate-x-6" : "translate-x-1"
+            }`}
+          />
+        </button>
+      </div>
+
+      {/* Token Metrics Cards Grid */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {metrics.map((metric) => {
+          const yieldEarned = showUSDEquivalent
+            ? convertToUSD(metric.totalYieldEarned, metric.token)
+            : metric.totalYieldEarned;
+
+          const funded = showUSDEquivalent
+            ? convertToUSD(metric.totalFunded, metric.token)
+            : metric.totalFunded;
+
+          const pendingYield = showUSDEquivalent
+            ? convertToUSD(metric.pendingYield, metric.token)
+            : metric.pendingYield;
+
+          const displaySymbol = showUSDEquivalent ? "USD" : metric.token.symbol;
+          const displayDecimals = showUSDEquivalent ? 6 : metric.token.decimals;
+
+          return (
+            <div
+              key={metric.token.contractId}
+              className="rounded-2xl border border-outline-variant/10 bg-surface-container-lowest p-6"
+            >
+              {/* Token Header */}
+              <div className="mb-4 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 font-bold text-primary">
+                    {metric.token.iconLabel}
+                  </div>
+                  <span className="font-semibold text-on-surface">{metric.token.symbol}</span>
+                </div>
+                <span className="text-xs font-bold uppercase text-on-surface-variant">
+                  {metric.paidCount}/{metric.invoiceCount} Invoices
+                </span>
+              </div>
+
+              {/* Metrics */}
+              <div className="space-y-3">
+                {/* Total Funded */}
+                <div className="rounded-lg bg-surface-container-low p-3">
+                  <p className="text-xs uppercase tracking-wider text-on-surface-variant">
+                    Total Funded
+                  </p>
+                  <p className="mt-1 font-headline text-lg font-bold text-on-surface">
+                    {formatTokenAmount(funded, {
+                      symbol: displaySymbol,
+                      decimals: displayDecimals,
+                    })}
+                  </p>
+                </div>
+
+                {/* Yield Earned with Percentage */}
+                <div className="rounded-lg bg-green-50 p-3 dark:bg-green-950/20">
+                  <p className="text-xs uppercase tracking-wider text-green-700 dark:text-green-400">
+                    Yield Earned
+                  </p>
+                  <p className="mt-1 flex items-baseline gap-2 font-headline">
+                    <span className="text-lg font-bold text-green-700 dark:text-green-400">
+                      {formatTokenAmount(yieldEarned, {
+                        symbol: displaySymbol,
+                        decimals: displayDecimals,
+                      })}
+                    </span>
+                    <span className="text-sm font-semibold text-green-600 dark:text-green-500">
+                      ({metric.yieldPercentage.toFixed(2)}%)
+                    </span>
+                  </p>
+                </div>
+
+                {/* Pending Yield */}
+                {Number(metric.pendingYield) > 0 && (
+                  <div className="rounded-lg bg-yellow-50 p-3 dark:bg-yellow-950/20">
+                    <p className="text-xs uppercase tracking-wider text-yellow-700 dark:text-yellow-400">
+                      Pending Yield
+                    </p>
+                    <p className="mt-1 font-headline text-sm font-bold text-yellow-700 dark:text-yellow-400">
+                      {formatTokenAmount(pendingYield, {
+                        symbol: displaySymbol,
+                        decimals: displayDecimals,
+                      })}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/WeeklyYieldChart.tsx
+++ b/frontend/components/WeeklyYieldChart.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import React from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { TokenYieldMetrics } from "../utils/per-token-yield";
+import { formatTokenAmount } from "../utils/format";
+
+interface WeeklyYieldChartProps {
+  invoices: any[];
+  metrics: TokenYieldMetrics[];
+  showUSDEquivalent: boolean;
+}
+
+interface ChartDataPoint {
+  week: string;
+  [tokenSymbol: string]: number | string;
+}
+
+export default function WeeklyYieldChart({
+  invoices,
+  metrics,
+  showUSDEquivalent,
+}: WeeklyYieldChartProps) {
+  if (invoices.length === 0 || metrics.length === 0) {
+    return null;
+  }
+
+  // Group paid invoices by week and token
+  const weeklyData = new Map<string, Record<string, bigint>>();
+  const tokenSymbols = new Set<string>();
+
+  invoices
+    .filter((inv) => inv.status === "Paid" && inv.funded_at)
+    .forEach((inv) => {
+      const token = metrics.find(
+        (m) => m.token.contractId === (inv.token || metrics[0]?.token.contractId),
+      );
+      if (!token) return;
+
+      const fundedDate = new Date(Number(inv.funded_at) * 1000);
+      const weekStart = new Date(fundedDate);
+      weekStart.setDate(fundedDate.getDate() - fundedDate.getDay());
+      const weekKey = weekStart.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      });
+
+      tokenSymbols.add(token.token.symbol);
+
+      if (!weeklyData.has(weekKey)) {
+        weeklyData.set(weekKey, {});
+      }
+
+      const weekRecord = weeklyData.get(weekKey)!;
+      const currentYield = (weekRecord[token.token.symbol] ?? 0n) as bigint;
+      const yieldAmount = (inv.amount * BigInt(inv.discount_rate)) / 10000n;
+      weekRecord[token.token.symbol] = currentYield + yieldAmount;
+    });
+
+  // Convert to chart format (convert bigint to number)
+  const chartData: ChartDataPoint[] = Array.from(weeklyData.entries()).map(
+    ([week, tokenYields]) => {
+      const dataPoint: ChartDataPoint = { week };
+      Object.entries(tokenYields).forEach(([symbol, yield_]) => {
+        // Convert from smallest unit to token amount
+        const yieldBigInt = yield_ as bigint;
+        const tokenMetric = metrics.find((m) => m.token.symbol === symbol);
+        if (tokenMetric) {
+          const divisor = 10 ** tokenMetric.token.decimals;
+          dataPoint[symbol] = Number(yieldBigInt) / divisor;
+        }
+      });
+      return dataPoint;
+    },
+  );
+
+  // Sort chronologically
+  chartData.sort((a, b) => {
+    const dateA = new Date(`${a.week} 2026`);
+    const dateB = new Date(`${b.week} 2026`);
+    return dateA.getTime() - dateB.getTime();
+  });
+
+  // Color palette for tokens
+  const colors = ["#6366f1", "#06b6d4", "#8b5cf6", "#ec4899", "#f59e0b"];
+
+  return (
+    <div className="rounded-2xl border border-outline-variant/10 bg-surface-container-lowest p-6">
+      <h2 className="mb-6 font-headline text-xl font-bold text-on-surface">
+        Weekly Yield Breakdown by Token
+      </h2>
+      <div className="h-80 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData} margin={{ top: 20, right: 30, left: 0, bottom: 20 }}>
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke="var(--color-outline-variant)"
+              opacity={0.1}
+            />
+            <XAxis
+              dataKey="week"
+              tick={{ fill: "var(--color-on-surface-variant)", fontSize: 12 }}
+            />
+            <YAxis
+              tick={{ fill: "var(--color-on-surface-variant)", fontSize: 12 }}
+              label={{ value: "Yield (Token Amount)", angle: -90, position: "insideLeft" }}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: "var(--color-surface-container)",
+                border: "1px solid var(--color-outline-variant)",
+              }}
+              labelStyle={{ color: "var(--color-on-surface)" }}
+              formatter={(value: number) => value.toFixed(4)}
+            />
+            <Legend />
+            {Array.from(tokenSymbols).map((symbol, idx) => (
+              <Bar
+                key={symbol}
+                dataKey={symbol}
+                fill={colors[idx % colors.length]}
+                radius={[8, 8, 0, 0]}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="mt-4 text-xs text-on-surface-variant italic">
+        Chart shows yield earned per week, grouped by token. Values are in native token amounts.
+      </p>
+    </div>
+  );
+}

--- a/frontend/utils/per-token-yield.ts
+++ b/frontend/utils/per-token-yield.ts
@@ -1,0 +1,216 @@
+import { Invoice } from "./soroban";
+import { calculateYield } from "./format";
+import type { ApprovedToken } from "../hooks/useApprovedTokens";
+
+/** Hardcoded testnet exchange rates (clearly marked as approximate) */
+export const TESTNET_EXCHANGE_RATES: Record<string, number> = {
+  USDC: 1.0,
+  EURC: 1.08,
+  XLM: 0.15,
+};
+
+export interface TokenYieldMetrics {
+  token: ApprovedToken;
+  totalFunded: bigint;
+  totalYieldEarned: bigint;
+  pendingYield: bigint; // Funded but not yet paid
+  yieldPercentage: number; // Percentage of funded amount
+  invoiceCount: number;
+  paidCount: number;
+}
+
+export interface TokenWeeklyYield {
+  token: ApprovedToken;
+  week: string; // e.g. "Apr 21-27"
+  yield: bigint; // Total yield for the week
+}
+
+/**
+ * Group invoices by token and calculate yield metrics for each
+ */
+export function calculatePerTokenMetrics(
+  invoices: Invoice[],
+  tokenMap: Map<string, ApprovedToken>,
+  defaultToken: ApprovedToken | null,
+): TokenYieldMetrics[] {
+  const groupedByToken = new Map<string, Invoice[]>();
+
+  // Group invoices by token
+  invoices.forEach((inv) => {
+    const tokenId = inv.token ?? defaultToken?.contractId ?? "";
+    if (!groupedByToken.has(tokenId)) {
+      groupedByToken.set(tokenId, []);
+    }
+    groupedByToken.get(tokenId)!.push(inv);
+  });
+
+  // Calculate metrics for each token
+  const metrics: TokenYieldMetrics[] = [];
+
+  groupedByToken.forEach((tokenInvoices, tokenId) => {
+    const token = tokenMap.get(tokenId);
+    if (!token) return; // Skip unknown tokens
+
+    let totalFunded = 0n;
+    let totalYieldEarned = 0n;
+    let pendingYield = 0n;
+    let paidCount = 0;
+
+    tokenInvoices.forEach((inv) => {
+      if (inv.status === "Funded" || inv.status === "Paid") {
+        totalFunded += inv.amount;
+        const yield_ = calculateYield(inv.amount, inv.discount_rate);
+
+        if (inv.status === "Paid") {
+          totalYieldEarned += yield_;
+          paidCount++;
+        } else if (inv.status === "Funded") {
+          pendingYield += yield_;
+        }
+      }
+    });
+
+    const yieldPercentage =
+      totalFunded > 0n
+        ? (Number(totalYieldEarned) / Number(totalFunded)) * 100
+        : 0;
+
+    metrics.push({
+      token,
+      totalFunded,
+      totalYieldEarned,
+      pendingYield,
+      yieldPercentage,
+      invoiceCount: tokenInvoices.length,
+      paidCount,
+    });
+  });
+
+  // Sort by total yield earned (descending)
+  return metrics.sort((a, b) => Number(b.totalYieldEarned) - Number(a.totalYieldEarned));
+}
+
+/**
+ * Calculate weekly yield breakdown per token (last 12 weeks)
+ */
+export function calculateWeeklyYieldPerToken(
+  invoices: Invoice[],
+  tokenMap: Map<string, ApprovedToken>,
+  defaultToken: ApprovedToken | null,
+): TokenWeeklyYield[] {
+  const now = new Date();
+  const weeklyData = new Map<string, Map<number, bigint>>(); // token -> (weekStart -> yield)
+
+  // Initialize token entries
+  tokenMap.forEach((token) => {
+    weeklyData.set(token.contractId, new Map());
+  });
+  if (defaultToken && !weeklyData.has(defaultToken.contractId)) {
+    weeklyData.set(defaultToken.contractId, new Map());
+  }
+
+  // Group paid invoices by week
+  invoices
+    .filter((inv) => inv.status === "Paid" && inv.funded_at)
+    .forEach((inv) => {
+      const tokenId = inv.token ?? defaultToken?.contractId ?? "";
+      const weekMap = weeklyData.get(tokenId);
+      if (!weekMap) return;
+
+      const fundedDate = new Date(Number(inv.funded_at) * 1000);
+      const weekStart = new Date(fundedDate);
+      weekStart.setDate(fundedDate.getDate() - fundedDate.getDay());
+      const weekKey = weekStart.getTime();
+
+      const yield_ = calculateYield(inv.amount, inv.discount_rate);
+      weekMap.set(weekKey, (weekMap.get(weekKey) ?? 0n) + yield_);
+    });
+
+  // Flatten and format
+  const result: TokenWeeklyYield[] = [];
+  weeklyData.forEach((weekMap, tokenId) => {
+    const token = tokenMap.get(tokenId);
+    if (!token) return;
+
+    weekMap.forEach((yield_, weekKey) => {
+      const weekStart = new Date(weekKey);
+      const weekEnd = new Date(weekStart);
+      weekEnd.setDate(weekStart.getDate() + 6);
+      const week = `${weekStart.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      })}-${weekEnd.toLocaleDateString("en-US", { month: "short", day: "numeric" })}`;
+
+      result.push({
+        token,
+        week,
+        yield: yield_,
+      });
+    });
+  });
+
+  return result.sort((a, b) => {
+    // Sort by token first, then by week
+    if (a.token.symbol !== b.token.symbol) {
+      return a.token.symbol.localeCompare(b.token.symbol);
+    }
+    return b.week.localeCompare(a.week);
+  });
+}
+
+/**
+ * Convert yield amount to USD equivalent using testnet rates
+ * @param amount - Amount in smallest unit
+ * @param token - Token metadata
+ * @param rate - Exchange rate (defaults to testnet rates)
+ * @returns Amount in USD
+ */
+export function convertToUSD(
+  amount: bigint,
+  token: ApprovedToken,
+  rate: number = TESTNET_EXCHANGE_RATES[token.symbol] ?? 1,
+): bigint {
+  // Convert amount from smallest unit to token amount
+  const divisor = 10n ** BigInt(token.decimals);
+  const tokenAmount = Number(amount) / Number(divisor);
+  
+  // Apply exchange rate and convert back to smallest unit
+  const usdAmount = tokenAmount * rate;
+  return BigInt(Math.round(usdAmount * Number(divisor)));
+}
+
+/**
+ * Get total yield across all tokens in USD
+ */
+export function getTotalYieldInUSD(
+  metrics: TokenYieldMetrics[],
+  useUSD: boolean,
+): bigint {
+  if (!useUSD) {
+    // Return total in native units (approximate as USDC)
+    return metrics.reduce((sum, m) => sum + m.totalYieldEarned, 0n);
+  }
+
+  return metrics.reduce((sum, m) => {
+    const usdYield = convertToUSD(m.totalYieldEarned, m.token);
+    return sum + usdYield;
+  }, 0n);
+}
+
+/**
+ * Get total funded across all tokens in USD
+ */
+export function getTotalFundedInUSD(
+  metrics: TokenYieldMetrics[],
+  useUSD: boolean,
+): bigint {
+  if (!useUSD) {
+    // Return total in native units (approximate as USDC)
+    return metrics.reduce((sum, m) => sum + m.totalFunded, 0n);
+  }
+
+  return metrics.reduce((sum, m) => {
+    const usdFunded = convertToUSD(m.totalFunded, m.token);
+    return sum + usdFunded;
+  }, 0n);
+}


### PR DESCRIPTION
- Create per-token yield utilities with metrics calculation
- Add LPTokenMetricsCards component showing yield per token with USD toggle
- Add WeeklyYieldChart component for yield breakdown by token over time
- Update LPPortfolio to display per-token metrics and charts
- Implement USD equivalent toggle with hardcoded testnet rates (1 EURC = 1.08 USD, etc.)
- Show yield percentage alongside absolute amounts (e.g. "30 USDC / 3.00%")
- Display pending yield separately per token
- Responsive grid layout for token cards and charts
- Clearly label approximate rates for USD conversion

Closes #53