### PR TITLE
feat: shortcuts modal + top funders widget

### DIFF
--- a/frontend/__tests__/CommandPalette.test.tsx
+++ b/frontend/__tests__/CommandPalette.test.tsx
@@ -219,6 +219,27 @@ describe("CommandPalette", () => {
     expect(screen.getByText("No recent commands")).toBeInTheDocument();
   });
 
+  it("opens shortcuts modal with ? outside input", () => {
+    render(<CommandPalette />);
+    fireEvent.keyDown(window, { key: "?" });
+    expect(screen.getByText("Keyboard shortcuts")).toBeInTheDocument();
+  });
+
+  it("does not open shortcuts modal from input fields", () => {
+    render(
+      <div>
+        <input aria-label="test-input" />
+        <CommandPalette />
+      </div>
+    );
+
+    const input = screen.getByLabelText("test-input");
+    input.focus();
+    fireEvent.keyDown(input, { key: "?" });
+
+    expect(screen.queryByText("Keyboard shortcuts")).not.toBeInTheDocument();
+  });
+
   it("resets selection when query changes", () => {
     render(<CommandPalette />);
     fireEvent.keyDown(window, { key: "k", metaKey: true });

--- a/frontend/app/i/[id]/page.tsx
+++ b/frontend/app/i/[id]/page.tsx
@@ -6,6 +6,7 @@ import { getInvoice, type Invoice } from "../../../utils/soroban";
 import { formatUsdcFromStroops, parseAmountToUnits, parseDiscountRateToBps, toUnixTimestamp } from "../../../utils/invoiceSubmission";
 import { TESTNET_USDC_TOKEN_ID, NETWORK_NAME, CONTRACT_ID } from "../../../constants";
 import ActivityFeed from "../../../components/ActivityFeed";
+import TopFundersWidget from "../../../components/TopFundersWidget";
 import { useWallet } from "../../../context/WalletContext";
 import { useToast } from "../../../context/ToastContext";
 import { useDocumentTitle } from "../../../hooks/useDocumentTitle";
@@ -792,6 +793,8 @@ export default function InvoiceStatusPage({
             </div>
           </section>
 
+          {displayInv.status === "Open" && <TopFundersWidget />}
+
           {/* ── Share panel ──────────────────────────────────────────────── */}
           <section
             aria-label="Share this invoice"
@@ -939,3 +942,4 @@ export default function InvoiceStatusPage({
     </>
   );
 }
+

--- a/frontend/components/CommandPalette.tsx
+++ b/frontend/components/CommandPalette.tsx
@@ -2,9 +2,12 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { useCommandPalette } from "../hooks/useCommandPalette";
+import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+import ShortcutsModal from "./ShortcutsModal";
 
 export default function CommandPalette() {
-  const { isOpen, query, setQuery, commands, executeCommand, close } = useCommandPalette();
+  const { isShortcutsOpen, openShortcuts, closeShortcuts } = useKeyboardShortcuts();
+  const { isOpen, query, setQuery, commands, executeCommand, close } = useCommandPalette(openShortcuts);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -29,10 +32,10 @@ export default function CommandPalette() {
         close();
       } else if (e.key === "ArrowDown") {
         e.preventDefault();
-        setSelectedIndex(prev => Math.min(prev + 1, commands.length - 1));
+        setSelectedIndex((prev) => Math.min(prev + 1, commands.length - 1));
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
-        setSelectedIndex(prev => Math.max(prev - 1, 0));
+        setSelectedIndex((prev) => Math.max(prev - 1, 0));
       } else if (e.key === "Enter" && commands[selectedIndex]) {
         e.preventDefault();
         executeCommand(commands[selectedIndex]);
@@ -50,54 +53,58 @@ export default function CommandPalette() {
     }
   }, [selectedIndex]);
 
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh] bg-black/50" onClick={close}>
-      <div className="w-full max-w-2xl bg-white dark:bg-gray-800 rounded-lg shadow-2xl" onClick={e => e.stopPropagation()}>
-        <div className="p-4 border-b border-gray-200 dark:border-gray-700">
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={e => setQuery(e.target.value)}
-            placeholder="Type a command or invoice number..."
-            className="w-full px-4 py-2 text-lg bg-transparent border-none outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400"
-          />
-        </div>
-
-        <div ref={listRef} className="max-h-96 overflow-y-auto">
-          {commands.length === 0 ? (
-            <div className="p-8 text-center text-gray-500 dark:text-gray-400">
-              {query ? "No commands found" : "No recent commands"}
+    <>
+      <ShortcutsModal isOpen={isShortcutsOpen} onClose={closeShortcuts} />
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[20vh]" onClick={close}>
+          <div className="w-full max-w-2xl rounded-lg bg-white shadow-2xl dark:bg-gray-800" onClick={(e) => e.stopPropagation()}>
+            <div className="border-b border-gray-200 p-4 dark:border-gray-700">
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Type a command or invoice number..."
+                className="w-full border-none bg-transparent px-4 py-2 text-lg text-gray-900 outline-none placeholder-gray-400 dark:text-gray-100"
+              />
             </div>
-          ) : (
-            commands.map((cmd, index) => (
-              <div
-                key={cmd.id}
-                onClick={() => executeCommand(cmd)}
-                className={`px-4 py-3 cursor-pointer flex items-center justify-between ${
-                  index === selectedIndex
-                    ? "bg-blue-50 dark:bg-blue-900/20"
-                    : "hover:bg-gray-50 dark:hover:bg-gray-700/50"
-                }`}
-              >
-                <span className="text-gray-900 dark:text-gray-100">{cmd.label}</span>
-                <span className="text-xs text-gray-500 dark:text-gray-400 uppercase">{cmd.category}</span>
-              </div>
-            ))
-          )}
-        </div>
 
-        <div className="p-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
-          <div className="flex gap-4">
-            <span><kbd className="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">↑↓</kbd> Navigate</span>
-            <span><kbd className="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">Enter</kbd> Select</span>
-            <span><kbd className="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 rounded">Esc</kbd> Close</span>
+            <div ref={listRef} className="max-h-96 overflow-y-auto">
+              {commands.length === 0 ? (
+                <div className="p-8 text-center text-gray-500 dark:text-gray-400">
+                  {query ? "No commands found" : "No recent commands"}
+                </div>
+              ) : (
+                commands.map((cmd, index) => (
+                  <div
+                    key={cmd.id}
+                    onClick={() => executeCommand(cmd)}
+                    className={`flex cursor-pointer items-center justify-between px-4 py-3 ${
+                      index === selectedIndex
+                        ? "bg-blue-50 dark:bg-blue-900/20"
+                        : "hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                    }`}
+                  >
+                    <span className="text-gray-900 dark:text-gray-100">{cmd.label}</span>
+                    <span className="text-xs uppercase text-gray-500 dark:text-gray-400">{cmd.category}</span>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <div className="flex items-center justify-between border-t border-gray-200 p-3 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+              <div className="flex gap-4">
+                <span><kbd className="rounded bg-gray-100 px-1.5 py-0.5 dark:bg-gray-700">Up/Down</kbd> Navigate</span>
+                <span><kbd className="rounded bg-gray-100 px-1.5 py-0.5 dark:bg-gray-700">Enter</kbd> Select</span>
+                <span><kbd className="rounded bg-gray-100 px-1.5 py-0.5 dark:bg-gray-700">Esc</kbd> Close</span>
+              </div>
+              <span>Tip: Type # + number for invoices</span>
+            </div>
           </div>
-          <span>Tip: Type # + number for invoices</span>
         </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 }
+

--- a/frontend/components/ShortcutsModal.tsx
+++ b/frontend/components/ShortcutsModal.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+type Shortcut = {
+  keys: string[];
+  description: string;
+};
+
+type ShortcutGroup = {
+  title: string;
+  items: Shortcut[];
+};
+
+const GROUPS: ShortcutGroup[] = [
+  {
+    title: "Navigation",
+    items: [
+      { keys: ["Cmd", "K"], description: "Command palette" },
+      { keys: ["G", "D"], description: "Go to Dashboard" },
+      { keys: ["G", "L"], description: "Go to LP" },
+      { keys: ["G", "A"], description: "Go to Analytics" },
+    ],
+  },
+  {
+    title: "Tables",
+    items: [
+      { keys: ["↑", "↓"], description: "Navigate rows" },
+      { keys: ["Enter"], description: "Open detail" },
+      { keys: ["F"], description: "Fund invoice" },
+      { keys: ["C"], description: "Cancel invoice" },
+    ],
+  },
+  {
+    title: "General",
+    items: [
+      { keys: ["?"], description: "Show shortcuts" },
+      { keys: ["Esc"], description: "Close modal/drawer" },
+      { keys: ["D"], description: "Toggle dark mode" },
+    ],
+  },
+  {
+    title: "Invoice Detail",
+    items: [
+      { keys: ["E"], description: "Edit invoice (Pending only)" },
+      { keys: ["P"], description: "Print/export PDF" },
+      { keys: ["Q"], description: "Show QR code" },
+    ],
+  },
+];
+
+function KeyBadge({ keyLabel }: { keyLabel: string }) {
+  return (
+    <kbd className="inline-flex min-w-7 items-center justify-center rounded-md border border-gray-300 bg-white px-2 py-1 text-xs font-bold text-gray-800 shadow-[0_1px_0_0_rgba(0,0,0,0.08)] dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100">
+      {keyLabel}
+    </kbd>
+  );
+}
+
+export default function ShortcutsModal({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/55 p-4" onClick={onClose}>
+      <div
+        className="w-full max-w-4xl rounded-2xl border border-gray-200 bg-white p-6 shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">Keyboard shortcuts</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-semibold text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+          >
+            Esc
+          </button>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          {GROUPS.map((group) => (
+            <section key={group.title} className="rounded-xl border border-gray-200 p-4 dark:border-gray-700">
+              <h3 className="mb-3 text-xs font-bold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">
+                {group.title}
+              </h3>
+              <div className="space-y-2.5">
+                {group.items.map((item) => (
+                  <div key={`${group.title}-${item.description}`} className="flex items-center justify-between gap-3">
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      {item.keys.map((k) => (
+                        <KeyBadge keyLabel={k} key={`${item.description}-${k}`} />
+                      ))}
+                    </div>
+                    <p className="text-sm text-gray-700 dark:text-gray-200">{item.description}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
+          These shortcuts work everywhere except inside text inputs.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/TopFundersWidget.tsx
+++ b/frontend/components/TopFundersWidget.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useToast } from "../context/ToastContext";
+
+type Funder = {
+  address: string;
+  fundedCount: number;
+  avgDiscountRate: number;
+};
+
+const CACHE_KEY = "iln_top_funders_30d";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+function truncateAddress(address: string): string {
+  if (address.length < 12) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+function normalizeFunders(data: unknown): Funder[] {
+  if (!Array.isArray(data)) return [];
+  return data.slice(0, 5).map((item: any) => ({
+    address: String(item.address ?? item.lp ?? ""),
+    fundedCount: Number(item.fundedCount ?? item.metric1 ?? 0),
+    avgDiscountRate: Number(item.avgDiscountRate ?? item.metric2 ?? 0),
+  })).filter((row) => row.address.length > 0);
+}
+
+export default function TopFundersWidget() {
+  const { addToast } = useToast();
+  const [rows, setRows] = useState<Funder[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const run = async () => {
+      try {
+        const cachedRaw = localStorage.getItem(CACHE_KEY);
+        if (cachedRaw) {
+          const cached = JSON.parse(cachedRaw) as { savedAt: number; rows: Funder[] };
+          if (Date.now() - cached.savedAt < CACHE_TTL_MS) {
+            setRows(cached.rows);
+            setLoading(false);
+            return;
+          }
+        }
+
+        const response = await fetch("/api/leaderboard?type=lp&period=30d&limit=5", { cache: "no-store" });
+        const data = await response.json();
+        const normalized = normalizeFunders(data);
+        setRows(normalized);
+        localStorage.setItem(CACHE_KEY, JSON.stringify({ savedAt: Date.now(), rows: normalized }));
+      } catch {
+        setRows([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    run();
+  }, []);
+
+  const copyAddress = async (address: string) => {
+    try {
+      await navigator.clipboard.writeText(address);
+      addToast({
+        type: "success",
+        title: "Address copied",
+        message: "LP address copied to clipboard.",
+      });
+    } catch {
+      addToast({
+        type: "error",
+        title: "Copy failed",
+        message: "Could not copy LP address.",
+      });
+    }
+  };
+
+  return (
+    <section className="mt-6 rounded-[24px] border border-outline-variant/15 bg-surface-container-lowest p-6 shadow-xl" aria-label="Top funders">
+      <h2 className="text-sm font-bold uppercase tracking-[0.2em] text-on-surface-variant">
+        Active liquidity providers on ILN
+      </h2>
+
+      {loading && <p className="mt-3 text-sm text-on-surface-variant">Loading active LPs...</p>}
+
+      {!loading && rows.length === 0 && (
+        <p className="mt-3 text-sm text-on-surface-variant">No active LP leaderboard data is available right now.</p>
+      )}
+
+      {!loading && rows.length > 0 && (
+        <div className="mt-4 space-y-3">
+          {rows.map((row, index) => (
+            <div key={row.address} className="rounded-xl border border-outline-variant/15 bg-surface p-4">
+              <div className="flex items-center justify-between">
+                <button
+                  type="button"
+                  onClick={() => copyAddress(row.address)}
+                  className="font-mono text-sm font-semibold text-primary transition-opacity hover:opacity-80"
+                >
+                  {index + 1}. {truncateAddress(row.address)}
+                </button>
+                <span className="text-sm text-on-surface">
+                  {row.fundedCount} invoices (30d)
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-on-surface-variant">
+                Avg discount accepted: {row.avgDiscountRate.toFixed(2)}%
+              </p>
+              <p className="mt-1 text-xs text-on-surface-variant/80">
+                This LP typically funds invoices with {row.avgDiscountRate.toFixed(2)}% discount rate or lower.
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/hooks/useCommandPalette.ts
+++ b/frontend/hooks/useCommandPalette.ts
@@ -25,7 +25,7 @@ function fuzzyMatch(text: string, query: string): boolean {
   return queryIndex === lowerQuery.length;
 }
 
-export function useCommandPalette() {
+export function useCommandPalette(onOpenShortcuts?: () => void) {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [recentCommandIds, setRecentCommandIds] = useState<string[]>([]);
@@ -44,7 +44,8 @@ export function useCommandPalette() {
     { id: "notifications", label: "Open notification settings", action: () => alert("Notification settings coming soon"), category: "settings" },
     { id: "addressbook", label: "Open address book", action: () => alert("Address book coming soon"), category: "settings" },
     { id: "darkmode", label: "Toggle dark mode", action: () => document.documentElement.classList.toggle("dark"), category: "settings" },
-  ], [router]);
+    { id: "shortcuts", label: "Keyboard shortcuts", action: () => onOpenShortcuts?.(), category: "settings" },
+  ], [router, onOpenShortcuts]);
 
   useEffect(() => {
     const stored = localStorage.getItem(RECENT_COMMANDS_KEY);

--- a/frontend/hooks/useKeyboardShortcuts.ts
+++ b/frontend/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from "react";
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+  if (!element) return false;
+  const tag = element.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    (element as HTMLElement).isContentEditable
+  );
+}
+
+export function useKeyboardShortcuts() {
+  const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
+
+  const openShortcuts = useCallback(() => setIsShortcutsOpen(true), []);
+  const closeShortcuts = useCallback(() => setIsShortcutsOpen(false), []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isShortcutsOpen) {
+        event.preventDefault();
+        closeShortcuts();
+        return;
+      }
+
+      if (event.key !== "?") return;
+      if (isTypingTarget(event.target)) return;
+
+      event.preventDefault();
+      openShortcuts();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isShortcutsOpen, openShortcuts, closeShortcuts]);
+
+  return {
+    isShortcutsOpen,
+    openShortcuts,
+    closeShortcuts,
+  };
+}


### PR DESCRIPTION
Closes #164
Closes #173
Closes #162 
 Closes #177 

## Changes
- Added a keyboard shortcuts cheat sheet modal with grouped shortcuts and key badges.
- Added a global ? keyboard trigger that is disabled while typing in inputs.
- Added a "Keyboard shortcuts" command in the command palette.
- Added a top funders widget on invoice detail pages for pending/open invoices only.
- Added address copy-to-clipboard with toast feedback and daily local cache for leaderboard data.
- Added tests for ? shortcut modal behavior and input-field exclusion.

## Testing
- Could not run frontend tests locally because vitest is unavailable in this workspace environment (vitest command not found).
