### PR TITLE
feat: add Redis caching to indexer and iln history command to CLI

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -12,6 +12,8 @@ import { decodeScValXdr, formatDecodedScVal } from "./xdr";
 import {
   createUi,
   describeConfig,
+  formatHistoryJson,
+  formatHistoryTable,
   formatInvoiceDetails,
   formatInvoiceList,
   formatProtocolConfig,
@@ -154,6 +156,73 @@ export async function runCli(
       const invoices = await client.listInvoicesByAddress(options.address);
       ui.info(formatInvoiceList(invoices));
     });
+
+  program
+    .command("history")
+    .description("Show past invoice submissions, fundings, and payments for a Stellar address.")
+    .requiredOption("--address <address>", "Stellar address to query history for")
+    .option("--id <invoiceId>", "filter to a specific invoice ID")
+    .option(
+      "--action <type>",
+      "filter by action type: submit (freelancer), fund (funder), pay (payer)",
+    )
+    .option("--limit <n>", "maximum number of results to return")
+    .option("--format <fmt>", "output format: table (default) or json", "table")
+    .action(
+      async (options: {
+        address: string;
+        id?: string;
+        action?: string;
+        limit?: string;
+        format: string;
+      }) => {
+        assertStellarAddress(options.address, "address");
+
+        if (options.format !== "table" && options.format !== "json") {
+          throw new Error("--format must be table or json");
+        }
+
+        const ACTION_TO_ROLE: Record<string, "freelancer" | "funder" | "payer"> = {
+          submit: "freelancer",
+          fund: "funder",
+          pay: "payer",
+        };
+
+        if (options.action && !ACTION_TO_ROLE[options.action]) {
+          throw new Error(
+            `--action must be one of: ${Object.keys(ACTION_TO_ROLE).join(", ")}`,
+          );
+        }
+
+        const client = createClient(load());
+        let invoices = await client.listInvoicesByAddress(options.address);
+
+        if (options.id !== undefined) {
+          const targetId = parseInvoiceId(options.id);
+          invoices = invoices.filter((inv) => inv.id === targetId);
+        }
+
+        if (options.action) {
+          const role = ACTION_TO_ROLE[options.action];
+          invoices = invoices.filter((inv) => inv.role === role);
+        }
+
+        if (options.limit !== undefined) {
+          const limit = parseInt(options.limit, 10);
+          if (isNaN(limit) || limit <= 0) {
+            throw new Error("--limit must be a positive integer");
+          }
+          invoices = invoices.slice(0, limit);
+        }
+
+        const output =
+          options.format === "json"
+            ? formatHistoryJson(invoices)
+            : formatHistoryTable(invoices);
+
+        ui.info(output);
+      },
+    );
 
   // Compatibility check command
   const compatCommand = program.command("compat").description("SDK and contract compatibility utilities");

--- a/cli/src/format.ts
+++ b/cli/src/format.ts
@@ -96,6 +96,54 @@ export function formatProtocolConfig(config: ProtocolConfig): string {
   return lines.filter((line): line is string => line !== null).join("\n");
 }
 
+const ACTION_LABEL: Record<string, string> = {
+  freelancer: "submit",
+  payer: "pay",
+  funder: "fund",
+};
+
+export function formatHistoryTable(invoices: ListedInvoice[]): string {
+  if (invoices.length === 0) {
+    return "No history found.";
+  }
+
+  const headers = ["ID", "Action", "Status", "Amount", "Due"];
+  const rows = invoices.map((invoice) => [
+    invoice.id.toString(),
+    ACTION_LABEL[invoice.role] ?? invoice.role,
+    invoice.status,
+    formatAmount(invoice.amount),
+    formatTimestamp(invoice.dueDate).slice(0, 10),
+  ]);
+
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index].length)),
+  );
+
+  const renderRow = (cells: string[]) =>
+    cells.map((cell, index) => cell.padEnd(widths[index])).join("  ");
+
+  return [pc.bold(renderRow(headers)), ...rows.map(renderRow)].join("\n");
+}
+
+export function formatHistoryJson(invoices: ListedInvoice[]): string {
+  return JSON.stringify(
+    invoices.map((inv) => ({
+      id: inv.id.toString(),
+      action: ACTION_LABEL[inv.role] ?? inv.role,
+      status: inv.status,
+      amount: inv.amount.toString(),
+      dueDate: inv.dueDate,
+      freelancer: inv.freelancer,
+      payer: inv.payer,
+      funder: inv.funder ?? null,
+      fundedAt: inv.fundedAt ?? null,
+    })),
+    null,
+    2,
+  );
+}
+
 function row(label: string, value: string): string {
   return `${pc.bold(label.padEnd(11))} ${value}`;
 }

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -17,7 +17,8 @@
     "@stellar/stellar-sdk": "^15.0.1",
     "better-sqlite3": "^11.0.0",
     "dotenv": "^16.4.5",
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "ioredis": "^5.3.2"
   },
   "devDependencies": {
     "@iln/eslint-config": "workspace:*",

--- a/indexer/src/api.ts
+++ b/indexer/src/api.ts
@@ -8,6 +8,7 @@ import {
   getTopLPs,
   queryInvoices,
 } from "./db";
+import { cacheGet, cacheSet } from "./cache";
 
 /**
  * Build and return the Express application.
@@ -29,17 +30,31 @@ export function createApp(): express.Application {
   //   ?freelancer=G...
   //   ?payer=G...
   //   ?funder=G...
-  app.get("/invoices", (req: Request, res: Response) => {
+  app.get("/invoices", async (req: Request, res: Response) => {
     const { status, freelancer, payer, funder } = req.query;
 
+    const s = typeof status === "string" ? status : "";
+    const fl = typeof freelancer === "string" ? freelancer : "";
+    const pa = typeof payer === "string" ? payer : "";
+    const fu = typeof funder === "string" ? funder : "";
+    const cacheKey = `invoices:${s}:${fl}:${pa}:${fu}`;
+
+    const cached = await cacheGet(cacheKey);
+    if (cached) {
+      res.json(JSON.parse(cached));
+      return;
+    }
+
     const invoices = queryInvoices({
-      status: typeof status === "string" ? status : undefined,
-      freelancer: typeof freelancer === "string" ? freelancer : undefined,
-      payer: typeof payer === "string" ? payer : undefined,
-      funder: typeof funder === "string" ? funder : undefined,
+      status: s || undefined,
+      freelancer: fl || undefined,
+      payer: pa || undefined,
+      funder: fu || undefined,
     });
 
-    res.json({ invoices });
+    const result = { invoices };
+    await cacheSet(cacheKey, JSON.stringify(result));
+    res.json(result);
   });
 
   app.get("/stats", (_req: Request, res: Response) => {
@@ -79,11 +94,18 @@ export function createApp(): express.Application {
   });
 
   // ── GET /invoice/:id ───────────────────────────────────────────────────────
-  app.get("/invoice/:id", (req: Request, res: Response) => {
+  app.get("/invoice/:id", async (req: Request, res: Response) => {
     const id = parseInt(req.params.id, 10);
 
     if (isNaN(id) || id <= 0) {
       res.status(400).json({ error: "Invalid invoice ID - must be a positive integer" });
+      return;
+    }
+
+    const cacheKey = `invoice:${id}`;
+    const cached = await cacheGet(cacheKey);
+    if (cached) {
+      res.json(JSON.parse(cached));
       return;
     }
 
@@ -93,7 +115,9 @@ export function createApp(): express.Application {
       return;
     }
 
-    res.json({ invoice });
+    const result = { invoice };
+    await cacheSet(cacheKey, JSON.stringify(result));
+    res.json(result);
   });
 
   return app;

--- a/indexer/src/cache.ts
+++ b/indexer/src/cache.ts
@@ -1,0 +1,73 @@
+import Redis from "ioredis";
+import { CONFIG } from "./config";
+
+const INVOICE_TTL_SECONDS = 30;
+
+let _client: Redis | null = null;
+
+function getClient(): Redis | null {
+  if (!CONFIG.redisUrl) return null;
+  if (!_client) {
+    _client = new Redis(CONFIG.redisUrl);
+    _client.on("error", (err: Error) => {
+      console.error("[cache] Redis error:", err.message);
+    });
+  }
+  return _client;
+}
+
+export async function cacheGet(key: string): Promise<string | null> {
+  try {
+    return (await getClient()?.get(key)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function cacheSet(
+  key: string,
+  value: string,
+  ttlSeconds = INVOICE_TTL_SECONDS,
+): Promise<void> {
+  try {
+    await getClient()?.set(key, value, "EX", ttlSeconds);
+  } catch {
+    // Non-fatal: the next request will simply miss the cache.
+  }
+}
+
+export async function cacheDelete(key: string): Promise<void> {
+  try {
+    await getClient()?.del(key);
+  } catch {
+    // Non-fatal.
+  }
+}
+
+export async function cacheDeletePattern(pattern: string): Promise<void> {
+  const client = getClient();
+  if (!client) return;
+  try {
+    const keys = await client.keys(pattern);
+    if (keys.length > 0) {
+      await client.del(keys);
+    }
+  } catch {
+    // Non-fatal.
+  }
+}
+
+/** Invalidate all cache entries for a given invoice and every invoice list. */
+export async function invalidateInvoiceCache(id: number): Promise<void> {
+  await Promise.all([
+    cacheDelete(`invoice:${id}`),
+    cacheDeletePattern("invoices:*"),
+  ]);
+}
+
+export async function disconnectCache(): Promise<void> {
+  if (_client) {
+    await _client.quit();
+    _client = null;
+  }
+}

--- a/indexer/src/config.ts
+++ b/indexer/src/config.ts
@@ -19,4 +19,6 @@ export const CONFIG = {
    * 0 = automatically start from (latestLedger - 1000).
    */
   startLedger: Number(process.env.START_LEDGER ?? "0"),
+  /** Optional Redis connection URL (e.g. redis://localhost:6379). Caching is disabled when unset. */
+  redisUrl: process.env.REDIS_URL,
 } as const;

--- a/indexer/src/processor.ts
+++ b/indexer/src/processor.ts
@@ -1,5 +1,6 @@
 import { type rpc, scValToNative } from "@stellar/stellar-sdk";
 import { hasEvent, insertEvent, upsertInvoice } from "./db";
+import { invalidateInvoiceCache } from "./cache";
 import { fetchInvoice } from "./rpc";
 import type { ILNEventType } from "./types";
 
@@ -60,5 +61,6 @@ export async function processEvent(
   const invoice = await fetchInvoice(invoiceId);
   if (invoice) {
     upsertInvoice(invoice);
+    await invalidateInvoiceCache(invoiceId);
   }
 }


### PR DESCRIPTION
Closes #457 
Closes #458 
Closes #459 
Closes #460 

## Summary

### Indexer – Redis Caching

**Files:** `indexer/src/cache.ts`, `indexer/src/api.ts`, `indexer/src/processor.ts`, `indexer/src/config.ts`, `indexer/package.json`

* Added `ioredis` dependency and support for a `REDIS_URL` environment variable.
* Caching is automatically disabled when `REDIS_URL` is not configured, ensuring the indexer continues to operate normally without Redis.
* Added caching for:

  * `GET /invoices` using cache keys generated from query parameter combinations.
  * `GET /invoice/:id` using the key format `invoice:{id}`.
* Configured a cache TTL of **30 seconds** for both endpoints.
* Implemented cache invalidation in `processor.ts` via `invalidateInvoiceCache(id)` after every invoice upsert:

  * Removes the corresponding `invoice:{id}` cache entry.
  * Clears cached invoice list queries (`invoices:*`).
* Redis errors are handled gracefully and logged without affecting API availability. On cache failure, requests fall back to SQLite.

### CLI – `iln history` Command

**Files:** `cli/src/cli.ts`, `cli/src/format.ts`

Added a new command:

```bash
iln history --address <G...>
```

Features:

* Lists all invoice activity associated with an address, including:

  * Submissions
  * Fundings
  * Payments
* Uses the existing `listInvoicesByAddress` RPC endpoint.
* Supports filtering by action:

  * `submit`
  * `fund`
  * `pay`
* Supports filtering by invoice ID:

  * `--id <n>`
* Supports limiting returned records:

  * `--limit <n>`
* Output formats:

  * `--format table` (default)
  * `--format json`
* JSON output serializes `BigInt` values as strings for compatibility.

## Test Plan

### Redis Caching

1. Start the indexer without `REDIS_URL`.

   * Verify API endpoints respond normally.

2. Start the indexer with:

```bash
REDIS_URL=redis://localhost:6379
```

* Verify repeated identical requests are served from cache.
* Confirm cached entries using Redis CLI, for example:

```bash
redis-cli get "invoice:1"
```

3. Submit or pay an invoice.

   * Verify related cache entries are invalidated within one polling cycle.

### CLI History Command

1. Verify full history output:

```bash
iln history --address <G...>
```

* Confirm submissions, fundings, and payments are displayed.

2. Verify filtering and JSON output:

```bash
iln history --address <G...> --action fund --limit 5 --format json
```

* Confirm only funding-related entries are returned.
* Confirm output contains at most 5 records.
* Confirm `BigInt` values are serialized as strings.

3. Verify invoice-specific filtering:

```bash
iln history --address <G...> --id 3
```

* Confirm only invoice `3` is returned when the address is associated with that invoice.
