### PR TITLE
Add property-based tests for amount utilities

### DIFF
--- a/packages/sdk/tests/properties/amount.test.ts
+++ b/packages/sdk/tests/properties/amount.test.ts
@@ -1,1 +1,73 @@
-// Lorem ipsum placeholder for amount property tests.
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+
+import { formatAmount, parseAmount, type AmountToken } from "../../../../sdk/src/amounts";
+
+const PROPERTY_RUNS = 50_000;
+const MAX_SAFE_AMOUNT = 10n ** 30n;
+
+describe("SDK amount property tests", () => {
+  it("roundtrips parseAmount(formatAmount(x, token), token) for random token decimals", () => {
+    fc.assert(
+      fc.property(amountArbitrary(), tokenArbitrary(), (amount, token) => {
+        expect(parseAmount(formatAmount(amount, token), token)).toBe(amount);
+      }),
+      { numRuns: PROPERTY_RUNS },
+    );
+  });
+
+  it("never formats non-negative amounts as negative values", () => {
+    fc.assert(
+      fc.property(amountArbitrary(), tokenArbitrary(), (amount, token) => {
+        expect(formatAmount(amount, token).startsWith("-")).toBe(false);
+      }),
+      { numRuns: PROPERTY_RUNS },
+    );
+  });
+
+  it("always formats exactly the token decimal places", () => {
+    fc.assert(
+      fc.property(amountArbitrary(), tokenArbitrary(), (amount, token) => {
+        const formatted = formatAmount(amount, token);
+        const [, fraction = ""] = formatted.split(".");
+
+        expect(fraction.length).toBe(token.decimals);
+      }),
+      { numRuns: PROPERTY_RUNS },
+    );
+  });
+
+  it("parses bounded random decimal strings without overflowing BigInt", () => {
+    fc.assert(
+      fc.property(decimalStringArbitrary(), tokenArbitrary(), ({ whole, fraction }, token) => {
+        const normalizedFraction = fraction.slice(0, token.decimals);
+        const value = token.decimals === 0
+          ? whole
+          : `${whole}.${normalizedFraction.padEnd(token.decimals, "0")}`;
+
+        const parsed = parseAmount(value, token);
+
+        expect(parsed).toBeGreaterThanOrEqual(0n);
+        const scale = 10n ** BigInt(token.decimals);
+        expect(parsed).toBeLessThanOrEqual(BigInt(whole) * scale + scale - 1n);
+      }),
+      { numRuns: PROPERTY_RUNS },
+    );
+  });
+});
+
+function amountArbitrary(): fc.Arbitrary<bigint> {
+  return fc.bigInt({ max: MAX_SAFE_AMOUNT, min: 0n });
+}
+
+function tokenArbitrary(): fc.Arbitrary<AmountToken> {
+  return fc.integer({ max: 18, min: 0 }).map((decimals) => ({ decimals }));
+}
+
+function decimalStringArbitrary(): fc.Arbitrary<{ fraction: string; whole: string }> {
+  return fc.record({
+    fraction: fc.array(fc.integer({ max: 9, min: 0 }), { maxLength: 18 })
+      .map((digits) => digits.join("")),
+    whole: fc.bigInt({ max: MAX_SAFE_AMOUNT, min: 0n }).map((value) => value.toString()),
+  });
+}

--- a/packages/sdk/tests/properties/amount.test.ts
+++ b/packages/sdk/tests/properties/amount.test.ts
@@ -1,0 +1,1 @@
+// Lorem ipsum placeholder for amount property tests.

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -17,6 +17,7 @@
         "@commitlint/config-conventional": "^17.6.0",
         "@types/node": "^24.7.2",
         "@vitest/coverage-v8": "^4.1.5",
+        "fast-check": "^4.8.0",
         "husky": "^8.0.0",
         "tsup": "^8.5.0",
         "typescript": "^5.9.3",
@@ -2792,6 +2793,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4465,6 +4489,23 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -39,6 +39,7 @@
     "@commitlint/config-conventional": "^17.6.0",
     "@types/node": "^24.7.2",
     "@vitest/coverage-v8": "^4.1.5",
+    "fast-check": "^4.8.0",
     "husky": "^8.0.0",
     "tsup": "^8.5.0",
     "typescript": "^5.9.3",

--- a/sdk/src/amounts.ts
+++ b/sdk/src/amounts.ts
@@ -1,0 +1,49 @@
+export interface AmountToken {
+  decimals: number;
+}
+
+const MAX_DECIMALS = 18;
+
+export function parseAmount(input: string, token: AmountToken): bigint {
+  const decimals = normalizeDecimals(token);
+  const trimmed = input.trim();
+  const match = trimmed.match(/^(\d+)(?:\.(\d+))?$/);
+
+  if (!match) {
+    throw new Error("Invalid amount. Use a non-negative decimal value.");
+  }
+
+  const fraction = match[2] ?? "";
+  if (fraction.length > decimals) {
+    throw new Error(`Invalid amount. Token supports at most ${decimals} decimal places.`);
+  }
+
+  const whole = BigInt(match[1]);
+  const fractional = BigInt(fraction.padEnd(decimals, "0") || "0");
+  return whole * 10n ** BigInt(decimals) + fractional;
+}
+
+export function formatAmount(amount: bigint, token: AmountToken): string {
+  if (amount < 0n) {
+    throw new Error("Cannot format a negative amount.");
+  }
+
+  const decimals = normalizeDecimals(token);
+  const scale = 10n ** BigInt(decimals);
+  const whole = amount / scale;
+
+  if (decimals === 0) {
+    return whole.toString();
+  }
+
+  const fraction = (amount % scale).toString().padStart(decimals, "0");
+  return `${whole.toString()}.${fraction}`;
+}
+
+function normalizeDecimals(token: AmountToken): number {
+  if (!Number.isInteger(token.decimals) || token.decimals < 0 || token.decimals > MAX_DECIMALS) {
+    throw new Error(`Token decimals must be an integer between 0 and ${MAX_DECIMALS}.`);
+  }
+
+  return token.decimals;
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./amounts";
 export * from "./client";
 export * from "./signers";
 export * from "./types";

--- a/sdk/vitest.config.ts
+++ b/sdk/vitest.config.ts
@@ -3,7 +3,12 @@ import base from "../vitest.config";
 
 export default mergeConfig(base, {
   test: {
-    include: ["src/**/*.test.ts", "__tests__/**/*.test.ts", "tests/**/*.test.ts"],
+    include: [
+      "src/**/*.test.ts",
+      "__tests__/**/*.test.ts",
+      "tests/**/*.test.ts",
+      "../packages/sdk/tests/**/*.test.ts",
+    ],
     coverage: {
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts"],


### PR DESCRIPTION
Summary
- Added SDK amount parsing/formatting utilities for token-aware financial values.
- Replaced the placeholder with property-based tests using `fast-check`.
- Configured SDK Vitest to include the requested `packages/sdk/tests/properties` test path.

Issue
- Closes #270

Changes
- Added `parseAmount(value, token)` and `formatAmount(amount, token)` in the SDK.
- Supports token decimals from 0 through 18.
- Rejects negative formatted values and decimal input with too many fractional places.
- Added `fast-check` as an SDK dev dependency.
- Added four property tests with 50,000 generated cases each covering roundtrip behavior, non-negative formatting, exact decimal-place formatting, and bounded decimal parsing.

Validation
- Passed: `git diff --check`
- Passed: `cd sdk && ..\\cli\\node_modules\\.bin\\vitest run ../packages/sdk/tests/properties/amount.test.ts --root .` (4 tests, 50,000 runs per property)
- Passed: `cd sdk && npx tsc --noEmit --target ES2020 --module ESNext --moduleResolution Bundler --types node --strict src/amounts.ts`
- Failed: `cd sdk && npm run check` still fails on existing SDK issues: e2e Stellar SDK `Server` typing, duplicate `parseContractError` import, and duplicate generated type exports.
- Failed: direct standalone `tsc` against `../packages/sdk/tests/properties/amount.test.ts` cannot resolve SDK-local `vitest`/`fast-check` packages from the external test path; the test is validated through SDK Vitest instead.

Notes
- Local SDK `npx vitest` is blocked by the repo's checked-in SDK node_modules missing Vitest files on this machine, so the property suite was run with the working CLI-installed Vitest binary and SDK root.
