### PR TITLE
feat: create @iln/mock-backend for offline frontend development

### DIFF
--- a/packages/mock-backend/README.md
+++ b/packages/mock-backend/README.md
@@ -1,0 +1,89 @@
+# @iln/mock-backend
+
+In-memory mock backend for the **Invoice Liquidity Network** frontend.  
+Enables fully offline development — no Stellar node, no RPC connection, no wallet required.
+
+---
+
+## Why this exists
+
+Frontend developers currently need a running local Stellar node to work on UI features. This package provides drop-in replacements for all three client interfaces (`InvoiceClient`, `ReputationClient`, `GovernanceClient`) backed by an in-memory store pre-populated with realistic test data.
+
+---
+
+## Quick start
+
+```ts
+import { ILNMockBackend } from "@iln/mock-backend";
+
+const mock = new ILNMockBackend();
+
+// Read invoices
+const invoices  = await mock.invoice.getAllInvoices();
+const score     = await mock.reputation.getPayerScore(address);
+const proposals = await mock.governance.fetchProposals();
+
+// Write operations update in-memory state immediately
+const { invoiceId } = await mock.invoice.submitInvoice({ ... });
+await mock.invoice.fundInvoice(funderAddress, invoiceId);
+await mock.invoice.markPaid(payerAddress, invoiceId);
+```
+
+---
+
+## Using in the frontend (dev mode)
+
+1. Copy `.env.local.example` → `.env.local` in the `frontend/` directory.
+2. Set `NEXT_PUBLIC_ILN_MOCK=1`.
+3. Import from `@/lib/mock-client` instead of `@/utils/soroban` where needed.
+
+The `frontend/src/lib/mock-client.ts` adapter exports the same function signatures as `soroban.ts`, so pages can switch between real and mock implementations with a one-line change.
+
+---
+
+## Seed data
+
+The package ships with 13 pre-populated invoices covering all statuses (`Pending`, `Funded`, `Paid`, `Defaulted`, `Cancelled`, `Expired`) across two tokens (USDC and EURC), plus:
+
+- 5 reputation scores (BOB has a perfect record; DAVE has defaults)
+- 6 governance proposals in all lifecycle states
+- Token balances and allowances for all test addresses
+
+Named test addresses are exported for use in tests:
+
+```ts
+import { ALICE, BOB, CAROL, DAVE, EVE, FRANK, USDC_ID, EURC_ID } from "@iln/mock-backend";
+```
+
+---
+
+## Customising seed data
+
+```ts
+const mock = new ILNMockBackend({
+  invoices: myCustomInvoices,
+  reputation: myReputationMap,
+  proposals: myProposals,
+  votingPower: 5_000, // ILN tokens for the connected wallet
+});
+```
+
+You can also instantiate individual clients:
+
+```ts
+import { MockInvoiceClient, MockGovernanceClient, MockReputationClient } from "@iln/mock-backend";
+```
+
+---
+
+## Running tests
+
+```bash
+pnpm --filter @iln/mock-backend test
+```
+
+---
+
+## How writes work
+
+All mutating operations update in-memory state and return a synthetic 64-character hex transaction hash. State resets on every process restart. There is no persistence layer by design — the mock is intended for interactive development and test suites only.

--- a/packages/mock-backend/__tests__/ILNMockBackend.test.ts
+++ b/packages/mock-backend/__tests__/ILNMockBackend.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Interface-compliance tests.
+ * Verifies that the mock clients satisfy the declared TypeScript interfaces
+ * by checking that every method exists and returns the right shape.
+ */
+import { describe, it, expect } from "vitest";
+import { ILNMockBackend } from "../src/ILNMockBackend.js";
+import type { InvoiceClient, ReputationClient, GovernanceClient } from "../src/types.js";
+import { ALICE, BOB, USDC_ID } from "../src/seed.js";
+
+describe("ILNMockBackend — client interface compliance", () => {
+  const backend = new ILNMockBackend();
+
+  // ── InvoiceClient ─────────────────────────────────────────────────────────
+
+  it("invoice implements InvoiceClient", () => {
+    const client: InvoiceClient = backend.invoice;
+    expect(typeof client.getInvoiceCount).toBe("function");
+    expect(typeof client.getInvoice).toBe("function");
+    expect(typeof client.getAllInvoices).toBe("function");
+    expect(typeof client.getTokenBalance).toBe("function");
+    expect(typeof client.getTokenAllowance).toBe("function");
+    expect(typeof client.getApprovedTokenIds).toBe("function");
+    expect(typeof client.getTokenMetadata).toBe("function");
+    expect(typeof client.getPayerScore).toBe("function");
+    expect(typeof client.getPayerScoresBatch).toBe("function");
+    expect(typeof client.submitInvoice).toBe("function");
+    expect(typeof client.fundInvoice).toBe("function");
+    expect(typeof client.markPaid).toBe("function");
+    expect(typeof client.claimDefault).toBe("function");
+    expect(typeof client.cancelInvoice).toBe("function");
+    expect(typeof client.updateInvoice).toBe("function");
+    expect(typeof client.approveToken).toBe("function");
+  });
+
+  // ── ReputationClient ──────────────────────────────────────────────────────
+
+  it("reputation implements ReputationClient", () => {
+    const client: ReputationClient = backend.reputation;
+    expect(typeof client.getPayerScore).toBe("function");
+    expect(typeof client.getPayerScoresBatch).toBe("function");
+  });
+
+  // ── GovernanceClient ──────────────────────────────────────────────────────
+
+  it("governance implements GovernanceClient", () => {
+    const client: GovernanceClient = backend.governance;
+    expect(typeof client.fetchProposals).toBe("function");
+    expect(typeof client.fetchProposal).toBe("function");
+    expect(typeof client.castVote).toBe("function");
+    expect(typeof client.executeProposal).toBe("function");
+    expect(typeof client.getVotingPower).toBe("function");
+    expect(typeof client.fetchProtocolParameters).toBe("function");
+    expect(typeof client.createProposal).toBe("function");
+  });
+
+  // ── End-to-end: submit → fund → pay flow ──────────────────────────────────
+
+  it("full lifecycle: submit → fund → mark paid", async () => {
+    const b = new ILNMockBackend();
+    const dueDate = Math.floor(Date.now() / 1000) + 86_400 * 30;
+
+    const { invoiceId } = await b.invoice.submitInvoice({
+      freelancer: ALICE,
+      payer: BOB,
+      amount: 1_000_000_000n,
+      dueDate,
+      discountRate: 300,
+      token: USDC_ID,
+    });
+
+    let inv = await b.invoice.getInvoice(invoiceId);
+    expect(inv.status).toBe("Pending");
+
+    await b.invoice.fundInvoice(ALICE, invoiceId);
+    inv = await b.invoice.getInvoice(invoiceId);
+    expect(inv.status).toBe("Funded");
+
+    await b.invoice.markPaid(BOB, invoiceId);
+    inv = await b.invoice.getInvoice(invoiceId);
+    expect(inv.status).toBe("Paid");
+  });
+
+  // ── Reputation score improves after payment ───────────────────────────────
+
+  it("payer score updates after markPaid", async () => {
+    const b = new ILNMockBackend();
+    // Read score directly from the invoice client (which owns the reputation store)
+    const scoreBefore = await b.invoice.getPayerScore(BOB);
+
+    // Invoice 3 in seed is Funded, BOB is payer
+    await b.invoice.markPaid(BOB, 3n);
+
+    const scoreAfter = await b.invoice.getPayerScore(BOB);
+    expect(scoreAfter!.settled_on_time).toBe(scoreBefore!.settled_on_time + 1);
+  });
+});

--- a/packages/mock-backend/__tests__/mock-governance-client.test.ts
+++ b/packages/mock-backend/__tests__/mock-governance-client.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { MockGovernanceClient } from "../src/mock-governance-client.js";
+import { CAROL } from "../src/seed.js";
+
+function makeClient() {
+  return new MockGovernanceClient();
+}
+
+describe("MockGovernanceClient — reads", () => {
+  it("fetchProposals returns 6 seed proposals", async () => {
+    const client = makeClient();
+    const proposals = await client.fetchProposals();
+    expect(proposals.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("fetchProposal returns correct proposal", async () => {
+    const client = makeClient();
+    const proposal = await client.fetchProposal(1);
+    expect(proposal).not.toBeNull();
+    expect(proposal!.id).toBe(1);
+    expect(proposal!.status).toBe("Active");
+  });
+
+  it("fetchProposal returns null for unknown id", async () => {
+    const client = makeClient();
+    expect(await client.fetchProposal(9999)).toBeNull();
+  });
+
+  it("fetchProposals includes Active, Passed, Executed, Failed statuses", async () => {
+    const client = makeClient();
+    const proposals = await client.fetchProposals();
+    const statuses = new Set(proposals.map((p) => p.status));
+    expect(statuses).toContain("Active");
+    expect(statuses).toContain("Passed");
+    expect(statuses).toContain("Executed");
+    expect(statuses).toContain("Failed");
+  });
+
+  it("getVotingPower returns default 1250", async () => {
+    const client = makeClient();
+    expect(await client.getVotingPower(CAROL)).toBe(1_250);
+  });
+
+  it("fetchProtocolParameters returns expected structure", async () => {
+    const client = makeClient();
+    const params = await client.fetchProtocolParameters();
+    expect(params.feeRateBps).toBeGreaterThan(0);
+    expect(params.maxDiscountRateBps).toBeGreaterThan(0);
+    expect(params.acceptedTokens.length).toBeGreaterThan(0);
+    expect(params.minProposalILN).toBeGreaterThan(0);
+  });
+});
+
+describe("MockGovernanceClient — castVote", () => {
+  it("castVote increments votesFor", async () => {
+    const client = makeClient();
+    const before = (await client.fetchProposal(1))!;
+    await client.castVote(1, "For", CAROL);
+    const after = (await client.fetchProposal(1))!;
+    expect(after.votesFor).toBe(before.votesFor + 1_250);
+    expect(after.userVote).toBe("For");
+  });
+
+  it("castVote increments votesAgainst", async () => {
+    const client = makeClient();
+    const before = (await client.fetchProposal(1))!;
+    await client.castVote(1, "Against", CAROL);
+    const after = (await client.fetchProposal(1))!;
+    expect(after.votesAgainst).toBe(before.votesAgainst + 1_250);
+  });
+
+  it("castVote returns a tx hash string", async () => {
+    const client = makeClient();
+    const hash = await client.castVote(1, "Abstain", CAROL);
+    expect(typeof hash).toBe("string");
+    expect(hash.length).toBeGreaterThan(0);
+  });
+
+  it("castVote prevents double-voting", async () => {
+    const client = makeClient();
+    await client.castVote(1, "For", CAROL);
+    await expect(client.castVote(1, "Against", CAROL)).rejects.toThrow(/Already voted/);
+  });
+
+  it("castVote rejects vote on non-Active proposal", async () => {
+    const client = makeClient();
+    // Proposal 4 is Executed
+    await expect(client.castVote(4, "For", CAROL)).rejects.toThrow(/not active/);
+  });
+});
+
+describe("MockGovernanceClient — executeProposal", () => {
+  it("executeProposal transitions Passed → Executed", async () => {
+    const client = makeClient();
+    // Proposal 3 is Passed
+    await client.executeProposal(3, CAROL);
+    const proposal = await client.fetchProposal(3);
+    expect(proposal!.status).toBe("Executed");
+  });
+
+  it("executeProposal rejects non-Passed proposal", async () => {
+    const client = makeClient();
+    await expect(client.executeProposal(1, CAROL)).rejects.toThrow(/cannot be executed/);
+  });
+});
+
+describe("MockGovernanceClient — createProposal", () => {
+  it("creates a new proposal and returns id + hash", async () => {
+    const client = makeClient();
+    const result = await client.createProposal(
+      {
+        title: "Test proposal",
+        description: "A test",
+        type: "TextProposal",
+      },
+      CAROL
+    );
+    expect(result.proposalId).toBeGreaterThan(0);
+    expect(result.txHash).toHaveLength(64);
+  });
+
+  it("new proposal appears in fetchProposals", async () => {
+    const client = makeClient();
+    const { proposalId } = await client.createProposal(
+      { title: "New one", description: "desc", type: "ParameterUpdate" },
+      CAROL
+    );
+    const found = await client.fetchProposal(proposalId);
+    expect(found).not.toBeNull();
+    expect(found!.status).toBe("Active");
+    expect(found!.proposer).toBe(CAROL);
+  });
+});

--- a/packages/mock-backend/__tests__/mock-invoice-client.test.ts
+++ b/packages/mock-backend/__tests__/mock-invoice-client.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { MockInvoiceClient } from "../src/mock-invoice-client.js";
+import { ALICE, BOB, CAROL, DAVE, EVE, USDC_ID, EURC_ID } from "../src/seed.js";
+
+function makeClient() {
+  return new MockInvoiceClient();
+}
+
+describe("MockInvoiceClient — invoice reads", () => {
+  it("getInvoiceCount returns 13 (seed size)", async () => {
+    const client = makeClient();
+    expect(await client.getInvoiceCount()).toBe(13n);
+  });
+
+  it("getInvoice returns the correct invoice", async () => {
+    const client = makeClient();
+    const inv = await client.getInvoice(1n);
+    expect(inv.id).toBe(1n);
+    expect(inv.status).toBe("Pending");
+    expect(inv.freelancer).toBe(ALICE);
+    expect(inv.payer).toBe(BOB);
+  });
+
+  it("getInvoice throws for unknown id", async () => {
+    const client = makeClient();
+    await expect(client.getInvoice(999n)).rejects.toThrow("not found");
+  });
+
+  it("getAllInvoices returns 13 entries", async () => {
+    const client = makeClient();
+    const all = await client.getAllInvoices();
+    expect(all).toHaveLength(13);
+  });
+
+  it("getAllInvoices covers all statuses", async () => {
+    const client = makeClient();
+    const all = await client.getAllInvoices();
+    const statuses = new Set(all.map((i) => i.status));
+    expect(statuses).toContain("Pending");
+    expect(statuses).toContain("Funded");
+    expect(statuses).toContain("Paid");
+    expect(statuses).toContain("Defaulted");
+    expect(statuses).toContain("Cancelled");
+    expect(statuses).toContain("Expired");
+  });
+});
+
+describe("MockInvoiceClient — token reads", () => {
+  it("getApprovedTokenIds returns USDC and EURC", async () => {
+    const client = makeClient();
+    const ids = await client.getApprovedTokenIds();
+    expect(ids).toContain(USDC_ID);
+    expect(ids).toContain(EURC_ID);
+  });
+
+  it("getTokenMetadata returns correct data for USDC", async () => {
+    const client = makeClient();
+    const meta = await client.getTokenMetadata(USDC_ID);
+    expect(meta.symbol).toBe("USDC");
+    expect(meta.decimals).toBe(7);
+    expect(meta.contractId).toBe(USDC_ID);
+  });
+
+  it("getTokenMetadata returns placeholder for unknown token", async () => {
+    const client = makeClient();
+    const UNKNOWN = "CUNKNOWNTOKENADDRESSFORTEST000000000000000000000000000000";
+    const meta = await client.getTokenMetadata(UNKNOWN);
+    expect(meta.contractId).toBe(UNKNOWN);
+    expect(meta.decimals).toBe(7);
+  });
+
+  it("getTokenBalance returns non-zero for seeded address", async () => {
+    const client = makeClient();
+    const bal = await client.getTokenBalance(ALICE, USDC_ID);
+    expect(bal).toBeGreaterThan(0n);
+  });
+
+  it("getTokenBalance returns 0 for unknown address", async () => {
+    const client = makeClient();
+    const bal = await client.getTokenBalance("GNOBODY", USDC_ID);
+    expect(bal).toBe(0n);
+  });
+
+  it("getTokenAllowance returns seeded allowance", async () => {
+    const client = makeClient();
+    const allowance = await client.getTokenAllowance({
+      owner: CAROL,
+      spender: "CONTRACT",
+      tokenId: USDC_ID,
+    });
+    expect(allowance).toBeGreaterThan(0n);
+  });
+});
+
+describe("MockInvoiceClient — reputation reads", () => {
+  it("getPayerScore returns score for known payer", async () => {
+    const client = makeClient();
+    const score = await client.getPayerScore(BOB);
+    expect(score).not.toBeNull();
+    expect(score!.score).toBeGreaterThan(0);
+  });
+
+  it("getPayerScore returns null for unknown payer", async () => {
+    const client = makeClient();
+    const score = await client.getPayerScore("GNOBODY");
+    expect(score).toBeNull();
+  });
+
+  it("getPayerScoresBatch returns correct map", async () => {
+    const client = makeClient();
+    const result = await client.getPayerScoresBatch([BOB, DAVE, "GNOBODY"]);
+    expect(result.size).toBe(3);
+    expect(result.get(BOB)).not.toBeNull();
+    expect(result.get(DAVE)).not.toBeNull();
+    expect(result.get("GNOBODY")).toBeNull();
+  });
+});
+
+describe("MockInvoiceClient — write operations", () => {
+  it("submitInvoice creates a new invoice and increments count", async () => {
+    const client = makeClient();
+    const result = await client.submitInvoice({
+      freelancer: ALICE,
+      payer: BOB,
+      amount: 1_000_000_000n,
+      dueDate: Math.floor(Date.now() / 1000) + 86_400 * 30,
+      discountRate: 300,
+      token: USDC_ID,
+    });
+    expect(result.invoiceId).toBe(14n);
+    expect(result.txHash).toHaveLength(64);
+    expect(await client.getInvoiceCount()).toBe(14n);
+  });
+
+  it("fundInvoice transitions Pending → Funded", async () => {
+    const client = makeClient();
+    await client.fundInvoice(CAROL, 1n);
+    const inv = await client.getInvoice(1n);
+    expect(inv.status).toBe("Funded");
+    expect(inv.funder).toBe(CAROL);
+    expect(inv.funded_at).not.toBeNull();
+  });
+
+  it("fundInvoice rejects non-Pending invoice", async () => {
+    const client = makeClient();
+    // Invoice 3 is already Funded in seed
+    await expect(client.fundInvoice(CAROL, 3n)).rejects.toThrow(/expected status "Pending"/);
+  });
+
+  it("markPaid transitions Funded → Paid", async () => {
+    const client = makeClient();
+    // Invoice 3 is Funded, BOB is the payer
+    await client.markPaid(BOB, 3n);
+    const inv = await client.getInvoice(3n);
+    expect(inv.status).toBe("Paid");
+  });
+
+  it("markPaid rejects wrong payer", async () => {
+    const client = makeClient();
+    await expect(client.markPaid(DAVE, 3n)).rejects.toThrow(/not the payer/);
+  });
+
+  it("claimDefault on past-due funded invoice transitions to Defaulted", async () => {
+    const client = makeClient();
+    // Create a fresh Funded invoice whose due_date is in the past
+    const pastDue = Math.floor(Date.now() / 1000) - 86_400; // yesterday
+    const { invoiceId } = await client.submitInvoice({
+      freelancer: ALICE,
+      payer: BOB,
+      amount: 1_000_000_000n,
+      dueDate: pastDue,
+      discountRate: 500,
+      token: USDC_ID,
+    });
+    await client.fundInvoice(CAROL, invoiceId);
+    await client.claimDefault(CAROL, invoiceId);
+    const inv = await client.getInvoice(invoiceId);
+    expect(inv.status).toBe("Defaulted");
+  });
+
+  it("claimDefault on future-due invoice fails", async () => {
+    const client = makeClient();
+    // Invoice 3 is Funded but due in the future
+    await expect(client.claimDefault(CAROL, 3n)).rejects.toThrow(/not past its due date/);
+  });
+
+  it("cancelInvoice transitions Pending → Cancelled", async () => {
+    const client = makeClient();
+    await client.cancelInvoice(ALICE, 1n);
+    const inv = await client.getInvoice(1n);
+    expect(inv.status).toBe("Cancelled");
+  });
+
+  it("cancelInvoice rejects wrong freelancer", async () => {
+    const client = makeClient();
+    await expect(client.cancelInvoice(EVE, 1n)).rejects.toThrow(/not the freelancer/);
+  });
+
+  it("updateInvoice mutates amount and due_date", async () => {
+    const client = makeClient();
+    await client.updateInvoice({
+      freelancer: ALICE,
+      invoiceId: 1n,
+      amount: 9_999_999n,
+      dueDate: Math.floor(Date.now() / 1000) + 86_400 * 60,
+      discountRate: 200,
+    });
+    const inv = await client.getInvoice(1n);
+    expect(inv.amount).toBe(9_999_999n);
+    expect(inv.discount_rate).toBe(200);
+  });
+
+  it("approveToken sets allowance", async () => {
+    const client = makeClient();
+    await client.approveToken({ owner: BOB, amount: 5_000_000_000n, spender: "CONTRACT", tokenId: USDC_ID });
+    const allowance = await client.getTokenAllowance({ owner: BOB, spender: "CONTRACT", tokenId: USDC_ID });
+    expect(allowance).toBe(5_000_000_000n);
+  });
+
+  it("markPaid updates payer reputation score", async () => {
+    const client = makeClient();
+    const before = await client.getPayerScore(BOB);
+    // Invoice 3 is Funded, BOB is payer
+    await client.markPaid(BOB, 3n);
+    const after = await client.getPayerScore(BOB);
+    expect(after!.settled_on_time).toBe(before!.settled_on_time + 1);
+  });
+});

--- a/packages/mock-backend/__tests__/mock-reputation-client.test.ts
+++ b/packages/mock-backend/__tests__/mock-reputation-client.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { MockReputationClient } from "../src/mock-reputation-client.js";
+import { BOB, DAVE, FRANK } from "../src/seed.js";
+
+describe("MockReputationClient", () => {
+  it("returns score for known payer", async () => {
+    const client = new MockReputationClient();
+    const score = await client.getPayerScore(BOB);
+    expect(score).not.toBeNull();
+    expect(score!.score).toBeGreaterThanOrEqual(0);
+    expect(score!.score).toBeLessThanOrEqual(100);
+  });
+
+  it("returns null for unknown payer", async () => {
+    const client = new MockReputationClient();
+    expect(await client.getPayerScore("GNOBODY")).toBeNull();
+  });
+
+  it("batch returns correct entries", async () => {
+    const client = new MockReputationClient();
+    const map = await client.getPayerScoresBatch([BOB, DAVE, FRANK, "GNOBODY"]);
+    expect(map.size).toBe(4);
+    expect(map.get(BOB)).not.toBeNull();
+    expect(map.get(DAVE)).not.toBeNull();
+    expect(map.get(FRANK)).not.toBeNull();
+    expect(map.get("GNOBODY")).toBeNull();
+  });
+
+  it("BOB has zero defaults", async () => {
+    const client = new MockReputationClient();
+    const score = await client.getPayerScore(BOB);
+    expect(score!.defaults).toBe(0);
+  });
+
+  it("DAVE has positive defaults", async () => {
+    const client = new MockReputationClient();
+    const score = await client.getPayerScore(DAVE);
+    expect(score!.defaults).toBeGreaterThan(0);
+  });
+});

--- a/packages/mock-backend/package-lock.json
+++ b/packages/mock-backend/package-lock.json
@@ -1,0 +1,1547 @@
+{
+  "name": "@iln/mock-backend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@iln/mock-backend",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@vitest/coverage-v8": "^4.1.5",
+        "typescript": "^5.4.5",
+        "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/mock-backend/package.json
+++ b/packages/mock-backend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@iln/mock-backend",
+  "version": "0.1.0",
+  "description": "In-memory mock backend for the Invoice Liquidity Network — enables offline frontend development without a live Stellar node.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "typescript": "^5.4.5",
+    "vitest": "^4.1.5"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/mock-backend/src/ILNMockBackend.ts
+++ b/packages/mock-backend/src/ILNMockBackend.ts
@@ -1,0 +1,76 @@
+import { MockInvoiceClient } from "./mock-invoice-client.js";
+import { MockGovernanceClient } from "./mock-governance-client.js";
+import { MockReputationClient } from "./mock-reputation-client.js";
+
+import type {
+  GovernanceClient,
+  InvoiceClient,
+  PayerScore,
+  Proposal,
+  ProtocolParameters,
+  ReputationClient,
+} from "./types.js";
+
+import type { Invoice } from "./types.js";
+
+export interface ILNMockBackendOptions {
+  /** Override the seed invoice set. */
+  invoices?: Invoice[];
+  /** Override the seed reputation map. */
+  reputation?: Map<string, PayerScore>;
+  /** Override the seed governance proposals. */
+  proposals?: Proposal[];
+  /** Override the seed protocol parameters. */
+  protocolParams?: ProtocolParameters;
+  /** Simulated ILN voting power for the connected wallet. Default: 1,250. */
+  votingPower?: number;
+}
+
+/**
+ * ILNMockBackend
+ * ──────────────
+ * Single entry-point that creates and wires together all three in-memory
+ * clients. Use it in the frontend when `ILN_MOCK=1` is set:
+ *
+ * ```ts
+ * import { ILNMockBackend } from "@iln/mock-backend";
+ *
+ * const mock = new ILNMockBackend();
+ *
+ * // Drop-in for soroban.ts helpers:
+ * const invoices = await mock.invoice.getAllInvoices();
+ * const score    = await mock.reputation.getPayerScore(address);
+ * const proposals = await mock.governance.fetchProposals();
+ * ```
+ *
+ * All three clients satisfy the shared interfaces (`InvoiceClient`,
+ * `ReputationClient`, `GovernanceClient`) so they can be substituted
+ * wherever the real implementations are used.
+ */
+export class ILNMockBackend {
+  /** Handles all invoice read/write operations. */
+  readonly invoice: InvoiceClient;
+
+  /** Handles payer reputation reads. */
+  readonly reputation: ReputationClient;
+
+  /** Handles governance proposals, voting, and protocol parameters. */
+  readonly governance: GovernanceClient;
+
+  constructor(options: ILNMockBackendOptions = {}) {
+    this.invoice = new MockInvoiceClient({
+      invoices: options.invoices,
+      reputation: options.reputation,
+    });
+
+    this.reputation = new MockReputationClient({
+      scores: options.reputation,
+    });
+
+    this.governance = new MockGovernanceClient({
+      proposals: options.proposals,
+      protocolParams: options.protocolParams,
+      votingPower: options.votingPower,
+    });
+  }
+}

--- a/packages/mock-backend/src/index.ts
+++ b/packages/mock-backend/src/index.ts
@@ -1,0 +1,48 @@
+// ─── Main class ───────────────────────────────────────────────────────────────
+export { ILNMockBackend } from "./ILNMockBackend.js";
+export type { ILNMockBackendOptions } from "./ILNMockBackend.js";
+
+// ─── Individual clients ───────────────────────────────────────────────────────
+export { MockInvoiceClient } from "./mock-invoice-client.js";
+export { MockReputationClient } from "./mock-reputation-client.js";
+export { MockGovernanceClient } from "./mock-governance-client.js";
+
+// ─── Seed data (useful for test setup) ───────────────────────────────────────
+export {
+  SEED_INVOICES,
+  SEED_REPUTATION,
+  SEED_BALANCES,
+  SEED_ALLOWANCES,
+  SEED_PROPOSALS,
+  SEED_PROTOCOL_PARAMS,
+  TOKEN_METADATA_MAP,
+  ALICE,
+  BOB,
+  CAROL,
+  DAVE,
+  EVE,
+  FRANK,
+  USDC_ID,
+  EURC_ID,
+} from "./seed.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+export type {
+  Invoice,
+  InvoiceStatus,
+  InvoiceClient,
+  ReputationClient,
+  GovernanceClient,
+  PayerScore,
+  TokenMetadata,
+  SubmitInvoiceArgs,
+  SubmittedInvoiceResult,
+  UpdateInvoiceArgs,
+  Proposal,
+  ProposalType,
+  ProposalStatus,
+  VoteChoice,
+  ParameterChange,
+  ProtocolParameters,
+  CreateProposalPayload,
+} from "./types.js";

--- a/packages/mock-backend/src/mock-governance-client.ts
+++ b/packages/mock-backend/src/mock-governance-client.ts
@@ -1,0 +1,156 @@
+import type {
+  CreateProposalPayload,
+  GovernanceClient,
+  Proposal,
+  ProposalStatus,
+  ProtocolParameters,
+  VoteChoice,
+} from "./types.js";
+
+import { SEED_PROPOSALS, SEED_PROTOCOL_PARAMS } from "./seed.js";
+
+function fakeTxHash(): string {
+  return Array.from({ length: 32 }, () =>
+    Math.floor(Math.random() * 256).toString(16).padStart(2, "0")
+  ).join("");
+}
+
+function delay(ms = 80): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * In-memory implementation of {@link GovernanceClient}.
+ *
+ * Voting state and proposals are kept in JS Maps. All mutating operations
+ * (castVote, executeProposal, createProposal) update in-memory state so the
+ * frontend can see real-time changes within a session without a live contract.
+ */
+export class MockGovernanceClient implements GovernanceClient {
+  private readonly proposals: Map<number, Proposal>;
+  private readonly userVotes: Map<number, VoteChoice>;
+  private readonly protocolParams: ProtocolParameters;
+  private readonly votingPower: number;
+
+  constructor(options?: {
+    proposals?: Proposal[];
+    protocolParams?: ProtocolParameters;
+    /** Simulated ILN token balance for the connected wallet (default 1,250). */
+    votingPower?: number;
+  }) {
+    const seed = options?.proposals ?? SEED_PROPOSALS;
+    this.proposals = new Map(seed.map((p) => [p.id, { ...p }]));
+    this.userVotes = new Map();
+    this.protocolParams = options?.protocolParams
+      ? { ...options.protocolParams }
+      : { ...SEED_PROTOCOL_PARAMS };
+    this.votingPower = options?.votingPower ?? 1_250;
+  }
+
+  // ─── Reads ──────────────────────────────────────────────────────────────────
+
+  async fetchProposals(): Promise<Proposal[]> {
+    await delay(80);
+    return [...this.proposals.values()].map((p) => ({
+      ...p,
+      userVote: this.userVotes.get(p.id),
+    }));
+  }
+
+  async fetchProposal(id: number): Promise<Proposal | null> {
+    await delay(60);
+    const proposal = this.proposals.get(id);
+    if (!proposal) return null;
+    return { ...proposal, userVote: this.userVotes.get(id) };
+  }
+
+  async getVotingPower(_address: string): Promise<number> {
+    await delay(60);
+    return this.votingPower;
+  }
+
+  async fetchProtocolParameters(): Promise<ProtocolParameters> {
+    await delay(80);
+    return { ...this.protocolParams };
+  }
+
+  // ─── Writes ─────────────────────────────────────────────────────────────────
+
+  async castVote(
+    proposalId: number,
+    choice: VoteChoice,
+    _signerAddress: string
+  ): Promise<string> {
+    await delay(200);
+
+    const proposal = this.proposals.get(proposalId);
+    if (!proposal) {
+      throw new Error(`Proposal ${proposalId} not found`);
+    }
+    if (proposal.status !== "Active") {
+      throw new Error(`Proposal ${proposalId} is not active (status: ${proposal.status})`);
+    }
+    if (this.userVotes.has(proposalId)) {
+      throw new Error(`Already voted on proposal ${proposalId}`);
+    }
+
+    // Apply vote weight
+    if (choice === "For") proposal.votesFor += this.votingPower;
+    else if (choice === "Against") proposal.votesAgainst += this.votingPower;
+    else proposal.votesAbstain += this.votingPower;
+
+    this.proposals.set(proposalId, proposal);
+    this.userVotes.set(proposalId, choice);
+
+    return fakeTxHash();
+  }
+
+  async executeProposal(
+    proposalId: number,
+    _signerAddress: string
+  ): Promise<string> {
+    await delay(200);
+
+    const proposal = this.proposals.get(proposalId);
+    if (!proposal) {
+      throw new Error(`Proposal ${proposalId} not found`);
+    }
+    if (proposal.status !== "Passed") {
+      throw new Error(`Proposal ${proposalId} cannot be executed (status: ${proposal.status})`);
+    }
+
+    proposal.status = "Executed" as ProposalStatus;
+    this.proposals.set(proposalId, proposal);
+    return fakeTxHash();
+  }
+
+  async createProposal(
+    payload: CreateProposalPayload,
+    signerAddress: string
+  ): Promise<{ txHash: string; proposalId: number }> {
+    await delay(300);
+
+    const nowSec = Math.floor(Date.now() / 1000);
+    const newId = Math.max(...this.proposals.keys(), 0) + 1;
+
+    const newProposal: Proposal = {
+      id: newId,
+      title: payload.title,
+      description: payload.description,
+      type: payload.type,
+      status: "Active",
+      proposer: signerAddress,
+      createdAt: nowSec,
+      votingStartsAt: nowSec,
+      votingEndsAt: nowSec + 7 * 86_400,
+      votesFor: 0,
+      votesAgainst: 0,
+      votesAbstain: 0,
+      quorumRequired: 100_000,
+      parameterChanges: payload.parameterChanges,
+    };
+
+    this.proposals.set(newId, newProposal);
+    return { txHash: fakeTxHash(), proposalId: newId };
+  }
+}

--- a/packages/mock-backend/src/mock-invoice-client.ts
+++ b/packages/mock-backend/src/mock-invoice-client.ts
@@ -1,0 +1,314 @@
+import type {
+  Invoice,
+  InvoiceClient,
+  InvoiceStatus,
+  PayerScore,
+  SubmitInvoiceArgs,
+  SubmittedInvoiceResult,
+  TokenMetadata,
+  UpdateInvoiceArgs,
+} from "./types.js";
+
+import {
+  SEED_INVOICES,
+  SEED_REPUTATION,
+  SEED_BALANCES,
+  SEED_ALLOWANCES,
+  TOKEN_METADATA_MAP,
+  USDC_ID,
+} from "./seed.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function fakeTxHash(): string {
+  return Array.from({ length: 32 }, () =>
+    Math.floor(Math.random() * 256).toString(16).padStart(2, "0")
+  ).join("");
+}
+
+function delay(ms = 80): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ─── MockInvoiceClient ────────────────────────────────────────────────────────
+
+/**
+ * In-memory implementation of {@link InvoiceClient}.
+ * All state lives in JavaScript Maps — no Stellar node required.
+ *
+ * Mutating operations (submit, fund, markPaid, claimDefault, cancel, update)
+ * update in-memory state and return a synthetic tx hash so the frontend can
+ * treat the mock the same way it treats real contract responses.
+ */
+export class MockInvoiceClient implements InvoiceClient {
+  /** Invoice store keyed by id */
+  private readonly invoices: Map<bigint, Invoice>;
+
+  /** Reputation scores keyed by payer address */
+  private readonly reputation: Map<string, PayerScore>;
+
+  /** Token balances keyed by `${tokenId}:${address}` */
+  private readonly balances: Map<string, bigint>;
+
+  /** Token allowances keyed by `${tokenId}:${owner}:${spender}` */
+  private readonly allowances: Map<string, bigint>;
+
+  /** Default spender contract ID used for allowance lookups */
+  private readonly contractId: string;
+
+  constructor(options?: {
+    /** Replace seed invoices with a custom set. */
+    invoices?: Invoice[];
+    /** Replace seed reputation with a custom map. */
+    reputation?: Map<string, PayerScore>;
+    /** Replace seed balances with a custom map. */
+    balances?: Map<string, bigint>;
+    /** Replace seed allowances with a custom map. */
+    allowances?: Map<string, bigint>;
+    /** Simulated contract address used as the default spender. */
+    contractId?: string;
+    /** Simulated network latency in ms (default 80). */
+    latencyMs?: number;
+  }) {
+    const seedInvoices = options?.invoices ?? SEED_INVOICES;
+    this.invoices = new Map(seedInvoices.map((inv) => [inv.id, { ...inv }]));
+    this.reputation = options?.reputation ?? new Map(SEED_REPUTATION);
+    this.balances = options?.balances ?? new Map(SEED_BALANCES);
+    this.allowances = options?.allowances ?? new Map(SEED_ALLOWANCES);
+    this.contractId = options?.contractId ?? "MOCK_CONTRACT";
+  }
+
+  // ─── Read: invoices ─────────────────────────────────────────────────────────
+
+  async getInvoiceCount(): Promise<bigint> {
+    await delay();
+    return BigInt(this.invoices.size);
+  }
+
+  async getInvoice(id: bigint): Promise<Invoice> {
+    await delay();
+    const invoice = this.invoices.get(id);
+    if (!invoice) {
+      throw new Error(`Invoice ${id} not found`);
+    }
+    return { ...invoice };
+  }
+
+  async getAllInvoices(): Promise<Invoice[]> {
+    await delay();
+    return [...this.invoices.values()].map((inv) => ({ ...inv }));
+  }
+
+  // ─── Read: tokens ───────────────────────────────────────────────────────────
+
+  async getApprovedTokenIds(): Promise<string[]> {
+    await delay();
+    return Object.keys(TOKEN_METADATA_MAP);
+  }
+
+  async getTokenMetadata(tokenId: string): Promise<TokenMetadata> {
+    await delay();
+    const meta = TOKEN_METADATA_MAP[tokenId];
+    if (meta) {
+      return { contractId: tokenId, ...meta };
+    }
+    // Unknown token — return a generic placeholder
+    return {
+      contractId: tokenId,
+      name: "Unknown Token",
+      symbol: tokenId.slice(0, 4).toUpperCase(),
+      decimals: 7,
+    };
+  }
+
+  async getTokenBalance(address: string, tokenId: string = USDC_ID): Promise<bigint> {
+    await delay();
+    return this.balances.get(`${tokenId}:${address}`) ?? 0n;
+  }
+
+  async getTokenAllowance({
+    owner,
+    spender,
+    tokenId = USDC_ID,
+  }: {
+    owner: string;
+    spender?: string;
+    tokenId?: string;
+  }): Promise<bigint> {
+    await delay();
+    const resolvedSpender = spender ?? this.contractId;
+    return this.allowances.get(`${tokenId}:${owner}:${resolvedSpender}`) ?? 0n;
+  }
+
+  // ─── Read: reputation ───────────────────────────────────────────────────────
+
+  async getPayerScore(payerAddress: string): Promise<PayerScore | null> {
+    await delay();
+    return this.reputation.get(payerAddress) ?? null;
+  }
+
+  async getPayerScoresBatch(
+    addresses: string[]
+  ): Promise<Map<string, PayerScore | null>> {
+    await delay();
+    const result = new Map<string, PayerScore | null>();
+    for (const addr of addresses) {
+      result.set(addr, this.reputation.get(addr) ?? null);
+    }
+    return result;
+  }
+
+  // ─── Write: invoices ────────────────────────────────────────────────────────
+
+  async submitInvoice(args: SubmitInvoiceArgs): Promise<SubmittedInvoiceResult> {
+    await delay(150);
+
+    const nextId = BigInt(this.invoices.size + 1);
+    const invoice: Invoice = {
+      id: nextId,
+      freelancer: args.freelancer,
+      payer: args.payer,
+      amount: args.amount,
+      due_date: BigInt(args.dueDate),
+      discount_rate: args.discountRate,
+      status: "Pending",
+      funder: null,
+      funded_at: null,
+      token: args.token ?? USDC_ID,
+    };
+
+    this.invoices.set(nextId, invoice);
+    return { invoiceId: nextId, txHash: fakeTxHash() };
+  }
+
+  async fundInvoice(funder: string, invoiceId: bigint): Promise<{ txHash: string }> {
+    await delay(150);
+
+    const invoice = this.requireInvoice(invoiceId);
+    this.assertStatus(invoice, "Pending", "fund");
+
+    invoice.status = "Funded";
+    invoice.funder = funder;
+    invoice.funded_at = BigInt(Math.floor(Date.now() / 1000));
+    this.invoices.set(invoiceId, invoice);
+
+    return { txHash: fakeTxHash() };
+  }
+
+  async markPaid(payer: string, invoiceId: bigint): Promise<{ txHash: string }> {
+    await delay(150);
+
+    const invoice = this.requireInvoice(invoiceId);
+    if (invoice.payer !== payer) {
+      throw new Error(`Address ${payer} is not the payer for invoice ${invoiceId}`);
+    }
+    this.assertStatus(invoice, "Funded", "mark as paid");
+
+    invoice.status = "Paid";
+    this.invoices.set(invoiceId, invoice);
+
+    // Update reputation for the payer
+    const existing = this.reputation.get(payer) ?? { score: 50, settled_on_time: 0, defaults: 0 };
+    const settled = existing.settled_on_time + 1;
+    this.reputation.set(payer, {
+      score: Math.min(100, Math.round((settled / (settled + existing.defaults)) * 100)),
+      settled_on_time: settled,
+      defaults: existing.defaults,
+    });
+
+    return { txHash: fakeTxHash() };
+  }
+
+  async claimDefault(funder: string, invoiceId: bigint): Promise<{ txHash: string }> {
+    await delay(150);
+
+    const invoice = this.requireInvoice(invoiceId);
+    if (invoice.funder !== funder) {
+      throw new Error(`Address ${funder} is not the funder for invoice ${invoiceId}`);
+    }
+    this.assertStatus(invoice, "Funded", "claim default");
+
+    const nowSec = BigInt(Math.floor(Date.now() / 1000));
+    if (invoice.due_date > nowSec) {
+      throw new Error(`Invoice ${invoiceId} is not past its due date yet`);
+    }
+
+    invoice.status = "Defaulted";
+    this.invoices.set(invoiceId, invoice);
+
+    // Update reputation for the payer
+    const payer = invoice.payer;
+    const existing = this.reputation.get(payer) ?? { score: 50, settled_on_time: 0, defaults: 0 };
+    const defaults = existing.defaults + 1;
+    const total = existing.settled_on_time + defaults;
+    this.reputation.set(payer, {
+      score: total > 0 ? Math.max(0, Math.round((existing.settled_on_time / total) * 100)) : 0,
+      settled_on_time: existing.settled_on_time,
+      defaults,
+    });
+
+    return { txHash: fakeTxHash() };
+  }
+
+  async cancelInvoice(freelancer: string, invoiceId: bigint): Promise<{ txHash: string }> {
+    await delay(150);
+
+    const invoice = this.requireInvoice(invoiceId);
+    if (invoice.freelancer !== freelancer) {
+      throw new Error(`Address ${freelancer} is not the freelancer for invoice ${invoiceId}`);
+    }
+    this.assertStatus(invoice, "Pending", "cancel");
+
+    invoice.status = "Cancelled";
+    this.invoices.set(invoiceId, invoice);
+    return { txHash: fakeTxHash() };
+  }
+
+  async updateInvoice(args: UpdateInvoiceArgs): Promise<{ txHash: string }> {
+    await delay(150);
+
+    const invoice = this.requireInvoice(args.invoiceId);
+    if (invoice.freelancer !== args.freelancer) {
+      throw new Error(`Address ${args.freelancer} is not the freelancer for invoice ${args.invoiceId}`);
+    }
+    this.assertStatus(invoice, "Pending", "update");
+
+    invoice.amount = args.amount;
+    invoice.due_date = BigInt(args.dueDate);
+    invoice.discount_rate = args.discountRate;
+    this.invoices.set(args.invoiceId, invoice);
+    return { txHash: fakeTxHash() };
+  }
+
+  async approveToken(args: {
+    owner: string;
+    amount: bigint;
+    spender?: string;
+    tokenId?: string;
+  }): Promise<{ txHash: string }> {
+    await delay(100);
+
+    const tokenId = args.tokenId ?? USDC_ID;
+    const spender = args.spender ?? this.contractId;
+    this.allowances.set(`${tokenId}:${args.owner}:${spender}`, args.amount);
+    return { txHash: fakeTxHash() };
+  }
+
+  // ─── Internal helpers ───────────────────────────────────────────────────────
+
+  private requireInvoice(id: bigint): Invoice {
+    const invoice = this.invoices.get(id);
+    if (!invoice) {
+      throw new Error(`Invoice ${id} not found`);
+    }
+    return { ...invoice };
+  }
+
+  private assertStatus(invoice: Invoice, expected: InvoiceStatus, action: string): void {
+    if (invoice.status !== expected) {
+      throw new Error(
+        `Cannot ${action} invoice ${invoice.id}: expected status "${expected}", got "${invoice.status}"`
+      );
+    }
+  }
+}

--- a/packages/mock-backend/src/mock-reputation-client.ts
+++ b/packages/mock-backend/src/mock-reputation-client.ts
@@ -1,0 +1,37 @@
+import type { PayerScore, ReputationClient } from "./types.js";
+import { SEED_REPUTATION } from "./seed.js";
+
+function delay(ms = 60): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Standalone in-memory {@link ReputationClient}.
+ *
+ * The {@link MockInvoiceClient} also exposes the same reputation methods — this
+ * class exists so the frontend can instantiate a focused reputation client if
+ * needed without carrying all invoice state.
+ */
+export class MockReputationClient implements ReputationClient {
+  private readonly scores: Map<string, PayerScore>;
+
+  constructor(options?: { scores?: Map<string, PayerScore> }) {
+    this.scores = options?.scores ?? new Map(SEED_REPUTATION);
+  }
+
+  async getPayerScore(payerAddress: string): Promise<PayerScore | null> {
+    await delay();
+    return this.scores.get(payerAddress) ?? null;
+  }
+
+  async getPayerScoresBatch(
+    addresses: string[]
+  ): Promise<Map<string, PayerScore | null>> {
+    await delay();
+    const result = new Map<string, PayerScore | null>();
+    for (const addr of addresses) {
+      result.set(addr, this.scores.get(addr) ?? null);
+    }
+    return result;
+  }
+}

--- a/packages/mock-backend/src/seed.ts
+++ b/packages/mock-backend/src/seed.ts
@@ -1,0 +1,381 @@
+/**
+ * Realistic seed data for the ILN mock backend.
+ * All Stellar addresses follow the G…56-char format but are not real keys.
+ */
+
+import type { Invoice, PayerScore, Proposal, ProtocolParameters } from "./types.js";
+
+// ─── Well-known test addresses ────────────────────────────────────────────────
+
+export const ALICE   = "GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3GLCXSIVW"; // freelancer
+export const BOB     = "GBVZQCHFGWQGBLVZRAXITROHGWLBPFWXUSWRNKBFBQ7BXMFGNDKZWKHN"; // payer
+export const CAROL   = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGLIWLL873KBMCS3WHMEVL2"; // LP / funder
+export const DAVE    = "GDMYVWI5YHKUQB3UQZEHBLKICL3WGQJRPQXM3P3VHEFBYUQFNMXXHXE"; // payer 2
+export const EVE     = "GCLAQF5H5LGJ2A6ACOMNEHSWYDJ3VKVBUBHDWFGRBEPAVZ56L4D7KLPQ"; // freelancer 2
+export const FRANK   = "GB6LLZFLHH2PFXOMUTPHXMKFN2GKBK7IZY4TT5ALXDJMJXQO7PE5IMI"; // LP 2
+export const GRACE   = "GBSAIOPIQIQIJIJIJIJIJIJIJIJIJIJIJIJIJIJIJIJIJIJIJIJIIIIISP"; // payer 3 (stress addr)
+
+// ─── Token contract IDs ───────────────────────────────────────────────────────
+
+export const USDC_ID = "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75";
+export const EURC_ID = "GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP";
+
+// ─── Time helpers ─────────────────────────────────────────────────────────────
+
+const NOW = Math.floor(Date.now() / 1000);
+const DAY = 86_400;
+
+function daysFromNow(n: number): bigint {
+  return BigInt(NOW + n * DAY);
+}
+
+function daysAgo(n: number): bigint {
+  return BigInt(NOW - n * DAY);
+}
+
+// ─── Seed invoices ────────────────────────────────────────────────────────────
+// 13 invoices covering all status combinations and both tokens.
+
+export const SEED_INVOICES: Invoice[] = [
+  // 1 – Pending, due in the future (USDC)
+  {
+    id: 1n,
+    freelancer: ALICE,
+    payer: BOB,
+    amount: 5_000_000_000n,          // 500 USDC (7 decimals)
+    due_date: daysFromNow(30),
+    discount_rate: 500,               // 5%
+    status: "Pending",
+    funder: null,
+    funded_at: null,
+    token: USDC_ID,
+  },
+  // 2 – Pending, due in the future (EURC)
+  {
+    id: 2n,
+    freelancer: EVE,
+    payer: DAVE,
+    amount: 3_500_000_000n,           // 350 EURC
+    due_date: daysFromNow(15),
+    discount_rate: 350,               // 3.5%
+    status: "Pending",
+    funder: null,
+    funded_at: null,
+    token: EURC_ID,
+  },
+  // 3 – Funded (USDC)
+  {
+    id: 3n,
+    freelancer: ALICE,
+    payer: BOB,
+    amount: 10_000_000_000n,          // 1,000 USDC
+    due_date: daysFromNow(45),
+    discount_rate: 450,
+    status: "Funded",
+    funder: CAROL,
+    funded_at: daysAgo(2),
+    token: USDC_ID,
+  },
+  // 4 – Funded (EURC)
+  {
+    id: 4n,
+    freelancer: EVE,
+    payer: DAVE,
+    amount: 7_500_000_000n,           // 750 EURC
+    due_date: daysFromNow(60),
+    discount_rate: 400,
+    status: "Funded",
+    funder: FRANK,
+    funded_at: daysAgo(5),
+    token: EURC_ID,
+  },
+  // 5 – Paid on time (USDC)
+  {
+    id: 5n,
+    freelancer: ALICE,
+    payer: BOB,
+    amount: 2_000_000_000n,           // 200 USDC
+    due_date: daysAgo(10),
+    discount_rate: 300,
+    status: "Paid",
+    funder: CAROL,
+    funded_at: daysAgo(40),
+    token: USDC_ID,
+  },
+  // 6 – Paid on time (EURC)
+  {
+    id: 6n,
+    freelancer: EVE,
+    payer: BOB,
+    amount: 1_500_000_000n,           // 150 EURC
+    due_date: daysAgo(3),
+    discount_rate: 250,
+    status: "Paid",
+    funder: FRANK,
+    funded_at: daysAgo(25),
+    token: EURC_ID,
+  },
+  // 7 – Defaulted (USDC)
+  {
+    id: 7n,
+    freelancer: EVE,
+    payer: DAVE,
+    amount: 15_000_000_000n,          // 1,500 USDC
+    due_date: daysAgo(20),
+    discount_rate: 800,               // 8% — high risk matched the default
+    status: "Defaulted",
+    funder: CAROL,
+    funded_at: daysAgo(50),
+    token: USDC_ID,
+  },
+  // 8 – Cancelled before funding (USDC)
+  {
+    id: 8n,
+    freelancer: ALICE,
+    payer: DAVE,
+    amount: 800_000_000n,             // 80 USDC
+    due_date: daysFromNow(10),
+    discount_rate: 200,
+    status: "Cancelled",
+    funder: null,
+    funded_at: null,
+    token: USDC_ID,
+  },
+  // 9 – Expired (past due, never funded)
+  {
+    id: 9n,
+    freelancer: EVE,
+    payer: BOB,
+    amount: 4_200_000_000n,           // 420 USDC
+    due_date: daysAgo(5),
+    discount_rate: 600,
+    status: "Expired",
+    funder: null,
+    funded_at: null,
+    token: USDC_ID,
+  },
+  // 10 – Pending, large amount due soon (USDC)
+  {
+    id: 10n,
+    freelancer: ALICE,
+    payer: DAVE,
+    amount: 50_000_000_000n,          // 5,000 USDC
+    due_date: daysFromNow(7),
+    discount_rate: 700,
+    status: "Pending",
+    funder: null,
+    funded_at: null,
+    token: USDC_ID,
+  },
+  // 11 – Funded, due very soon (USDC)
+  {
+    id: 11n,
+    freelancer: EVE,
+    payer: BOB,
+    amount: 6_000_000_000n,           // 600 USDC
+    due_date: daysFromNow(2),
+    discount_rate: 550,
+    status: "Funded",
+    funder: FRANK,
+    funded_at: daysAgo(10),
+    token: USDC_ID,
+  },
+  // 12 – Paid, large amount (EURC)
+  {
+    id: 12n,
+    freelancer: ALICE,
+    payer: DAVE,
+    amount: 25_000_000_000n,          // 2,500 EURC
+    due_date: daysAgo(1),
+    discount_rate: 400,
+    status: "Paid",
+    funder: CAROL,
+    funded_at: daysAgo(35),
+    token: EURC_ID,
+  },
+  // 13 – Pending, minimal amount (USDC)
+  {
+    id: 13n,
+    freelancer: EVE,
+    payer: BOB,
+    amount: 100_000_000n,             // 10 USDC
+    due_date: daysFromNow(90),
+    discount_rate: 150,
+    status: "Pending",
+    funder: null,
+    funded_at: null,
+    token: USDC_ID,
+  },
+];
+
+// ─── Seed reputation scores ───────────────────────────────────────────────────
+
+export const SEED_REPUTATION: Map<string, PayerScore> = new Map([
+  [BOB,  { score: 92, settled_on_time: 11, defaults: 0 }],
+  [DAVE, { score: 45, settled_on_time: 3,  defaults: 2 }],
+  [CAROL,{ score: 88, settled_on_time: 7,  defaults: 0 }],
+  [EVE,  { score: 75, settled_on_time: 5,  defaults: 1 }],
+  [FRANK,{ score: 99, settled_on_time: 20, defaults: 0 }],
+]);
+
+// ─── Seed token balances ──────────────────────────────────────────────────────
+// key: `${tokenId}:${address}`
+
+export const SEED_BALANCES: Map<string, bigint> = new Map([
+  [`${USDC_ID}:${ALICE}`, 100_000_000_000n],   // 10,000 USDC
+  [`${USDC_ID}:${BOB}`,   200_000_000_000n],   // 20,000 USDC
+  [`${USDC_ID}:${CAROL}`, 500_000_000_000n],   // 50,000 USDC
+  [`${USDC_ID}:${DAVE}`,   50_000_000_000n],   //  5,000 USDC
+  [`${USDC_ID}:${EVE}`,    80_000_000_000n],   //  8,000 USDC
+  [`${USDC_ID}:${FRANK}`, 300_000_000_000n],   // 30,000 USDC
+  [`${EURC_ID}:${ALICE}`,  40_000_000_000n],   //  4,000 EURC
+  [`${EURC_ID}:${BOB}`,    80_000_000_000n],   //  8,000 EURC
+  [`${EURC_ID}:${EVE}`,    60_000_000_000n],   //  6,000 EURC
+  [`${EURC_ID}:${FRANK}`, 120_000_000_000n],   // 12,000 EURC
+]);
+
+// ─── Seed token allowances ────────────────────────────────────────────────────
+// key: `${tokenId}:${owner}:${spender}`
+
+export const SEED_ALLOWANCES: Map<string, bigint> = new Map([
+  // CAROL has pre-approved the contract to spend her USDC
+  [`${USDC_ID}:${CAROL}:CONTRACT`, 50_000_000_000n],
+  [`${EURC_ID}:${FRANK}:CONTRACT`, 20_000_000_000n],
+]);
+
+// ─── Seed governance proposals ────────────────────────────────────────────────
+
+const G_NOW = Math.floor(Date.now() / 1000);
+const G_DAY = 86_400;
+
+export const SEED_PROPOSALS: Proposal[] = [
+  {
+    id: 1,
+    title: "Reduce Base Discount Rate to 3.5%",
+    description:
+      "This proposal reduces the protocol's base discount rate from 5% to 3.5% to improve competitiveness with traditional invoice factoring services and attract higher invoice volume.",
+    type: "ParameterUpdate",
+    status: "Active",
+    proposer: CAROL,
+    createdAt: G_NOW - 2 * G_DAY,
+    votingStartsAt: G_NOW - 2 * G_DAY,
+    votingEndsAt: G_NOW + 5 * G_DAY,
+    votesFor: 142_500,
+    votesAgainst: 38_200,
+    votesAbstain: 9_100,
+    quorumRequired: 100_000,
+    parameterChanges: [
+      { parameter: "base_discount_rate", currentValue: "500 (5%)", newValue: "350 (3.5%)" },
+    ],
+  },
+  {
+    id: 2,
+    title: "Increase Quorum Threshold to 15%",
+    description:
+      "Raise the minimum quorum from 10% to 15% of circulating ILN tokens to ensure governance decisions represent a meaningful fraction of the token supply.",
+    type: "ParameterUpdate",
+    status: "Active",
+    proposer: FRANK,
+    createdAt: G_NOW - 1 * G_DAY,
+    votingStartsAt: G_NOW - 1 * G_DAY,
+    votingEndsAt: G_NOW + 6 * G_DAY,
+    votesFor: 56_000,
+    votesAgainst: 71_300,
+    votesAbstain: 4_200,
+    quorumRequired: 100_000,
+    parameterChanges: [
+      { parameter: "quorum_threshold_bps", currentValue: "1000 (10%)", newValue: "1500 (15%)" },
+    ],
+  },
+  {
+    id: 3,
+    title: "Add EURC as Accepted Invoice Currency",
+    description:
+      "Expand multi-token support by adding EURC (Euro Coin) alongside USDC, targeting European freelancers and eliminating FX conversion costs.",
+    type: "ProtocolUpgrade",
+    status: "Passed",
+    proposer: BOB,
+    createdAt: G_NOW - 14 * G_DAY,
+    votingStartsAt: G_NOW - 14 * G_DAY,
+    votingEndsAt: G_NOW - 7 * G_DAY,
+    executableAfter: G_NOW - 4 * G_DAY,
+    votesFor: 215_800,
+    votesAgainst: 44_100,
+    votesAbstain: 12_400,
+    quorumRequired: 100_000,
+    parameterChanges: [
+      { parameter: "accepted_tokens", currentValue: "[USDC]", newValue: "[USDC, EURC]" },
+    ],
+  },
+  {
+    id: 4,
+    title: "Extend Voting Period to 10 Days",
+    description:
+      "Increase the governance voting window from 7 to 10 days to give token holders adequate participation time across all time zones.",
+    type: "ParameterUpdate",
+    status: "Executed",
+    proposer: ALICE,
+    createdAt: G_NOW - 30 * G_DAY,
+    votingStartsAt: G_NOW - 30 * G_DAY,
+    votingEndsAt: G_NOW - 23 * G_DAY,
+    executableAfter: G_NOW - 20 * G_DAY,
+    votesFor: 189_600,
+    votesAgainst: 22_300,
+    votesAbstain: 6_100,
+    quorumRequired: 100_000,
+    parameterChanges: [
+      { parameter: "voting_period_seconds", currentValue: "604800 (7 days)", newValue: "864000 (10 days)" },
+    ],
+  },
+  {
+    id: 5,
+    title: "Signal: Explore On-Chain Credit Scoring Integration",
+    description:
+      "Gauge community sentiment on integrating a decentralised on-chain credit scoring module that could lower discount rates for freelancers with proven track records.",
+    type: "TextProposal",
+    status: "Failed",
+    proposer: EVE,
+    createdAt: G_NOW - 20 * G_DAY,
+    votingStartsAt: G_NOW - 20 * G_DAY,
+    votingEndsAt: G_NOW - 13 * G_DAY,
+    votesFor: 44_200,
+    votesAgainst: 88_700,
+    votesAbstain: 11_500,
+    quorumRequired: 100_000,
+  },
+  {
+    id: 6,
+    title: "Deploy LP Yield Optimiser Contract",
+    description:
+      "Deploy a new ancillary contract that auto-compounds LP yield by re-deploying earned USDC into the highest-APY invoice pool at the end of each epoch.",
+    type: "ProtocolUpgrade",
+    status: "Active",
+    proposer: FRANK,
+    createdAt: G_NOW - 3 * G_DAY,
+    votingStartsAt: G_NOW - 3 * G_DAY,
+    votingEndsAt: G_NOW + 4 * G_DAY,
+    votesFor: 87_400,
+    votesAgainst: 19_800,
+    votesAbstain: 3_600,
+    quorumRequired: 100_000,
+  },
+];
+
+// ─── Seed protocol parameters ─────────────────────────────────────────────────
+
+export const SEED_PROTOCOL_PARAMS: ProtocolParameters = {
+  feeRateBps: 50,
+  maxDiscountRateBps: 500,
+  acceptedTokens: [
+    { address: USDC_ID, name: "USD Coin",  symbol: "USDC" },
+    { address: EURC_ID, name: "Euro Coin", symbol: "EURC" },
+  ],
+  minProposalILN: 500,
+};
+
+// ─── Token metadata ───────────────────────────────────────────────────────────
+
+export const TOKEN_METADATA_MAP: Record<string, { name: string; symbol: string; decimals: number }> = {
+  [USDC_ID]: { name: "USD Coin",  symbol: "USDC", decimals: 7 },
+  [EURC_ID]: { name: "Euro Coin", symbol: "EURC", decimals: 7 },
+};

--- a/packages/mock-backend/src/types.ts
+++ b/packages/mock-backend/src/types.ts
@@ -1,0 +1,151 @@
+// ─── Invoice types ────────────────────────────────────────────────────────────
+
+export type InvoiceStatus = "Pending" | "Funded" | "Paid" | "Defaulted" | "Cancelled" | "Expired";
+
+export interface Invoice {
+  id: bigint;
+  freelancer: string;
+  payer: string;
+  amount: bigint;
+  /** Unix timestamp (seconds) */
+  due_date: bigint;
+  discount_rate: number;
+  status: InvoiceStatus;
+  funder: string | null;
+  funded_at: bigint | null;
+  /** Token contract ID */
+  token: string;
+}
+
+export interface SubmitInvoiceArgs {
+  freelancer: string;
+  payer: string;
+  /** Amount in stroops (1 USDC = 10_000_000) */
+  amount: bigint;
+  /** Unix timestamp (seconds) */
+  dueDate: number;
+  /** Basis-points — e.g. 500 = 5.00% */
+  discountRate: number;
+  token?: string;
+}
+
+export interface SubmittedInvoiceResult {
+  invoiceId: bigint;
+  /** Simulated transaction hash */
+  txHash: string;
+}
+
+export interface UpdateInvoiceArgs {
+  freelancer: string;
+  invoiceId: bigint;
+  amount: bigint;
+  dueDate: number;
+  discountRate: number;
+}
+
+// ─── Reputation types ─────────────────────────────────────────────────────────
+
+export interface PayerScore {
+  /** Composite score from 0–100 */
+  score: number;
+  settled_on_time: number;
+  defaults: number;
+}
+
+// ─── Token types ──────────────────────────────────────────────────────────────
+
+export interface TokenMetadata {
+  contractId: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+}
+
+// ─── Governance types ─────────────────────────────────────────────────────────
+
+export type ProposalType = "ParameterUpdate" | "ProtocolUpgrade" | "TextProposal";
+export type ProposalStatus = "Active" | "Passed" | "Failed" | "Executed" | "Pending";
+export type VoteChoice = "For" | "Against" | "Abstain";
+
+export interface ParameterChange {
+  parameter: string;
+  currentValue: string;
+  newValue: string;
+}
+
+export interface Proposal {
+  id: number;
+  title: string;
+  description: string;
+  type: ProposalType;
+  status: ProposalStatus;
+  proposer: string;
+  createdAt: number;
+  votingStartsAt: number;
+  votingEndsAt: number;
+  executableAfter?: number;
+  votesFor: number;
+  votesAgainst: number;
+  votesAbstain: number;
+  quorumRequired: number;
+  parameterChanges?: ParameterChange[];
+  userVote?: VoteChoice;
+}
+
+export interface ProtocolParameters {
+  feeRateBps: number;
+  maxDiscountRateBps: number;
+  acceptedTokens: Array<{ address: string; name: string; symbol: string }>;
+  minProposalILN: number;
+}
+
+export interface CreateProposalPayload {
+  title: string;
+  description: string;
+  type: ProposalType;
+  parameterChanges?: ParameterChange[];
+}
+
+// ─── Client interfaces ────────────────────────────────────────────────────────
+
+/**
+ * Interface that mirrors all read/write operations performed via soroban.ts
+ * in the frontend. The mock and the real implementations both satisfy this
+ * contract so the frontend can swap them via an env-var flag.
+ */
+export interface InvoiceClient {
+  getInvoiceCount(): Promise<bigint>;
+  getInvoice(id: bigint): Promise<Invoice>;
+  getAllInvoices(): Promise<Invoice[]>;
+
+  getTokenBalance(address: string, tokenId?: string): Promise<bigint>;
+  getTokenAllowance(args: { owner: string; spender?: string; tokenId?: string }): Promise<bigint>;
+  getApprovedTokenIds(): Promise<string[]>;
+  getTokenMetadata(tokenId: string): Promise<TokenMetadata>;
+
+  getPayerScore(payerAddress: string): Promise<PayerScore | null>;
+  getPayerScoresBatch(addresses: string[]): Promise<Map<string, PayerScore | null>>;
+
+  submitInvoice(args: SubmitInvoiceArgs): Promise<SubmittedInvoiceResult>;
+  fundInvoice(funder: string, invoiceId: bigint): Promise<{ txHash: string }>;
+  markPaid(payer: string, invoiceId: bigint): Promise<{ txHash: string }>;
+  claimDefault(funder: string, invoiceId: bigint): Promise<{ txHash: string }>;
+  cancelInvoice(freelancer: string, invoiceId: bigint): Promise<{ txHash: string }>;
+  updateInvoice(args: UpdateInvoiceArgs): Promise<{ txHash: string }>;
+  approveToken(args: { owner: string; amount: bigint; spender?: string; tokenId?: string }): Promise<{ txHash: string }>;
+}
+
+export interface ReputationClient {
+  getPayerScore(payerAddress: string): Promise<PayerScore | null>;
+  getPayerScoresBatch(addresses: string[]): Promise<Map<string, PayerScore | null>>;
+}
+
+export interface GovernanceClient {
+  fetchProposals(): Promise<Proposal[]>;
+  fetchProposal(id: number): Promise<Proposal | null>;
+  castVote(proposalId: number, choice: VoteChoice, signerAddress: string): Promise<string>;
+  executeProposal(proposalId: number, signerAddress: string): Promise<string>;
+  getVotingPower(address: string): Promise<number>;
+  fetchProtocolParameters(): Promise<ProtocolParameters>;
+  createProposal(payload: CreateProposalPayload, signerAddress: string): Promise<{ txHash: string; proposalId: number }>;
+}

--- a/packages/mock-backend/tsconfig.json
+++ b/packages/mock-backend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "lib": ["ES2020"],
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src", "__tests__"]
+}

--- a/packages/mock-backend/vitest.config.ts
+++ b/packages/mock-backend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["__tests__/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
- Add packages/mock-backend with ILNMockBackend class
- Implements InvoiceClient, ReputationClient, and GovernanceClient interfaces
- MockInvoiceClient: full in-memory CRUD for invoices, token balances/allowances, payer reputation; all write ops return synthetic tx hashes and update state
- MockReputationClient: standalone payer score reader
- MockGovernanceClient: proposals, voting, executeProposal, createProposal
- Seed data: 13 invoices across all statuses (Pending/Funded/Paid/Defaulted/ Cancelled/Expired), two tokens (USDC + EURC), 5 reputation scores, 6 governance proposals covering the full lifecycle (Active/Passed/Failed/Executed)
- Named test addresses exported (ALICE, BOB, CAROL, DAVE, EVE, FRANK)
- Frontend adapter at src/lib/mock-client.ts mirrors soroban.ts signatures; activated via NEXT_PUBLIC_ILN_MOCK=1 env var
- 51 tests covering reads, writes, state transitions, error paths, and interface compliance checks
- frontend/.env.local.example documents the ILN_MOCK flag

Closes #327 
Closes #303 