### PR TITLE
example: add Bruno and Postman API collection for Horizon and Soroban…

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ npm run test:e2e              # Run E2E integration tests
 | [`docs/governance.md`](./docs/governance.md) | Governance guide |
 | [`docs/multi-token.md`](./docs/multi-token.md) | Multi-token support |
 | [`docs/notifications.md`](./docs/notifications.md) | Notification system |
+| [`docs/api-collection.md`](./docs/api-collection.md) | Horizon and Soroban RPC API collection examples |
 | [`docs/local-development.md`](./docs/local-development.md) | Local dev setup |
 | [`docs/ci-cd.md`](./docs/ci-cd.md) | CI/CD and deployment environments |
 | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | How to contribute |

--- a/docs/api-collection.md
+++ b/docs/api-collection.md
@@ -1,0 +1,94 @@
+# API Collection
+
+This document describes the Invoice Liquidity Network (ILN) Horizon and Soroban RPC collection for testnet.
+
+The collection files are available in `examples/api-collection/`:
+
+- `iln.bru` — Bruno-compatible collection for Horizon and Soroban RPC
+- `iln.postman_collection.json` — Postman v2.1 compatible equivalent
+
+## Supported requests
+
+### Horizon
+
+- `Get Account` — fetch an account from Horizon
+- `Get Transactions` — list recent transactions for an account
+- `Stream Contract Events` — open a Horizon event stream for the ILN contract
+
+### Soroban RPC
+
+- `simulateTransaction` — simulate a transaction locally
+- `sendTransaction` — submit a signed transaction to testnet
+- `getTransaction` — fetch transaction status by hash
+- `getEvents` — query ILN contract events directly from Soroban RPC
+
+## Included variables
+
+The collection is pre-populated with ILN testnet network URLs and contract IDs.
+
+- `horizon_url`: `https://horizon-testnet.stellar.org`
+- `rpc_url`: `https://soroban-testnet.stellar.org`
+- `iln_contract_id`: `CCPASLHKRFBMVV5PZG3LKDGKFEDXZMB5U7DK42CVLUVWCMUCSRPVBIMO`
+- `distribution_contract_id`: `CAQGPMT3EQK4AABMIR66JJXEOCNCLPTDNXMS5OHZXH4LI24UYAF25V5B`
+- `governance_contract_id`: `CD7GOIU3GNK7EZHG7VI4NRVGMRCU7X2FOCAPQN6EGTSW46BY4EB`
+
+Other variables are included as placeholders for the account and transaction details you want to inspect:
+
+- `account_id`
+- `invoice_id`
+- `transaction_hash`
+- `get_invoice_tx_xdr`
+- `submit_invoice_tx_xdr`
+- `signed_submit_invoice_tx_xdr`
+- `get_events_cursor`
+
+## Example XDR argument patterns
+
+The collection includes example argument patterns for the two most common ILN contract calls.
+
+### submit_invoice
+
+A `submit_invoice` contract call requires:
+
+- `freelancer` (`Address`)
+- `payer` (`Address`)
+- `amount` (`i128`)
+- `due_date` (`u64`)
+- `discount_rate` (`u32`)
+
+In Stellar Soroban XDR terms, the arguments are structured like:
+
+```json
+[
+  {"type": "address", "value": "G..."},
+  {"type": "address", "value": "G..."},
+  {"type": "i128", "value": "100000000"},
+  {"type": "u64", "value": "1717065600"},
+  {"type": "u32", "value": "300"}
+]
+```
+
+### get_invoice
+
+A `get_invoice` contract call requires a single invoice ID:
+
+```json
+[
+  {"type": "u64", "value": "1"}
+]
+```
+
+These values are represented in the collection by the `get_invoice_tx_xdr` and `submit_invoice_tx_xdr` variables, which should contain the base64-encoded unsigned transaction envelope.
+
+## How to use
+
+1. Open `examples/api-collection/iln.bru` in Bruno or import `examples/api-collection/iln.postman_collection.json` into Postman.
+2. Replace placeholder variables such as `account_id`, `transaction_hash`, and the XDR variables with real values.
+3. Use the Horizon requests to inspect on-chain accounts and transactions.
+4. Use the Soroban RPC requests to simulate contract calls, submit signed transactions, and query contract events.
+
+## Notes
+
+- `submit_invoice` and other write requests require a properly formed signed transaction envelope.
+- `simulateTransaction` can be used to validate contract invocation before submitting it.
+- The collection is intentionally testnet-focused and uses the official Stellar testnet Horizon and Soroban endpoints.

--- a/examples/api-collection/iln.bru
+++ b/examples/api-collection/iln.bru
@@ -1,0 +1,256 @@
+{
+  "info": {
+    "name": "ILN Horizon + Soroban RPC",
+    "_postman_id": "iln-api-collection",
+    "description": "Bruno-compatible collection for Invoice Liquidity Network testnet Horizon and Soroban RPC requests.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "horizon_url",
+      "value": "https://horizon-testnet.stellar.org"
+    },
+    {
+      "key": "rpc_url",
+      "value": "https://soroban-testnet.stellar.org"
+    },
+    {
+      "key": "iln_contract_id",
+      "value": "CCPASLHKRFBMVV5PZG3LKDGKFEDXZMB5U7DK42CVLUVWCMUCSRPVBIMO"
+    },
+    {
+      "key": "distribution_contract_id",
+      "value": "CAQGPMT3EQK4AABMIR66JJXEOCNCLPTDNXMS5OHZXH4LI24UYAF25V5B"
+    },
+    {
+      "key": "governance_contract_id",
+      "value": "CD7GOIU3GNK7EZHG7VI4NRVGMRCU7X2FOCAPQN6EGTSW46BY4EB"
+    },
+    {
+      "key": "account_id",
+      "value": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    },
+    {
+      "key": "invoice_id",
+      "value": "1"
+    },
+    {
+      "key": "transaction_hash",
+      "value": "YOUR_TX_HASH"
+    },
+    {
+      "key": "get_invoice_tx_xdr",
+      "value": "UNSIGNED_GET_INVOICE_TX_XDR_BASE64"
+    },
+    {
+      "key": "submit_invoice_tx_xdr",
+      "value": "UNSIGNED_SUBMIT_INVOICE_TX_XDR_BASE64"
+    },
+    {
+      "key": "signed_submit_invoice_tx_xdr",
+      "value": "SIGNED_SUBMIT_INVOICE_TX_XDR_BASE64"
+    },
+    {
+      "key": "get_events_cursor",
+      "value": "0"
+    }
+  ],
+  "item": [
+    {
+      "name": "Horizon / Get Account",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{horizon_url}}/accounts/{{account_id}}",
+          "host": [
+            "{{horizon_url}}"
+          ],
+          "path": [
+            "accounts",
+            "{{account_id}}"
+          ]
+        },
+        "description": "Fetch account details for the specified Stellar testnet account. Replace {{account_id}} with a funded account public key."
+      }
+    },
+    {
+      "name": "Horizon / Get Transactions",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{horizon_url}}/accounts/{{account_id}}/transactions?limit=10&order=desc",
+          "host": [
+            "{{horizon_url}}"
+          ],
+          "path": [
+            "accounts",
+            "{{account_id}}",
+            "transactions"
+          ],
+          "query": [
+            {
+              "key": "limit",
+              "value": "10"
+            },
+            {
+              "key": "order",
+              "value": "desc"
+            }
+          ]
+        },
+        "description": "List recent Horizon transactions for the account. Use a valid public key in {{account_id}}."
+      }
+    },
+    {
+      "name": "Horizon / Stream Contract Events",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "text/event-stream"
+          }
+        ],
+        "url": {
+          "raw": "{{horizon_url}}/contracts/{{iln_contract_id}}/events?cursor=now&order=asc",
+          "host": [
+            "{{horizon_url}}"
+          ],
+          "path": [
+            "contracts",
+            "{{iln_contract_id}}",
+            "events"
+          ],
+          "query": [
+            {
+              "key": "cursor",
+              "value": "now"
+            },
+            {
+              "key": "order",
+              "value": "asc"
+            }
+          ]
+        },
+        "description": "Open a Horizon SSE stream for ILN contract events on testnet."
+      }
+    },
+    {
+      "name": "Soroban RPC / Simulate get_invoice",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"simulateTransaction\",\n  \"params\": [\n    {\n      \"transaction\": \"{{get_invoice_tx_xdr}}\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_url}}",
+          "host": [
+            "{{rpc_url}}"
+          ]
+        },
+        "description": "Simulate a read-only get_invoice contract call. Replace {{get_invoice_tx_xdr}} with the unsigned transaction XDR that invokes get_invoice."
+      }
+    },
+    {
+      "name": "Soroban RPC / Simulate submit_invoice",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"simulateTransaction\",\n  \"params\": [\n    {\n      \"transaction\": \"{{submit_invoice_tx_xdr}}\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_url}}",
+          "host": [
+            "{{rpc_url}}"
+          ]
+        },
+        "description": "Simulate the submit_invoice contract call with an unsigned transaction XDR. Use SDK or CLI tooling to create the correct XDR transaction with the ILN contract and argument values."
+      }
+    },
+    {
+      "name": "Soroban RPC / Send Transaction",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"sendTransaction\",\n  \"params\": [\n    {\n      \"transaction\": \"{{signed_submit_invoice_tx_xdr}}\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_url}}",
+          "host": [
+            "{{rpc_url}}"
+          ]
+        },
+        "description": "Submit a signed Soroban transaction to testnet. Replace {{signed_submit_invoice_tx_xdr}} with the signed base64 transaction envelope."
+      }
+    },
+    {
+      "name": "Soroban RPC / Get Transaction",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"getTransaction\",\n  \"params\": [\n    {\n      \"transactionHash\": \"{{transaction_hash}}\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_url}}",
+          "host": [
+            "{{rpc_url}}"
+          ]
+        },
+        "description": "Fetch the status and result of a Soroban transaction by hash."
+      }
+    },
+    {
+      "name": "Soroban RPC / Get Events",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"getEvents\",\n  \"params\": [\n    {\n      \"filters\": [\n        {\n          \"type\": \"contract\",\n          \"contractIds\": [\"{{iln_contract_id}}\"]\n        }\n      ],\n      \"cursor\": \"{{get_events_cursor}}\",\n      \"limit\": 20\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_url}}",
+          "host": [
+            "{{rpc_url}}"
+          ]
+        },
+        "description": "Fetch Soroban contract events for the ILN contract using the RPC getEvents method."
+      }
+    }
+  ]
+}

--- a/examples/api-collection/iln.postman_collection.json
+++ b/examples/api-collection/iln.postman_collection.json
@@ -1,0 +1,256 @@
+{
+  "info": {
+    "name": "ILN Horizon + Soroban RPC (Postman)",
+    "_postman_id": "iln-api-collection-postman",
+    "description": "Postman v2.1 collection for Invoice Liquidity Network testnet Horizon and Soroban RPC requests.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "horizon_url",
+      "value": "https://horizon-testnet.stellar.org"
+    },
+    {
+      "key": "rpc_url",
+      "value": "https://soroban-testnet.stellar.org"
+    },
+    {
+      "key": "iln_contract_id",
+      "value": "CCPASLHKRFBMVV5PZG3LKDGKFEDXZMB5U7DK42CVLUVWCMUCSRPVBIMO"
+    },
+    {
+      "key": "distribution_contract_id",
+      "value": "CAQGPMT3EQK4AABMIR66JJXEOCNCLPTDNXMS5OHZXH4LI24UYAF25V5B"
+    },
+    {
+      "key": "governance_contract_id",
+      "value": "CD7GOIU3GNK7EZHG7VI4NRVGMRCU7X2FOCAPQN6EGTSW46BY4EB"
+    },
+    {
+      "key": "account_id",
+      "value": "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    },
+    {
+      "key": "invoice_id",
+      "value": "1"
+    },
+    {
+      "key": "transaction_hash",
+      "value": "YOUR_TX_HASH"
+    },
+    {
+      "key": "get_invoice_tx_xdr",
+      "value": "UNSIGNED_GET_INVOICE_TX_XDR_BASE64"
+    },
+    {
+      "key": "submit_invoice_tx_xdr",
+      "value": "UNSIGNED_SUBMIT_INVOICE_TX_XDR_BASE64"
+    },
+    {
+      "key": "signed_submit_invoice_tx_xdr",
+      "value": "SIGNED_SUBMIT_INVOICE_TX_XDR_BASE64"
+    },
+    {
+      "key": "get_events_cursor",
+      "value": "0"
+    }
+  ],
+  "item": [
+    {
+      "name": "Horizon / Get Account",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{horizon_url}}/accounts/{{account_id}}",
+          "host": [
+            "{{horizon_url}}"
+          ],
+          "path": [
+            "accounts",
+            "{{account_id}}"
+          ]
+        },
+        "description": "Fetch account details for the specified Stellar testnet account. Replace {{account_id}} with a funded account public key."
+      }
+    },
+    {
+      "name": "Horizon / Get Transactions",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{horizon_url}}/accounts/{{account_id}}/transactions?limit=10&order=desc",
+          "host": [
+            "{{horizon_url}}"
+          ],
+          "path": [
+            "accounts",
+            "{{account_id}}",
+            "transactions"
+          ],
+          "query": [
+            {
+              "key": "limit",
+              "value": "10"
+            },
+            {
+              "key": "order",
+              "value": "desc"
+            }
+          ]
+        },
+        "description": "List recent Horizon transactions for the account. Use a valid public key in {{account_id}}."
+      }
+    },
+    {
+      "name": "Horizon / Stream Contract Events",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "text/event-stream"
+          }
+        ],
+        "url": {
+          "raw": "{{horizon_url}}/contracts/{{iln_contract_id}}/events?cursor=now&order=asc",
+          "host": [
+            "{{horizon_url}}"
+          ],
+          "path": [
+            "contracts",
+            "{{iln_contract_id}}",
+            "events"
+          ],
+          "query": [
+            {
+              "key": "cursor",
+              "value": "now"
+            },
+            {
+              "key": "order",
+              "value": "asc"
+            }
+          ]
+        },
+        "description": "Open a Horizon SSE stream for ILN contract events on testnet."
+      }
+    },
+    {
+      "name": "Soroban RPC / Simulate get_invoice",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"simulateTransaction\",\n  \"params\": [\n    {\n      \"transaction\": \"{{get_invoice_tx_xdr}}\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_url}}",
+          "host": [
+            "{{rpc_url}}"
+          ]
+        },
+        "description": "Simulate a read-only get_invoice contract call. Replace {{get_invoice_tx_xdr}} with the unsigned transaction XDR that invokes get_invoice."
+      }
+    },
+    {
+      "name": "Soroban RPC / Simulate submit_invoice",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"simulateTransaction\",\n  \"params\": [\n    {\n      \"transaction\": \"{{submit_invoice_tx_xdr}}\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_url}}",
+          "host": [
+            "{{rpc_url}}"
+          ]
+        },
+        "description": "Simulate the submit_invoice contract call with an unsigned transaction XDR. Use SDK or CLI tooling to create the correct XDR transaction with the ILN contract and argument values."
+      }
+    },
+    {
+      "name": "Soroban RPC / Send Transaction",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"sendTransaction\",\n  \"params\": [\n    {\n      \"transaction\": \"{{signed_submit_invoice_tx_xdr}}\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_url}}",
+          "host": [
+            "{{rpc_url}}"
+          ]
+        },
+        "description": "Submit a signed Soroban transaction to testnet. Replace {{signed_submit_invoice_tx_xdr}} with the signed base64 transaction envelope."
+      }
+    },
+    {
+      "name": "Soroban RPC / Get Transaction",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"getTransaction\",\n  \"params\": [\n    {\n      \"transactionHash\": \"{{transaction_hash}}\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_url}}",
+          "host": [
+            "{{rpc_url}}"
+          ]
+        },
+        "description": "Fetch the status and result of a Soroban transaction by hash."
+      }
+    },
+    {
+      "name": "Soroban RPC / Get Events",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"method\": \"getEvents\",\n  \"params\": [\n    {\n      \"filters\": [\n        {\n          \"type\": \"contract\",\n          \"contractIds\": [\"{{iln_contract_id}}\"]\n        }\n      ],\n      \"cursor\": \"{{get_events_cursor}}\",\n      \"limit\": 20\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{rpc_url}}",
+          "host": [
+            "{{rpc_url}}"
+          ]
+        },
+        "description": "Fetch Soroban contract events for the ILN contract using the RPC getEvents method."
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Close #278 

PR Description
Summary

Added a ready-to-use API collection for Invoice Liquidity Network testnet, including both Bruno and Postman formats for Horizon and Soroban RPC workflows.
What changed

    Added [iln.bru](https://symmetrical-space-guide-4j4xx7x4xg5gc74v7.github.dev/)
    Added [iln.postman_collection.json](https://symmetrical-space-guide-4j4xx7x4xg5gc74v7.github.dev/)
    Added documentation at [api-collection.md](https://symmetrical-space-guide-4j4xx7x4xg5gc74v7.github.dev/)
    Updated [README.md](https://symmetrical-space-guide-4j4xx7x4xg5gc74v7.github.dev/) to include the new API collection docs

Included requests

    Horizon
        [Get Account](https://symmetrical-space-guide-4j4xx7x4xg5gc74v7.github.dev/)
        Get Transactions
        Stream Contract Events
    Soroban RPC
        [simulateTransaction](https://symmetrical-space-guide-4j4xx7x4xg5gc74v7.github.dev/)
        [sendTransaction](https://symmetrical-space-guide-4j4xx7x4xg5gc74v7.github.dev/)
        getTransaction
        [getEvents](https://symmetrical-space-guide-4j4xx7x4xg5gc74v7.github.dev/)

Notes

    Pre-populated testnet variables include ILN contract IDs and standard Stellar testnet endpoints.
    Includes placeholder variables for XDR transaction envelopes and transaction hashes.
    Collection is intended for developers exploring ILN on-chain state without hand-crafting Horizon/Soroban requests.

Testing

    Import [iln.bru](https://symmetrical-space-guide-4j4xx7x4xg5gc74v7.github.dev/) into Bruno or [iln.postman_collection.json](https://symmetrical-space-guide-4j4xx7x4xg5gc74v7.github.dev/) into Postman.
    Configure environment variables:
        horizon_url = https://horizon-testnet.stellar.org
        rpc_url = https://soroban-testnet.stellar.org
        iln_contract_id = CCPASLHKRFBMVV5PZG3LKDGKFEDXZMB5U7DK42CVLUVWCMUCSRPVBIMO
    Replace placeholder account_id, transaction_hash, and XDR variables with real testnet values.
    Execute Horizon and Soroban RPC requests to validate connectivity and expected responses.