### PR TITLE
feat: add SDK error mapping layer (#231)

### DIFF
--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -1,4 +1,4 @@
-import {
+﻿import {
   Account,
   Address,
   BASE_FEE,
@@ -21,6 +21,10 @@ import type {
   SubmitInvoiceParams,
   TransactionSigner,
 } from "./types";
+
+import { parseContractError } from "./errors";
+
+import { parseContractError } from "./errors";
 
 const READ_ACCOUNT = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 const POLL_ATTEMPTS = 20;
@@ -287,14 +291,10 @@ export class ILNSdk {
       return (value as { Ok: unknown }).Ok;
     }
     if ("err" in value) {
-      throw new Error(
-        `Contract method ${method} returned an error: ${JSON.stringify((value as { err: unknown }).err)}.`,
-      );
+      throw parseContractError((value as { err: unknown }).err);
     }
     if ("Err" in value) {
-      throw new Error(
-        `Contract method ${method} returned an error: ${JSON.stringify((value as { Err: unknown }).Err)}.`,
-      );
+      throw parseContractError((value as { Err: unknown }).Err);
     }
 
     return value;
@@ -374,3 +374,5 @@ export class ILNSdk {
     return String(error);
   }
 }
+
+

--- a/sdk/src/errors.test.ts
+++ b/sdk/src/errors.test.ts
@@ -1,0 +1,22 @@
+﻿import { describe, it, expect } from "vitest";
+import { parseContractError, InvalidDiscountRateError, TokenMismatchError, PayerReputationTooLowError, GenericContractError } from "./errors";
+
+describe("Error Mapping SDK", () => {
+  it("maps InvalidDiscountRate", () => {
+    const err = parseContractError("Error: InvalidDiscountRate");
+    expect(err).toBeInstanceOf(InvalidDiscountRateError);
+    expect(err.code).toBe("INVALID_DISCOUNT_RATE");
+  });
+  it("maps TokenMismatch", () => {
+    const err = parseContractError("Error: TokenMismatch");
+    expect(err).toBeInstanceOf(TokenMismatchError);
+  });
+  it("maps PayerReputationTooLow", () => {
+    const err = parseContractError("Error: PayerReputationTooLow");
+    expect(err).toBeInstanceOf(PayerReputationTooLowError);
+  });
+  it("maps generic errors", () => {
+    const err = parseContractError("UnknownXDRCode");
+    expect(err).toBeInstanceOf(GenericContractError);
+  });
+});

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -1,0 +1,43 @@
+﻿export class ILNError extends Error {
+  public code: string;
+  public remediation: string;
+
+  constructor(message: string, code: string, remediation: string) {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = code;
+    this.remediation = remediation;
+  }
+}
+
+export class InvalidDiscountRateError extends ILNError {
+  constructor() { 
+    super("Invalid discount rate provided.", "INVALID_DISCOUNT_RATE", "Ensure the discount rate is within the allowed bounds."); 
+  }
+}
+
+export class TokenMismatchError extends ILNError {
+  constructor() { 
+    super("Token mismatch in transaction.", "TOKEN_MISMATCH", "Verify that the correct token addresses are being used."); 
+  }
+}
+
+export class PayerReputationTooLowError extends ILNError {
+  constructor() { 
+    super("Payer reputation is too low.", "PAYER_REPUTATION_TOO_LOW", "The payer must improve their reputation score before proceeding."); 
+  }
+}
+
+export class GenericContractError extends ILNError {
+  constructor(rawError: string) { 
+    super(`Contract error: ${rawError}`, "CONTRACT_ERROR", "Check contract logic or inputs."); 
+  }
+}
+
+export function parseContractError(xdrError: unknown): ILNError {
+  const errorStr = typeof xdrError === 'string' ? xdrError : JSON.stringify(xdrError);
+  if (errorStr.includes("InvalidDiscountRate")) return new InvalidDiscountRateError();
+  if (errorStr.includes("TokenMismatch")) return new TokenMismatchError();
+  if (errorStr.includes("PayerReputationTooLow")) return new PayerReputationTooLowError();
+  return new GenericContractError(errorStr);
+}


### PR DESCRIPTION
## Description
This PR implements a structured error mapping layer for the SDK to translate raw XDR contract errors into typed, human-readable exceptions. 

## Changes Made
* Defined `ILNError` base class and specific contract error subclasses (`InvalidDiscountRateError`, `TokenMismatchError`, `PayerReputationTooLowError`, `GenericContractError`).
* Implemented `parseContractError` factory function to handle translation.
* Integrated the error mapping into `client.ts` (`unwrapContractResult` and `extractSimulationRetval`) to ensure all Client methods throw typed `ILNError` subclasses instead of raw strings.
* Added unit tests for the error mapping logic.

Closes #231