### PR TITLE
docs: document branch protection rules for main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Thank you for your interest in contributing. ILN is an open-source protocol and 
 - [Applying to work on an issue](#applying-to-work-on-an-issue)
 - [Development setup](#development-setup)
 - [Submitting a pull request](#submitting-a-pull-request)
+- [Branch protection](#branch-protection)
 - [Code standards](#code-standards)
 - [Getting help](#getting-help)
 
@@ -35,8 +36,8 @@ We use an application process to avoid duplicate work.
 
 Browse [open issues](../../issues) and filter by label:
 
-|        Label       |             Meaning                |
-|--------------------|------------------------------------|
+| Label              | Meaning                            |
+| ------------------ | ---------------------------------- |
 | `help wanted`      | High priority, no funding attached |
 | `good first issue` | Well-scoped, good entry point      |
 | `in progress`      | Already claimed, do not apply      |
@@ -138,6 +139,13 @@ git merge upstream/main
 
 ---
 
+## Branch protection
+
+Branch protection settings for the `main` branch are documented in [docs/branch-protection.md](docs/branch-protection.md).
+These settings include required PR reviews, required status checks, dismissing stale reviews on new commits, requiring linear history, and restricting force pushes.
+
+---
+
 ## Code standards
 
 ### Rust / Soroban contracts
@@ -169,6 +177,7 @@ not just what was changed.
 Allowed types: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `perf`, `ci`, `design`, `build`
 
 Commit messages are validated automatically:
+
 - Local: Husky runs `commitlint` on commit messages via the `commit-msg` hook.
 - CI: Pull request titles are validated by a GitHub Action. The PR title is used as the squash commit message, so it must follow the same format.
 
@@ -183,6 +192,7 @@ If you discover a security vulnerability in the smart contract or any part of IL
 Email us at: `margretnursca@gmail.com` (or open a [GitHub Security Advisory](../../security/advisories/new))
 
 Please include:
+
 - A description of the vulnerability
 - Steps to reproduce
 - Your assessment of impact
@@ -194,7 +204,7 @@ We will acknowledge your report within 48 hours and work with you on a responsib
 
 - **GitHub Discussions** — for questions, ideas, and general conversation: [Discussions tab](../../discussions)
 - **Issues** — for bug reports and feature requests only
-- **Discord** — [invite link] *(add your community link here)*
+- **Discord** — [invite link] _(add your community link here)_
 
 If you are new to Soroban development, the [Stellar Developer Docs](https://developers.stellar.org/docs/build/smart-contracts/overview) are the best starting point. The [Soroban examples repo](https://github.com/stellar/soroban-examples) is also very useful for understanding contract patterns.
 
@@ -206,4 +216,4 @@ This project follows the [Contributor Covenant](https://www.contributor-covenant
 
 ---
 
-*Questions about the contribution process? Open a [Discussion](../../discussions) and we'll help.*
+_Questions about the contribution process? Open a [Discussion](../../discussions) and we'll help._

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,60 @@
+# Branch protection rules for `main`
+
+This document describes the required GitHub branch protection settings for the `main` branch.
+These settings are intended to preserve code quality, enforce review discipline, and protect the repository from unsafe history changes.
+
+## Required settings for `main`
+
+### 1. Protect the `main` branch
+
+- Enable branch protection on the `main` branch.
+- Do not allow direct pushes to `main` unless through a protected merge path.
+
+### 2. Require pull request reviews before merging
+
+- Require pull request review before merging.
+- Require at least **1 approving review**.
+- Require review from **CODEOWNERS**.
+  - This ensures the domain experts and maintainers identified in `.github/CODEOWNERS` must sign off on changes affecting owned files.
+  - If a `.github/CODEOWNERS` file is not present, add one and keep this branch protection requirement enabled.
+
+### 3. Dismiss stale pull request approvals when new commits are pushed
+
+- Enable **Dismiss stale pull request approvals when new commits are pushed**.
+- Reason: ensures reviewers reapprove the PR after any code changes, keeping review status current.
+
+### 4. Require linear history
+
+- Enable **Require linear history**.
+- Reason: prevents merge commits and ensures the `main` commit history remains easy to audit and backtrack.
+
+### 5. Restrict force pushes
+
+- Enable **Restrict force pushes** for `main`.
+- Reason: prevents destructive rewrites of the branch history and preserves auditability.
+
+### 6. Require status checks to pass before merging
+
+Require the following GitHub Actions status checks on `main`:
+
+- `CI / Run tests`
+- `CI / Build contract`
+- `CI / Lint code`
+- `CI / Run Node.js tests`
+- `CI / Node.js coverage (≥80%)`
+- `PR title lint / lint`
+
+Reason: these checks enforce the repository's core build, test, lint, and PR quality gates before any merge into `main`.
+
+> Note: `E2E Nightly` is a scheduled workflow, not a required merge-time check. It still provides important nightly regression coverage, but it is not typically included as a required PR status check.
+
+## Additional notes
+
+- If the repository adds a `.github/CODEOWNERS` file, update it to include the teams or maintainers responsible for each area of the codebase.
+- If branch protection settings are changed in the GitHub UI, this document should be updated to match those settings.
+- These settings are intended for `main` only; feature branches should follow the same PR workflow but do not require the same repository-level protection rules.
+
+## Verification
+
+- Verify the `main` branch protection settings in GitHub repository settings.
+- Confirm that the required status checks listed above appear in the branch protection rule for `main`.


### PR DESCRIPTION
closes #319 

PR Title
docs: document branch protection rules for main branch

PR Description
Added [branch-protection.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) documenting required GitHub branch protection settings for main
Included required status checks, required reviews, dismiss stale approvals, linear history, and force push restrictions
Updated [CONTRIBUTING.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with a new Branch protection section and TOC entry linking to the new documentation
Based the required checks on existing workflows in [ci.yml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [pr-title-lint.yml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)