### PR TITLE
chore: add Renovate configuration for automated dependency updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for your interest in contributing. ILN is an open-source protocol and 
 - [Development setup](#development-setup)
 - [Submitting a pull request](#submitting-a-pull-request)
 - [Code standards](#code-standards)
+- [Automated dependency updates](#automated-dependency-updates)
 - [Getting help](#getting-help)
 
 ---
@@ -173,6 +174,49 @@ Commit messages are validated automatically:
 - CI: Pull request titles are validated by a GitHub Action. The PR title is used as the squash commit message, so it must follow the same format.
 
 Example: `ci: add commitlint for conventional commit enforcement`
+
+---
+
+## Automated dependency updates
+
+This repository uses [Renovate](https://github.com/renovatebot/renovate) to keep npm, pnpm, Cargo, and GitHub Actions dependencies current. Configuration lives in [`renovate.json`](./renovate.json) at the repository root.
+
+### Behavior
+
+| Update type | Behavior |
+|-------------|----------|
+| Patch | Individual pull requests (ungrouped for safe auto-merge); merged automatically when CI passes after a short release-age window |
+| Minor, pin, digest | Grouped into a single weekly pull request (Mondays, 09:00 UTC) |
+| Major | Separate pull requests with migration notes; never auto-merged |
+| `@stellar/*` major | Requires dependency-dashboard approval and manual review |
+| Lock files | Refreshed weekly (Mondays, 09:00 UTC) |
+
+Renovate runs on weekdays between 09:00 and 10:00 UTC.
+
+### Enabling Renovate on a fork
+
+1. Install the [Mend Renovate GitHub App](https://github.com/apps/renovate) on your fork or organization.
+2. Grant access to this repository.
+3. Renovate opens an onboarding pull request; merge it to activate updates.
+
+Maintainers enable Renovate on the upstream repository the same way.
+
+### Validating configuration locally
+
+```bash
+npx --yes --package renovate renovate-config-validator renovate.json
+```
+
+Optional full dry run (requires a GitHub token with repository read access):
+
+```bash
+export RENOVATE_TOKEN="$GITHUB_TOKEN"
+npx --yes --package renovate renovate --platform=github \
+  --dry-run=full \
+  Invoice-Liquidity-Network/Invoice-Liquidity-Network
+```
+
+Review the dry-run output for expected package managers, schedules, and grouping before merging configuration changes.
 
 ---
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":separateMajorReleases",
+    "group:monorepos",
+    "group:recommended",
+    "workarounds:all"
+  ],
+  "timezone": "UTC",
+  "schedule": [
+    "after 9am on monday,tuesday,wednesday,thursday,friday",
+    "before 10am on monday,tuesday,wednesday,thursday,friday"
+  ],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 4,
+  "platformAutomerge": true,
+  "automergeType": "pr",
+  "commitMessagePrefix": "chore(deps): ",
+  "commitMessageAction": "update",
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "to {{newVersion}}",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 10am on monday"],
+    "timezone": "UTC",
+    "commitMessageAction": "refresh",
+    "commitMessageTopic": "lock files",
+    "groupName": "lock file maintenance"
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "automerge": false
+  },
+  "packageRules": [
+    {
+      "description": "Weekly batch for non-major updates (patch PRs are ungrouped below for auto-merge)",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "non-major dependencies",
+      "groupSlug": "non-major",
+      "schedule": ["before 10am on monday"],
+      "timezone": "UTC"
+    },
+    {
+      "description": "Auto-merge patch updates when CI passes",
+      "matchUpdateTypes": ["patch"],
+      "groupName": null,
+      "automerge": true,
+      "automergeType": "pr",
+      "minimumReleaseAge": "3 days",
+      "ignoreTests": false
+    },
+    {
+      "description": "Major updates as separate PRs with migration context",
+      "matchUpdateTypes": ["major"],
+      "groupName": null,
+      "automerge": false,
+      "labels": ["dependencies", "major-update"],
+      "prBodyNotes": [
+        "This is a major version upgrade. Review the release notes and migration guide linked below before merging."
+      ]
+    },
+    {
+      "description": "Stellar SDK major releases require manual review",
+      "matchPackagePatterns": ["^@stellar/"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "dependencyDashboardApproval": true,
+      "labels": ["dependencies", "stellar-sdk", "manual-review"],
+      "prBodyNotes": [
+        "Stellar SDK major releases may include breaking API changes. Confirm Soroban compatibility and run the full test suite before merging."
+      ]
+    },
+    {
+      "description": "Stellar packages use semver bump ranges; major updates use separate rules above",
+      "matchPackagePatterns": ["^@stellar/"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": "GitHub Actions use digest pinning where applicable",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    },
+    {
+      "description": "Rust crate updates respect workspace lockfiles",
+      "matchManagers": ["cargo"],
+      "rangeStrategy": "bump"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `renovate.json` at the repository root with scheduling, grouping, auto-merge, and Stellar SDK policies per issue requirements.
- Documents Renovate behavior, enablement, and local validation in `CONTRIBUTING.md`.

Closes #254

## Configuration highlights

| Requirement | Implementation |
|-------------|----------------|
| Weekly non-major batch | Minor, pin, and digest updates grouped Mondays before 10:00 UTC |
| Patch auto-merge | Patch updates ungrouped and auto-merged when CI passes (3-day release age) |
| Major updates | Separate PRs with migration notes; never auto-merged |
| Stellar SDK | `@stellar/*` majors require dependency-dashboard approval and manual review |
| Schedule | Weekdays 09:00–10:00 UTC |
| Lock files | Weekly maintenance on Mondays before 10:00 UTC |

## Changes

- **`renovate.json`** — Renovate config for the pnpm monorepo, GitHub Actions, and Cargo; semantic commit messages compatible with commitlint and PR title lint.
- **`CONTRIBUTING.md`** — New “Automated dependency updates” section with behavior table, Mend Renovate setup steps, and validator / dry-run commands.

## Test plan

- [x] `npx --yes --package renovate renovate-config-validator renovate.json` passes
- [ ] Merge PR and install [Mend Renovate](https://github.com/apps/renovate) on the org/repo if not already enabled
- [ ] Merge Renovate onboarding PR when it appears
- [ ] Optional: run Renovate dry-run per `CONTRIBUTING.md` before enabling on production
