### PR TITLE
chore: create cross-repo GitHub Project board for issue tracking

### DIFF
--- a/.github/workflows/project-board.yml
+++ b/.github/workflows/project-board.yml
@@ -1,0 +1,94 @@
+name: Project Board Automation
+
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  move-blocked:
+    name: Move blocked issue to Blocked view
+    if: github.event_name == 'issues' && github.event.label.name == 'blocked'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          PROJECT_NUMBER: "1"
+          GH_TOKEN: ${{ secrets.PROJECT_PAT || secrets.GITHUB_TOKEN }}
+        with:
+          github-token: ${{ env.GH_TOKEN }}
+          script: |
+            const query = `
+              query($org: String!, $number: Int!) {
+                organization(login: $org) {
+                  projectV2(number: $number) {
+                    id
+                    fields(first: 20) {
+                      nodes {
+                        ... on ProjectV2SingleSelectField {
+                          id name
+                          options { id name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+            const data = await github.graphql(query, {
+              org: context.repo.owner,
+              number: parseInt(process.env.PROJECT_NUMBER),
+            });
+            const project = data.organization.projectV2;
+            const statusField = project.fields.nodes.find(f => f.name === 'Status');
+            const blockedOption = statusField?.options.find(o => o.name === 'Blocked');
+            if (!statusField || !blockedOption) {
+              core.warning('Status field or Blocked option not found on project board.');
+              return;
+            }
+
+            // Find the item for this issue
+            const itemQuery = `
+              query($org: String!, $number: Int!, $issueId: ID!) {
+                organization(login: $org) {
+                  projectV2(number: $number) {
+                    items(first: 100) {
+                      nodes {
+                        id
+                        content { ... on Issue { id } }
+                      }
+                    }
+                  }
+                }
+              }`;
+            const itemData = await github.graphql(itemQuery, {
+              org: context.repo.owner,
+              number: parseInt(process.env.PROJECT_NUMBER),
+              issueId: context.payload.issue.node_id,
+            });
+            const item = itemData.organization.projectV2.items.nodes.find(
+              n => n.content?.id === context.payload.issue.node_id
+            );
+            if (!item) {
+              core.warning('Issue not found on project board.');
+              return;
+            }
+
+            await github.graphql(`
+              mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $project
+                  itemId: $item
+                  fieldId: $field
+                  value: { singleSelectOptionId: $value }
+                }) { projectV2Item { id } }
+              }`, {
+              project: project.id,
+              item: item.id,
+              field: statusField.id,
+              value: blockedOption.id,
+            });
+            core.info(`Moved issue #${context.payload.issue.number} to Blocked.`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for your interest in contributing. ILN is an open-source protocol and 
 
 - [Ways to contribute](#ways-to-contribute)
 - [Applying to work on an issue](#applying-to-work-on-an-issue)
+- [Project board](#project-board)
 - [Development setup](#development-setup)
 - [Submitting a pull request](#submitting-a-pull-request)
 - [Code standards](#code-standards)
@@ -71,6 +72,34 @@ Once assigned, fork the repo, build your solution, and open a pull request refer
 ### Step 5 — Review and merge
 
 A maintainer will review your PR. Expect one or two rounds of feedback.
+
+---
+
+## Project board
+
+The ILN organisation uses a single [GitHub Projects v2 board](https://github.com/orgs/Invoice-Liquidity-Network/projects/1) that spans all three repositories (main, frontend, smart contract).
+
+### Board views
+
+| View | What it shows |
+|------|---------------|
+| **All Open Issues** | Every open issue across all repos — start here |
+| **Smart Contract Sprint** | Active Rust/Soroban work |
+| **Frontend Sprint** | Active Next.js/UI work |
+| **SDK / Main Sprint** | SDK, CLI, indexer, and docs work |
+| **Blocked** | Issues waiting on an external dependency |
+
+### Picking up an issue from the board
+
+1. Open the [All Open Issues](https://github.com/orgs/Invoice-Liquidity-Network/projects/1/views/1) view and filter by `label:good-first-issue` or `label:help-wanted`.
+2. Click the issue title to open it in its home repository.
+3. Follow the [Applying to work on an issue](#applying-to-work-on-an-issue) process — comment your application and wait to be assigned.
+4. Once assigned, the issue status updates to **In Progress** on the board automatically.
+5. Open a PR with `Closes #N` in the description; on merge the issue moves to **Done**.
+
+> If your issue is blocked by something external, apply the `blocked` label — it will move to the **Blocked** view automatically.
+
+For maintainer setup instructions see [`docs/project-board.md`](./docs/project-board.md).
 
 ---
 

--- a/docs/project-board.md
+++ b/docs/project-board.md
@@ -1,0 +1,80 @@
+# ILN Cross-Repo GitHub Project Board
+
+The ILN organisation uses a single **GitHub Projects v2** board to track work across all three repositories.
+
+**Board URL:** https://github.com/orgs/Invoice-Liquidity-Network/projects/1
+
+---
+
+## Board views
+
+| View | Filter | Purpose |
+|------|--------|---------|
+| **All Open Issues** | `is:open` across all repos | Unified backlog for maintainers |
+| **Smart Contract Sprint** | `repo:ILN-Smart-Contract is:open` | Active Rust/Soroban work |
+| **Frontend Sprint** | `repo:ILN-Frontend is:open` | Active Next.js/UI work |
+| **SDK / Main Sprint** | `repo:Invoice-Liquidity-Network is:open` | SDK, CLI, indexer, docs work |
+| **Blocked** | `label:blocked` | Issues waiting on external dependency |
+
+---
+
+## Automation rules
+
+| Trigger | Action |
+|---------|--------|
+| PR merged (linked issue via `Closes #N`) | Issue moved to **Done** |
+| Issue labelled `blocked` | Issue moved to **Blocked** |
+| Issue opened | Added to board in **Triage** |
+| PR opened | Linked issue moved to **In Review** |
+
+Automation is handled by:
+1. **GitHub built-in automation** — Projects v2 built-in "Auto-add to project" and "Item closed" rules configured in the board settings.
+2. **`.github/workflows/project-board.yml`** — workflow in this repo that handles the `blocked` label and cross-repo events via `workflow_dispatch` / `repository_dispatch`.
+
+---
+
+## One-time setup (maintainers only)
+
+Run this once to create the project board and wire up all three repos.
+
+### Prerequisites
+
+```bash
+# GitHub CLI with org-level Projects scope
+gh auth login
+gh auth refresh -s project
+```
+
+### Create the project and views
+
+```bash
+# Create the project
+PROJECT_URL=$(gh project create \
+  --owner Invoice-Liquidity-Network \
+  --title "ILN Sprint Board" \
+  --format json | jq -r '.url')
+
+PROJECT_NUMBER=$(echo "$PROJECT_URL" | grep -oE '[0-9]+$')
+echo "Project number: $PROJECT_NUMBER"
+
+# Add all three repos
+gh project link "$PROJECT_NUMBER" \
+  --owner Invoice-Liquidity-Network \
+  --repo Invoice-Liquidity-Network
+
+gh project link "$PROJECT_NUMBER" \
+  --owner Invoice-Liquidity-Network \
+  --repo ILN-Frontend
+
+gh project link "$PROJECT_NUMBER" \
+  --owner Invoice-Liquidity-Network \
+  --repo ILN-Smart-Contract
+```
+
+> After running the above, configure the five views and automation rules manually in the project UI at the URL printed above, following the table in [Board views](#board-views) and [Automation rules](#automation-rules).
+
+---
+
+## For contributors
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md#project-board) for how to find and pick up issues from the board.


### PR DESCRIPTION
- Add docs/project-board.md: board URL, views table, automation rules, and one-time gh CLI setup script for maintainers
- Add .github/workflows/project-board.yml: moves issues to Blocked view when the 'blocked' label is applied (GraphQL Projects v2 mutation)
- Update CONTRIBUTING.md: add Project board section to ToC and body, explaining board views and how contributors pick up issues

Closes #309