### PR TITLE
feat: add public protocol health status page with uptime monitoring

### DIFF
--- a/.github/workflows/upptime.yml
+++ b/.github/workflows/upptime.yml
@@ -1,0 +1,57 @@
+name: Upptime
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  summary:
+    name: Summary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: upptime/uptime-monitor@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  response-time:
+    name: Response Time
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: upptime/uptime-monitor@master
+        env:
+          NOTIFICATION_SLACK: ${{ secrets.NOTIFICATION_SLACK }}
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TYPE: response-time
+
+  graphs:
+    name: Graphs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: upptime/uptime-monitor@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TYPE: graphs
+
+  static-site:
+    name: Static Site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: upptime/uptime-monitor@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TYPE: static-site

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -1,0 +1,52 @@
+owner: Invoice-Liquidity-Network
+repo: Invoice-Liquidity-Network
+userAgent: Upptime/1.0
+
+sites:
+  - name: Stellar Horizon Testnet
+    url: https://horizon-testnet.stellar.org
+  - name: Stellar Horizon Mainnet
+    url: https://horizon.stellar.org
+  - name: ILN Contract (Testnet)
+    url: https://soroban-testnet.stellar.org
+    method: POST
+    headers:
+      - "Content-Type: application/json"
+    body: '{"jsonrpc":"2.0","id":1,"method":"getContractData","params":{"contract":"CCPASLHKRFBMVV5PZG3LKDGKFEDXZMB5U7DK42CVLUVWCMUCSRPVBIMO"}}'
+    expectedStatusCodes:
+      - 200
+  - name: ILN Frontend
+    url: https://iln.finance
+  - name: ILN Docs
+    url: https://docs.iln.finance
+
+status-website:
+  cname: status.iln.finance
+  name: ILN Status
+  logoUrl: https://iln.finance/logo.png
+  introTitle: ILN Protocol Status
+  introMessage: Real-time and historical uptime for the Invoice Liquidity Network protocol services.
+  navbar:
+    - title: ILN
+      href: https://iln.finance
+    - title: Docs
+      href: https://docs.iln.finance
+    - title: GitHub
+      href: https://github.com/Invoice-Liquidity-Network
+
+assignees:
+  - abikedaniel22
+
+skipDeleteIssues: false
+commitMessages:
+  readmeContent: "docs: update status summary [skip ci]"
+
+i18n:
+  langCode: en
+
+workflowSchedule:
+  graphs: "0 0 * * *"
+  responseTime: "0 23 * * 0"
+  staticSite: "0 1 * * *"
+  summary: "0 0 * * *"
+  updates: "*/5 * * * *"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/actions/workflows/ci.yml/badge.svg)](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/actions/workflows/ci.yml)
 [![E2E Nightly](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/actions/workflows/e2e-nightly.yml/badge.svg)](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/actions/workflows/e2e-nightly.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![Status](https://img.shields.io/badge/status-status.iln.finance-brightgreen)](https://status.iln.finance)
 
 **Turn unpaid invoices into instant liquidity on-chain, on Stellar.**
 


### PR DESCRIPTION
- Add .upptimerc.yml configuring Upptime with 5-minute checks for: Stellar Horizon testnet/mainnet, ILN contract (Soroban RPC), ILN frontend, and ILN docs site
- Add .github/workflows/upptime.yml GitHub Actions workflow for automated monitoring, incident creation, and GitHub Pages deployment
- Add status badge to README pointing to status.iln.finance
- 90-day historical uptime chart enabled via Upptime graphs job

Closes #296