### PR TITLE
chore: add Changesets for multi-package version management

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "packages": [
+    "packages/sdk",
+    "sdk"
+  ],
+  "ignore": []
+}

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,83 @@
+# ==============================================================================
+# Changeset Check — Issue #247
+#
+# Enforces that every PR touching package source files includes a changeset.
+# This ensures changelog entries and semver bumps are never missed.
+#
+# Runs on: PRs touching packages/** or sdk/**
+# Skips:   PRs that only touch docs, tests, CI config, or non-package files
+# ==============================================================================
+
+name: Changeset Check
+
+on:
+  pull_request:
+    paths:
+      - 'packages/**'
+      - 'sdk/**'
+
+jobs:
+  changeset-check:
+    name: Require changeset for package changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check for changeset
+        run: |
+          # Get list of changed files in this PR
+          CHANGED=$(git diff --name-only origin/main...HEAD)
+
+          # Check if any package source files changed
+          PKG_CHANGED=$(echo "$CHANGED" | grep -E '^(packages|sdk)/' || true)
+
+          if [ -z "$PKG_CHANGED" ]; then
+            echo "No package source files changed — changeset not required."
+            exit 0
+          fi
+
+          # Check if a changeset file was added
+          CHANGESET=$(echo "$CHANGED" | grep -E '^\.changeset/.+\.md$' || true)
+
+          if [ -z "$CHANGESET" ]; then
+            echo ""
+            echo "❌ Package source files were changed but no changeset was found."
+            echo ""
+            echo "Please add a changeset by running:"
+            echo "  pnpm changeset"
+            echo ""
+            echo "Changed package files:"
+            echo "$PKG_CHANGED"
+            exit 1
+          fi
+
+          echo "✅ Changeset found: $CHANGESET"
+
+      - name: Comment PR on failure
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ **Changeset required!** This PR changes package source files but does not include a changeset.\n\nPlease run `pnpm changeset` locally, follow the prompts, and commit the generated `.changeset/*.md` file.\n\nSee [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#changeset-workflow) for details.'
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+# ==============================================================================
+# Release — Issue #247
+#
+# When changesets are merged into main, this workflow opens a "Version Packages"
+# PR that bumps versions and updates changelogs. Merging that PR triggers a
+# publish to npm.
+# ==============================================================================
+
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Version Packages or Publish
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create Release PR or Publish
+        uses: changesets/action@v1
+        with:
+          # Opens a "Version Packages" PR when changesets are present.
+          # Publishes to npm when the Version Packages PR is merged.
+          publish: pnpm changeset:publish
+          version: pnpm changeset:version
+          title: 'chore: version packages'
+          commit: 'chore: version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -362,3 +362,54 @@ Please prefer **option 1** when possible. If you suppress a finding via
 `knip.json` lives at the repo root. Each workspace package has its own
 section under `workspaces`. The schema is documented at
 [knip.dev/reference/configuration](https://knip.dev/reference/configuration).
+
+---
+
+## Changeset Workflow
+
+ILN uses [Changesets](https://github.com/changesets/changesets) to manage versioning and changelogs for the `@iln/sdk` and `@iln/shared` packages. Every PR that changes a package's public API must include a changeset.
+
+### When to add a changeset
+
+Add a changeset when your PR modifies any file under `packages/` or `sdk/`. You do **not** need a changeset for:
+
+- Documentation-only changes
+- CI/CD configuration changes
+- Test-only changes that do not affect public API behaviour
+- Changes to non-package files (scripts, indexer, notifications)
+
+### How to add a changeset
+
+1. From the repo root, run:
+
+```bash
+pnpm changeset
+```
+
+2. Follow the interactive prompts:
+   - Select the packages affected (`@iln/sdk`, `@iln/shared`, or both)
+   - Choose the semver bump type:
+     - `patch` — bug fixes, non-breaking internal changes
+     - `minor` — new features, non-breaking additions to public API
+     - `major` — breaking changes to public API
+   - Write a short summary of the change (this becomes the changelog entry)
+
+3. Commit the generated `.changeset/*.md` file alongside your code changes:
+
+```bash
+git add .changeset/
+git commit -m "chore: add changeset"
+```
+
+### What happens after merge
+
+When a PR with changesets is merged into `main`, the Changesets GitHub Action automatically opens a **"Version Packages"** PR that:
+
+- Bumps the version in each affected `package.json`
+- Updates `CHANGELOG.md` for each package with the changeset summaries
+
+Merging the Version Packages PR triggers a publish to npm.
+
+### CI enforcement
+
+The `changeset-check` CI job runs on every PR that touches `packages/**` or `sdk/**`. It will fail if no changeset file is present. If your PR does not require a changeset (documentation, tests, CI only), the check is skipped automatically.

--- a/package.json
+++ b/package.json
@@ -6,10 +6,14 @@
     "test:coverage": "turbo run test:coverage",
     "build": "turbo run build",
     "generate:types": "ts-node --esm scripts/generate-types.ts",
-    "dead-code:check": "knip"
-    "syncpack:check": "syncpack list-mismatches"
+    "dead-code:check": "knip",
+    "syncpack:check": "syncpack list-mismatches",
+    "changeset": "changeset",
+    "changeset:version": "changeset version",
+    "changeset:publish": "changeset publish"
   },
   "devDependencies": {
+    "@changesets/cli": "3.1.2",
     "@commitlint/cli": "^17.6.0",
     "@commitlint/config-conventional": "^17.6.0",
     "husky": "^8.0.0",


### PR DESCRIPTION
## Summary
Adds Changesets to the monorepo for automated version management and changelog 
generation across `@iln/sdk` and `@iln/shared`. Contributors must now add a 
changeset with each PR that changes a package's public API. The Changesets bot 
automatically opens a "Version Packages" PR when changesets are merged into main.

## Related Issue
Closes #247

## Complexity
- [x] Medium (new feature, non-breaking change)

## Changes Made
- `.changeset/config.json` — Changesets configuration scoped to `@iln/sdk` and `@iln/shared`
- `.github/workflows/changeset-check.yml` — CI job that requires a changeset on PRs touching `packages/**` or `sdk/**`
- `.github/workflows/release.yml` — Changesets bot workflow that opens a "Version Packages" PR on merge to main and publishes to npm
- `package.json` — added `@changesets/cli` to devDependencies, added `changeset`, `changeset:version`, and `changeset:publish` scripts, fixed missing comma syntax error
- `CONTRIBUTING.md` — new Changeset Workflow section documenting when and how to add a changeset

## Test Coverage
No contract code modified — tooling and documentation change only.

## Security Considerations
None. No contract logic, access control, or protocol behaviour affected.
The `NPM_TOKEN` secret must be added to the repository secrets before the 
release workflow can publish to npm.

## Checklist
- [ ] Tests pass locally — N/A, tooling change only
- [ ] New functionality has test coverage — N/A
- [ ] `cargo fmt` applied — N/A
- [ ] `cargo clippy` warnings resolved — N/A
- [ ] Public functions have doc comments — N/A
- [x] Breaking changes documented — no breaking changes
- [x] Issue linked (Closes #247)