### PR TITLE
feat: InvoiceStatus enum, React hooks, indexer health endpoint, SDK README badges

### DIFF
--- a/.changeset/feat-442-443-445-447.md
+++ b/.changeset/feat-442-443-445-447.md
@@ -1,0 +1,11 @@
+---
+"@iln/sdk": minor
+"@iln/react": minor
+---
+
+feat: add InvoiceStatus enum, React hooks, indexer health endpoint, and SDK README badges
+
+- (#443) Add `InvoiceStatus` enum with all statuses (Pending, Funded, Paid, Defaulted, Disputed), helper predicates (`isPending`, `isFunded`, `isPaid`, `isDefaulted`, `isDisputed`, `isTerminal`), and `InvoiceStatusColor` map for UI integration
+- (#447) Add `useILN` wallet-connection hook, `useInvoices` paginated list hook, `useSubmitInvoice` and `useFundInvoice` mutation hooks to `@iln/react`; implement missing `ILNProvider` component and `TestWrapper` test utility
+- (#445) Enhance indexer `GET /health` to return `{ status, db, lastSync, uptime }` including a live DB connectivity check and last-sync ISO timestamp
+- (#442) Add npm, license, and CI badges to SDK README along with a 5-line quick start code block

--- a/indexer/src/api.ts
+++ b/indexer/src/api.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from "express";
 import {
+  getDb,
   getFreelancerStats,
   getInvoiceById,
   getInvoiceHistory,
@@ -8,6 +9,7 @@ import {
   getTopLPs,
   queryInvoices,
   queryInvoicesPaginated,
+  getCursorUpdatedAt,
 } from "./db";
 import { cacheGet, cacheSet } from "./cache";
 
@@ -20,9 +22,27 @@ export function createApp(): express.Application {
   const app = express();
   app.use(express.json());
 
+  const startTime = Date.now();
+
   // ── GET /health ────────────────────────────────────────────────────────────
   app.get("/health", (_req: Request, res: Response) => {
-    res.json({ status: "ok" });
+    let dbStatus: "ok" | "error" = "ok";
+    try {
+      getDb().prepare("SELECT 1").get();
+    } catch {
+      dbStatus = "error";
+    }
+
+    const lastSyncMs = getCursorUpdatedAt();
+    const uptime = Date.now() - startTime;
+    const status = dbStatus === "ok" ? "ok" : "degraded";
+
+    res.json({
+      status,
+      db: dbStatus,
+      lastSync: lastSyncMs !== null ? new Date(lastSyncMs).toISOString() : null,
+      uptime,
+    });
   });
 
   // ── GET /invoices ──────────────────────────────────────────────────────────

--- a/indexer/src/db.ts
+++ b/indexer/src/db.ts
@@ -430,6 +430,14 @@ export function getCursorLedger(): number {
   return row?.last_ledger ?? 0;
 }
 
+/** Return the Unix ms timestamp of the last processed ledger, or null if never synced. */
+export function getCursorUpdatedAt(): number | null {
+  const row = getDb()
+    .prepare("SELECT updated_at FROM cursor WHERE id = 1")
+    .get() as { updated_at: number } | undefined;
+  return row?.updated_at ?? null;
+}
+
 /** Persist the last processed ledger sequence. */
 export function setCursorLedger(ledger: number): void {
   getDb()

--- a/indexer/tests/api.test.ts
+++ b/indexer/tests/api.test.ts
@@ -2,7 +2,7 @@ import type { Express } from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createApp } from "../src/api";
-import { createDb, setDb, upsertInvoice } from "../src/db";
+import { createDb, setDb, upsertInvoice, setCursorLedger } from "../src/db";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -45,10 +45,36 @@ beforeEach(() => {
 // ── /health ───────────────────────────────────────────────────────────────────
 
 describe("GET /health", () => {
-  it("returns 200 with status ok", async () => {
+  it("returns 200 with all required fields", async () => {
     const res = await request(app).get("/health");
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: "ok" });
+    expect(res.body).toHaveProperty("status");
+    expect(res.body).toHaveProperty("db");
+    expect(res.body).toHaveProperty("lastSync");
+    expect(res.body).toHaveProperty("uptime");
+  });
+
+  it("reports status ok and db ok when database is healthy", async () => {
+    const res = await request(app).get("/health");
+    expect(res.body.status).toBe("ok");
+    expect(res.body.db).toBe("ok");
+  });
+
+  it("returns null lastSync when the indexer has never synced", async () => {
+    const res = await request(app).get("/health");
+    expect(res.body.lastSync).toBeNull();
+  });
+
+  it("returns an ISO 8601 lastSync timestamp after a ledger is processed", async () => {
+    setCursorLedger(12345);
+    const res = await request(app).get("/health");
+    expect(res.body.lastSync).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("returns a non-negative uptime in milliseconds", async () => {
+    const res = await request(app).get("/health");
+    expect(typeof res.body.uptime).toBe("number");
+    expect(res.body.uptime).toBeGreaterThanOrEqual(0);
   });
 });
 

--- a/packages/react/src/context/ILNProvider.tsx
+++ b/packages/react/src/context/ILNProvider.tsx
@@ -1,24 +1,24 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import type { ILNClient } from '@invoice-liquidity/sdk';
-import { ILNContext } from '../context/ILNContext';
+import { ILNContext } from './ILNContext';
 
-interface TestWrapperProps {
+export interface ILNProviderProps {
   client: ILNClient;
   children: ReactNode;
+  queryClient?: QueryClient;
 }
 
-export function TestWrapper({ client, children }: TestWrapperProps): JSX.Element {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        staleTime: 0,
-        gcTime: 0,
-      },
+const defaultQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 30_000,
     },
-  });
+  },
+});
 
+export function ILNProvider({ client, children, queryClient = defaultQueryClient }: ILNProviderProps): JSX.Element {
   return (
     <QueryClientProvider client={queryClient}>
       <ILNContext.Provider value={client}>

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,8 +1,20 @@
+export { useILN } from './useILN';
+export type { UseILNResult } from './useILN';
+
 export { useInvoice } from './useInvoice';
 export type { UseInvoiceResult } from './useInvoice';
 
+export { useInvoices } from './useInvoices';
+export type { UseInvoicesResult, UseInvoicesOptions } from './useInvoices';
+
 export { useInvoiceList } from './useInvoiceList';
 export type { UseInvoiceListResult, InvoiceRole } from './useInvoiceList';
+
+export { useSubmitInvoice } from './useSubmitInvoice';
+export type { UseSubmitInvoiceResult, SubmitInvoiceParams } from './useSubmitInvoice';
+
+export { useFundInvoice } from './useFundInvoice';
+export type { UseFundInvoiceResult, FundInvoiceParams } from './useFundInvoice';
 
 export { useReputationScore } from './useReputationScore';
 export type { UseReputationScoreResult } from './useReputationScore';

--- a/packages/react/src/hooks/useFundInvoice.test.ts
+++ b/packages/react/src/hooks/useFundInvoice.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFundInvoice } from './useFundInvoice';
+import type { FundInvoiceParams } from './useFundInvoice';
+import { createMockILNClient } from '../test/mocks';
+import { TestWrapper } from '../test/wrapper';
+
+const validParams: FundInvoiceParams = {
+  invoiceId: 42,
+  funder: 'GDRMKYQMTNZ3XPRF7K7L3PFBJQI2S2Y2E3KJQF3KHKY3XT3LZXG3G5X2',
+};
+
+describe('useFundInvoice', () => {
+  it('returns idle state initially', () => {
+    const mockClient = createMockILNClient();
+    const { result } = renderHook(() => useFundInvoice(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls client.fundInvoice with the provided params', async () => {
+    const mockClient = createMockILNClient({
+      fundInvoice: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const { result } = renderHook(() => useFundInvoice(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    await act(async () => {
+      await result.current.fundInvoice(validParams);
+    });
+
+    expect(mockClient.fundInvoice).toHaveBeenCalledWith(validParams);
+  });
+
+  it('sets isPending to true while funding and false after', async () => {
+    let resolve!: () => void;
+    const fundPromise = new Promise<void>((res) => { resolve = res; });
+
+    const mockClient = createMockILNClient({
+      fundInvoice: vi.fn().mockReturnValue(fundPromise),
+    });
+
+    const { result } = renderHook(() => useFundInvoice(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    expect(result.current.isPending).toBe(false);
+
+    act(() => { void result.current.fundInvoice(validParams); });
+    expect(result.current.isPending).toBe(true);
+
+    await act(async () => { resolve(); });
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('sets error state on failure', async () => {
+    const mockError = new Error('Not enough liquidity');
+    const mockClient = createMockILNClient({
+      fundInvoice: vi.fn().mockRejectedValue(mockError),
+    });
+
+    const { result } = renderHook(() => useFundInvoice(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    await act(async () => {
+      await result.current.fundInvoice(validParams).catch(() => undefined);
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.error).toEqual(mockError);
+  });
+
+  it('reset clears the error state', async () => {
+    const mockClient = createMockILNClient({
+      fundInvoice: vi.fn().mockRejectedValue(new Error('failed')),
+    });
+
+    const { result } = renderHook(() => useFundInvoice(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    await act(async () => {
+      await result.current.fundInvoice(validParams).catch(() => undefined);
+    });
+
+    expect(result.current.error).not.toBeNull();
+
+    act(() => { result.current.reset(); });
+
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/packages/react/src/hooks/useFundInvoice.ts
+++ b/packages/react/src/hooks/useFundInvoice.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from 'react';
+import { useILNClient } from '../context';
+import { useQueryClient } from '@tanstack/react-query';
+
+export interface FundInvoiceParams {
+  invoiceId: number;
+  funder: string;
+}
+
+export interface UseFundInvoiceResult {
+  fundInvoice: (params: FundInvoiceParams) => Promise<void>;
+  isPending: boolean;
+  error: Error | null;
+  reset: () => void;
+}
+
+/**
+ * Mutation hook for funding an existing invoice.
+ *
+ * Automatically invalidates invoice queries on success so UIs stay in sync.
+ *
+ * @returns {UseFundInvoiceResult} Fund function, pending state, and error
+ *
+ * @example
+ * ```tsx
+ * function FundButton({ invoiceId }: { invoiceId: number }) {
+ *   const { fundInvoice, isPending, error } = useFundInvoice();
+ *
+ *   return (
+ *     <>
+ *       {error && <p className="error">{error.message}</p>}
+ *       <button
+ *         disabled={isPending}
+ *         onClick={() => fundInvoice({ invoiceId, funder: myAddress })}
+ *       >
+ *         {isPending ? 'Funding…' : 'Fund Invoice'}
+ *       </button>
+ *     </>
+ *   );
+ * }
+ * ```
+ */
+export function useFundInvoice(): UseFundInvoiceResult {
+  const client = useILNClient();
+  const queryClient = useQueryClient();
+
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fundInvoice = useCallback(
+    async (params: FundInvoiceParams): Promise<void> => {
+      setIsPending(true);
+      setError(null);
+
+      try {
+        await (client as unknown as { fundInvoice(p: FundInvoiceParams): Promise<void> }).fundInvoice(params);
+        await queryClient.invalidateQueries({ queryKey: ['invoices'] });
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error('Failed to fund invoice');
+        setError(e);
+        throw e;
+      } finally {
+        setIsPending(false);
+      }
+    },
+    [client, queryClient],
+  );
+
+  const reset = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return { fundInvoice, isPending, error, reset };
+}

--- a/packages/react/src/hooks/useILN.test.ts
+++ b/packages/react/src/hooks/useILN.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useILN } from './useILN';
+import { createMockILNClient } from '../test/mocks';
+import { TestWrapper } from '../test/wrapper';
+
+describe('useILN', () => {
+  it('returns isInitialized false when not inside a provider', () => {
+    const { result } = renderHook(() => useILN());
+    expect(result.current.isInitialized).toBe(false);
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.address).toBeNull();
+  });
+
+  it('returns isInitialized true when inside a provider', () => {
+    const mockClient = createMockILNClient();
+    const { result } = renderHook(() => useILN(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+    expect(result.current.isInitialized).toBe(true);
+  });
+
+  it('sets error when connect is called without a provider', async () => {
+    const { result } = renderHook(() => useILN());
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toMatch(/not initialized/i);
+  });
+
+  it('connects successfully and sets address', async () => {
+    const walletAddress = 'GDRMKYQMTNZ3XPRF7K7L3PFBJQI2S2Y2E3KJQF3KHKY3XT3LZXG3G5X2';
+    const mockClient = createMockILNClient({
+      connectWallet: vi.fn().mockResolvedValue(walletAddress),
+    });
+
+    const { result } = renderHook(() => useILN(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.address).toBe(walletAddress);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error state when connect throws', async () => {
+    const mockClient = createMockILNClient({
+      connectWallet: vi.fn().mockRejectedValue(new Error('User rejected connection')),
+    });
+
+    const { result } = renderHook(() => useILN(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.isConnected).toBe(false);
+    expect(result.current.address).toBeNull();
+    expect(result.current.error?.message).toBe('User rejected connection');
+  });
+
+  it('tracks isConnecting state during connection', async () => {
+    let resolveConnect!: (addr: string) => void;
+    const connectPromise = new Promise<string>((res) => { resolveConnect = res; });
+
+    const mockClient = createMockILNClient({
+      connectWallet: vi.fn().mockReturnValue(connectPromise),
+    });
+
+    const { result } = renderHook(() => useILN(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    expect(result.current.isConnecting).toBe(false);
+
+    act(() => { void result.current.connect(); });
+    expect(result.current.isConnecting).toBe(true);
+
+    await act(async () => { resolveConnect('G_ADDRESS'); });
+    expect(result.current.isConnecting).toBe(false);
+  });
+});

--- a/packages/react/src/hooks/useILN.ts
+++ b/packages/react/src/hooks/useILN.ts
@@ -1,0 +1,71 @@
+import { useCallback, useContext, useState } from 'react';
+import { ILNContext } from '../context/ILNContext';
+
+export interface UseILNResult {
+  isInitialized: boolean;
+  address: string | null;
+  isConnected: boolean;
+  isConnecting: boolean;
+  error: Error | null;
+  connect: () => Promise<void>;
+}
+
+/**
+ * Hook for SDK initialization and wallet connection management.
+ *
+ * Must be used inside an ILNProvider. Returns wallet state and a connect function.
+ *
+ * @returns {UseILNResult} Wallet state and connect function
+ *
+ * @example
+ * ```tsx
+ * function ConnectButton() {
+ *   const { isConnected, isConnecting, address, connect, error } = useILN();
+ *
+ *   if (isConnected) return <span>Connected: {address}</span>;
+ *
+ *   return (
+ *     <button onClick={connect} disabled={isConnecting}>
+ *       {isConnecting ? 'Connecting…' : 'Connect Wallet'}
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
+export function useILN(): UseILNResult {
+  const client = useContext(ILNContext);
+
+  const [address, setAddress] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const connect = useCallback(async () => {
+    if (!client) {
+      setError(new Error('ILN client not initialized. Wrap your app with <ILNProvider>.'));
+      return;
+    }
+
+    setIsConnecting(true);
+    setError(null);
+
+    try {
+      const walletAddress = await (client as unknown as { connectWallet(): Promise<string> }).connectWallet();
+      setAddress(walletAddress);
+      setIsConnected(true);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Wallet connection failed'));
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [client]);
+
+  return {
+    isInitialized: client !== null,
+    address,
+    isConnected,
+    isConnecting,
+    error,
+    connect,
+  };
+}

--- a/packages/react/src/hooks/useInvoices.test.ts
+++ b/packages/react/src/hooks/useInvoices.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useInvoices } from './useInvoices';
+import { createMockILNClient, mockInvoiceList } from '../test/mocks';
+import { TestWrapper } from '../test/wrapper';
+
+const VALID_ADDRESS = 'GDRMKYQMTNZ3XPRF7K7L3PFBJQI2S2Y2E3KJQF3KHKY3XT3LZXG3G5X2';
+
+describe('useInvoices', () => {
+  it('returns loading state initially for a valid address', () => {
+    const mockClient = createMockILNClient();
+    const { result } = renderHook(() => useInvoices(VALID_ADDRESS), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('fetches invoices by issuer role by default', async () => {
+    const mockClient = createMockILNClient();
+    const { result } = renderHook(() => useInvoices(VALID_ADDRESS), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockClient.getInvoicesByIssuer).toHaveBeenCalledWith(VALID_ADDRESS);
+    expect(result.current.data).toBeDefined();
+  });
+
+  it('returns correct pagination metadata', async () => {
+    const mockClient = createMockILNClient();
+    const { result } = renderHook(
+      () => useInvoices(VALID_ADDRESS, { role: 'issuer', page: 1, pageSize: 1 }),
+      { wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper> },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.page).toBe(1);
+    expect(result.current.pageSize).toBe(1);
+    expect(result.current.totalCount).toBe(mockInvoiceList.length);
+    expect(result.current.data?.length).toBe(1);
+    expect(result.current.hasPreviousPage).toBe(false);
+    expect(result.current.hasNextPage).toBe(mockInvoiceList.length > 1);
+  });
+
+  it('handles page 2 with correct slice', async () => {
+    const mockClient = createMockILNClient();
+    const { result } = renderHook(
+      () => useInvoices(VALID_ADDRESS, { page: 2, pageSize: 1 }),
+      { wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper> },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.page).toBe(2);
+    expect(result.current.hasPreviousPage).toBe(true);
+  });
+
+  it('does not fetch with invalid address', () => {
+    const mockClient = createMockILNClient();
+    const { result } = renderHook(() => useInvoices('invalid-address'), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(mockClient.getInvoicesByIssuer).not.toHaveBeenCalled();
+  });
+
+  it('returns error when fetch fails', async () => {
+    const mockError = new Error('Network error');
+    const mockClient = createMockILNClient({
+      getInvoicesByIssuer: vi.fn().mockRejectedValue(mockError),
+    });
+
+    const { result } = renderHook(() => useInvoices(VALID_ADDRESS), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toEqual(mockError);
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/react/src/hooks/useInvoices.ts
+++ b/packages/react/src/hooks/useInvoices.ts
@@ -1,0 +1,96 @@
+import { useQuery } from '@tanstack/react-query';
+import { useILNClient } from '../context';
+import type { InvoiceRole } from './useInvoiceList';
+
+export type { InvoiceRole };
+
+export interface UseInvoicesOptions {
+  role?: InvoiceRole;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface UseInvoicesResult {
+  data: import('@invoice-liquidity/sdk').Invoice[] | undefined;
+  totalCount: number;
+  page: number;
+  pageSize: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const invoicesKeys = {
+  all: ['invoices', 'paginated'] as const,
+  list: (address: string, role: InvoiceRole) =>
+    [...invoicesKeys.all, address, role] as const,
+};
+
+/**
+ * Fetches a paginated list of invoices filtered by address and role.
+ *
+ * @param address - The Stellar address to filter by
+ * @param options - Optional role, page, and pageSize controls
+ * @returns {UseInvoicesResult} Paginated invoices, pagination metadata, loading state, and error
+ *
+ * @example
+ * ```tsx
+ * function InvoiceListPage({ address }: { address: string }) {
+ *   const [page, setPage] = React.useState(1);
+ *   const { data, hasNextPage, hasPreviousPage } = useInvoices(address, {
+ *     role: 'issuer',
+ *     page,
+ *     pageSize: 5,
+ *   });
+ *
+ *   return (
+ *     <>
+ *       <InvoiceTable invoices={data ?? []} />
+ *       <button disabled={!hasPreviousPage} onClick={() => setPage((p) => p - 1)}>Prev</button>
+ *       <button disabled={!hasNextPage} onClick={() => setPage((p) => p + 1)}>Next</button>
+ *     </>
+ *   );
+ * }
+ * ```
+ */
+export function useInvoices(address: string, options: UseInvoicesOptions = {}): UseInvoicesResult {
+  const { role = 'issuer', page = 1, pageSize = 10 } = options;
+  const client = useILNClient();
+
+  const { data: allData, isLoading, error } = useQuery({
+    queryKey: invoicesKeys.list(address, role),
+    queryFn: async () => {
+      switch (role) {
+        case 'issuer':
+          return client.getInvoicesByIssuer(address);
+        case 'lp':
+          return client.getInvoicesByStatus(1);
+        case 'payer': {
+          const all = await client.getInvoicesByStatus(0);
+          return all.filter((inv) => inv.payer === address);
+        }
+        default:
+          return [];
+      }
+    },
+    enabled: !!address && address.startsWith('G'),
+    staleTime: 30_000,
+  });
+
+  const totalCount = allData?.length ?? 0;
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+  const data = allData?.slice(start, end);
+
+  return {
+    data,
+    totalCount,
+    page,
+    pageSize,
+    hasNextPage: end < totalCount,
+    hasPreviousPage: page > 1,
+    isLoading,
+    error: error instanceof Error ? error : null,
+  };
+}

--- a/packages/react/src/hooks/useSubmitInvoice.test.ts
+++ b/packages/react/src/hooks/useSubmitInvoice.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSubmitInvoice } from './useSubmitInvoice';
+import type { SubmitInvoiceParams } from './useSubmitInvoice';
+import { createMockILNClient } from '../test/mocks';
+import { TestWrapper } from '../test/wrapper';
+
+const validParams: SubmitInvoiceParams = {
+  issuer: 'GDRMKYQMTNZ3XPRF7K7L3PFBJQI2S2Y2E3KJQF3KHKY3XT3LZXG3G5X2',
+  payer: 'GDELEGATE000000000000000000000000000000000000000000000001',
+  amount: 100_0000000,
+  discountRate: 300,
+  dueDate: 1_800_000_000,
+};
+
+describe('useSubmitInvoice', () => {
+  it('returns idle state initially', () => {
+    const mockClient = createMockILNClient();
+    const { result } = renderHook(() => useSubmitInvoice(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls client.submitInvoice with the provided params', async () => {
+    const mockClient = createMockILNClient({
+      submitInvoice: vi.fn().mockResolvedValue(42),
+    });
+
+    const { result } = renderHook(() => useSubmitInvoice(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    await act(async () => {
+      await result.current.submitInvoice(validParams);
+    });
+
+    expect(mockClient.submitInvoice).toHaveBeenCalledWith(validParams);
+  });
+
+  it('returns the invoice id from submitInvoice', async () => {
+    const mockClient = createMockILNClient({
+      submitInvoice: vi.fn().mockResolvedValue(99),
+    });
+
+    const { result } = renderHook(() => useSubmitInvoice(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    let returnedId: unknown;
+    await act(async () => {
+      returnedId = await result.current.submitInvoice(validParams);
+    });
+
+    expect(returnedId).toBe(99);
+  });
+
+  it('sets and surfaces error on failure', async () => {
+    const mockError = new Error('Insufficient balance');
+    const mockClient = createMockILNClient({
+      submitInvoice: vi.fn().mockRejectedValue(mockError),
+    });
+
+    const { result } = renderHook(() => useSubmitInvoice(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    await act(async () => {
+      await result.current.submitInvoice(validParams).catch(() => undefined);
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.error).toEqual(mockError);
+  });
+
+  it('reset clears the error state', async () => {
+    const mockClient = createMockILNClient({
+      submitInvoice: vi.fn().mockRejectedValue(new Error('oops')),
+    });
+
+    const { result } = renderHook(() => useSubmitInvoice(), {
+      wrapper: ({ children }) => <TestWrapper client={mockClient}>{children}</TestWrapper>,
+    });
+
+    await act(async () => {
+      await result.current.submitInvoice(validParams).catch(() => undefined);
+    });
+
+    expect(result.current.error).not.toBeNull();
+
+    act(() => { result.current.reset(); });
+
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/packages/react/src/hooks/useSubmitInvoice.ts
+++ b/packages/react/src/hooks/useSubmitInvoice.ts
@@ -1,0 +1,86 @@
+import { useCallback, useState } from 'react';
+import { useILNClient } from '../context';
+import { useQueryClient } from '@tanstack/react-query';
+
+export interface SubmitInvoiceParams {
+  issuer: string;
+  payer: string;
+  amount: number;
+  discountRate: number;
+  dueDate: number;
+}
+
+export interface UseSubmitInvoiceResult {
+  submitInvoice: (params: SubmitInvoiceParams) => Promise<unknown>;
+  isPending: boolean;
+  error: Error | null;
+  reset: () => void;
+}
+
+/**
+ * Mutation hook for submitting a new invoice to the contract.
+ *
+ * Automatically invalidates invoice list queries on success.
+ *
+ * @returns {UseSubmitInvoiceResult} Submit function, pending state, and error
+ *
+ * @example
+ * ```tsx
+ * function SubmitInvoiceForm() {
+ *   const { submitInvoice, isPending, error } = useSubmitInvoice();
+ *
+ *   const handleSubmit = async (data: FormData) => {
+ *     const id = await submitInvoice({
+ *       issuer: data.issuer,
+ *       payer: data.payer,
+ *       amount: data.amount,
+ *       discountRate: 300,
+ *       dueDate: Date.now() / 1000 + 30 * 86400,
+ *     });
+ *     console.log('Invoice submitted, id:', id);
+ *   };
+ *
+ *   return (
+ *     <form onSubmit={handleSubmit}>
+ *       {error && <p className="error">{error.message}</p>}
+ *       <button type="submit" disabled={isPending}>
+ *         {isPending ? 'Submitting…' : 'Submit Invoice'}
+ *       </button>
+ *     </form>
+ *   );
+ * }
+ * ```
+ */
+export function useSubmitInvoice(): UseSubmitInvoiceResult {
+  const client = useILNClient();
+  const queryClient = useQueryClient();
+
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const submitInvoice = useCallback(
+    async (params: SubmitInvoiceParams): Promise<unknown> => {
+      setIsPending(true);
+      setError(null);
+
+      try {
+        const result = await (client as unknown as { submitInvoice(p: SubmitInvoiceParams): Promise<unknown> }).submitInvoice(params);
+        await queryClient.invalidateQueries({ queryKey: ['invoices'] });
+        return result;
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error('Failed to submit invoice');
+        setError(e);
+        throw e;
+      } finally {
+        setIsPending(false);
+      }
+    },
+    [client, queryClient],
+  );
+
+  const reset = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return { submitInvoice, isPending, error, reset };
+}

--- a/packages/react/src/index.test.ts
+++ b/packages/react/src/index.test.ts
@@ -3,8 +3,12 @@ import * as exports from './index';
 
 describe('package exports', () => {
   it('exports all hooks', () => {
+    expect(exports.useILN).toBeDefined();
     expect(exports.useInvoice).toBeDefined();
+    expect(exports.useInvoices).toBeDefined();
     expect(exports.useInvoiceList).toBeDefined();
+    expect(exports.useSubmitInvoice).toBeDefined();
+    expect(exports.useFundInvoice).toBeDefined();
     expect(exports.useReputationScore).toBeDefined();
     expect(exports.useLPPortfolio).toBeDefined();
     expect(exports.useContractStats).toBeDefined();

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,8 +9,12 @@ export type { ILNProviderProps } from './context';
 
 // Hooks
 export {
+  useILN,
   useInvoice,
+  useInvoices,
   useInvoiceList,
+  useSubmitInvoice,
+  useFundInvoice,
   useReputationScore,
   useLPPortfolio,
   useContractStats,
@@ -19,9 +23,16 @@ export {
 } from './hooks';
 
 export type {
+  UseILNResult,
   UseInvoiceResult,
+  UseInvoicesResult,
+  UseInvoicesOptions,
   UseInvoiceListResult,
   InvoiceRole,
+  UseSubmitInvoiceResult,
+  SubmitInvoiceParams,
+  UseFundInvoiceResult,
+  FundInvoiceParams,
   UseReputationScoreResult,
   UseLPPortfolioResult,
   UseContractStatsResult,

--- a/packages/react/src/test/mocks.ts
+++ b/packages/react/src/test/mocks.ts
@@ -1,4 +1,5 @@
-import type { ILNClient, Invoice, InvoiceStatus, Proposal, ReputationScore, LPPortfolio, ContractStats, TokenBalance } from '@invoice-liquidity/sdk';
+import { vi } from 'vitest';
+import type { ILNClient, Invoice, Proposal, ReputationScore, LPPortfolio, ContractStats, TokenBalance } from '@invoice-liquidity/sdk';
 
 export const mockInvoice: Invoice = {
   id: 42,
@@ -7,19 +8,19 @@ export const mockInvoice: Invoice = {
   amount: 100_0000000,
   discountRate: 300,
   dueDate: 1735689600,
-  status: InvoiceStatus.Funded,
+  status: 'Funded',
   fundedBy: 'G_LP_ADDRESS',
   token: 'USDC_CONTRACT_ID',
-};
+} as unknown as Invoice;
 
 export const mockInvoiceList: Invoice[] = [
   mockInvoice,
   {
     ...mockInvoice,
     id: 43,
-    status: InvoiceStatus.Pending,
+    status: 'Pending',
     fundedBy: null,
-  },
+  } as unknown as Invoice,
 ];
 
 export const mockReputationScore: ReputationScore = {
@@ -29,7 +30,7 @@ export const mockReputationScore: ReputationScore = {
   paidOnTime: 11,
   defaulted: 1,
   avgDiscountRate: 250,
-};
+} as unknown as ReputationScore;
 
 export const mockLPPortfolio: LPPortfolio = {
   address: 'G_LP_ADDRESS',
@@ -39,7 +40,7 @@ export const mockLPPortfolio: LPPortfolio = {
   completedPositions: 8,
   defaultedPositions: 1,
   avgReturn: 3.2,
-};
+} as unknown as LPPortfolio;
 
 export const mockContractStats: ContractStats = {
   totalValueLocked: 1_000_000_0000000,
@@ -47,7 +48,7 @@ export const mockContractStats: ContractStats = {
   totalVolume: 5_000_000_0000000,
   activeInvoices: 342,
   avgDiscountRate: 280,
-};
+} as unknown as ContractStats;
 
 export const mockProposal: Proposal = {
   id: 1,
@@ -58,15 +59,15 @@ export const mockProposal: Proposal = {
   votesAgainst: 2_000_0000000,
   deadline: 1738368000,
   executed: false,
-};
+} as unknown as Proposal;
 
 export const mockTokenBalances: TokenBalance[] = [
   { token: 'USDC', contractId: 'USDC_ID', balance: 1000_0000000 },
   { token: 'EURC', contractId: 'EURC_ID', balance: 500_0000000 },
   { token: 'XLM', contractId: 'XLM_ID', balance: 50_0000000 },
-];
+] as unknown as TokenBalance[];
 
-export function createMockILNClient(overrides: Partial<ILNClient> = {}): ILNClient {
+export function createMockILNClient(overrides: Partial<Record<string, unknown>> = {}): ILNClient {
   return {
     getInvoice: vi.fn().mockResolvedValue(mockInvoice),
     getInvoicesByIssuer: vi.fn().mockResolvedValue(mockInvoiceList),
@@ -76,12 +77,12 @@ export function createMockILNClient(overrides: Partial<ILNClient> = {}): ILNClie
     getContractStats: vi.fn().mockResolvedValue(mockContractStats),
     getProposal: vi.fn().mockResolvedValue(mockProposal),
     getTokenBalances: vi.fn().mockResolvedValue(mockTokenBalances),
-    submitInvoice: vi.fn(),
-    fundInvoice: vi.fn(),
-    markPaid: vi.fn(),
-    createProposal: vi.fn(),
-    vote: vi.fn(),
-    connectWallet: vi.fn(),
+    submitInvoice: vi.fn().mockResolvedValue(42),
+    fundInvoice: vi.fn().mockResolvedValue(undefined),
+    markPaid: vi.fn().mockResolvedValue(undefined),
+    createProposal: vi.fn().mockResolvedValue(undefined),
+    vote: vi.fn().mockResolvedValue(undefined),
+    connectWallet: vi.fn().mockResolvedValue('GDRMKYQMTNZ3XPRF7K7L3PFBJQI2S2Y2E3KJQF3KHKY3XT3LZXG3G5X2'),
     ...overrides,
   } as unknown as ILNClient;
 }

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,13 +1,33 @@
-# `@invoice-liquidity/sdk`
+# `@iln/sdk`
+
+[![npm version](https://img.shields.io/npm/v/@iln/sdk)](https://www.npmjs.com/package/@iln/sdk)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![CI](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/actions/workflows/ci.yml/badge.svg)](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/actions/workflows/ci.yml)
 
 Typed JavaScript and TypeScript SDK for the Invoice Liquidity Network Soroban contract on Stellar.
 
 By participating in this project, you agree to abide by our [Code of Conduct](../CODE_OF_CONDUCT.md).
 
+## Quick Start
+
+```bash
+npm install @iln/sdk
+```
+
+```ts
+import { ILNSdk, ILN_TESTNET, createFreighterSigner } from "@iln/sdk";
+
+const sdk = new ILNSdk({ ...ILN_TESTNET, signer: createFreighterSigner() });
+const invoiceId = await sdk.submitInvoice({ freelancer: "G...", payer: "G...", amount: 25_000_000n, dueDate: Math.floor(Date.now() / 1000) + 604800, discountRate: 300 });
+await sdk.fundInvoice({ funder: "G...", invoiceId });
+const invoice = await sdk.getInvoice(invoiceId);
+console.log(invoice.status); // "Funded"
+```
+
 ## Install
 
 ```bash
-npm install @invoice-liquidity/sdk
+npm install @iln/sdk
 ```
 
 ## Quickstart
@@ -131,7 +151,22 @@ getInvoice(invoiceId: bigint): Promise<Invoice>;
 The canonical domain definitions live in `@iln/shared`; the SDK re-exports them for compatibility.
 
 ```ts
-type InvoiceStatus = "Pending" | "Funded" | "Paid" | "Defaulted";
+import { InvoiceStatus, isPending, isFunded, isTerminal, InvoiceStatusColor } from "@iln/sdk";
+
+// Enum for full type safety and autocomplete
+InvoiceStatus.Pending   // "Pending"
+InvoiceStatus.Funded    // "Funded"
+InvoiceStatus.Paid      // "Paid"
+InvoiceStatus.Defaulted // "Defaulted"
+InvoiceStatus.Disputed  // "Disputed"
+
+// Helper predicates
+isPending(invoice.status)   // true / false
+isFunded(invoice.status)
+isTerminal(invoice.status)  // true for Paid | Defaulted | Disputed
+
+// UI color mapping
+InvoiceStatusColor[invoice.status] // e.g. "#10B981"
 
 interface Invoice {
   id: bigint;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./amounts";
 export * from "./client";
+export * from "./invoice-status";
 export * from "./signers";
 export * from "./types";
 export * from "./timeouts";

--- a/sdk/src/invoice-status.test.ts
+++ b/sdk/src/invoice-status.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  InvoiceStatus,
+  isPending,
+  isFunded,
+  isPaid,
+  isDefaulted,
+  isDisputed,
+  isTerminal,
+  InvoiceStatusColor,
+} from "./invoice-status";
+
+describe("InvoiceStatus enum", () => {
+  it("has all required values", () => {
+    expect(InvoiceStatus.Pending).toBe("Pending");
+    expect(InvoiceStatus.Funded).toBe("Funded");
+    expect(InvoiceStatus.Paid).toBe("Paid");
+    expect(InvoiceStatus.Defaulted).toBe("Defaulted");
+    expect(InvoiceStatus.Disputed).toBe("Disputed");
+  });
+
+  it("enum values are string literals for easy serialisation", () => {
+    for (const value of Object.values(InvoiceStatus)) {
+      expect(typeof value).toBe("string");
+    }
+  });
+});
+
+describe("isPending", () => {
+  it("returns true for Pending", () => {
+    expect(isPending(InvoiceStatus.Pending)).toBe(true);
+    expect(isPending("Pending")).toBe(true);
+  });
+
+  it("returns false for all other statuses", () => {
+    expect(isPending(InvoiceStatus.Funded)).toBe(false);
+    expect(isPending(InvoiceStatus.Paid)).toBe(false);
+    expect(isPending(InvoiceStatus.Defaulted)).toBe(false);
+    expect(isPending(InvoiceStatus.Disputed)).toBe(false);
+  });
+});
+
+describe("isFunded", () => {
+  it("returns true for Funded", () => {
+    expect(isFunded(InvoiceStatus.Funded)).toBe(true);
+    expect(isFunded("Funded")).toBe(true);
+  });
+
+  it("returns false for other statuses", () => {
+    expect(isFunded(InvoiceStatus.Pending)).toBe(false);
+    expect(isFunded(InvoiceStatus.Paid)).toBe(false);
+  });
+});
+
+describe("isPaid", () => {
+  it("returns true for Paid", () => {
+    expect(isPaid(InvoiceStatus.Paid)).toBe(true);
+    expect(isPaid("Paid")).toBe(true);
+  });
+
+  it("returns false for other statuses", () => {
+    expect(isPaid(InvoiceStatus.Pending)).toBe(false);
+    expect(isPaid(InvoiceStatus.Funded)).toBe(false);
+  });
+});
+
+describe("isDefaulted", () => {
+  it("returns true for Defaulted", () => {
+    expect(isDefaulted(InvoiceStatus.Defaulted)).toBe(true);
+    expect(isDefaulted("Defaulted")).toBe(true);
+  });
+
+  it("returns false for other statuses", () => {
+    expect(isDefaulted(InvoiceStatus.Pending)).toBe(false);
+  });
+});
+
+describe("isDisputed", () => {
+  it("returns true for Disputed", () => {
+    expect(isDisputed(InvoiceStatus.Disputed)).toBe(true);
+    expect(isDisputed("Disputed")).toBe(true);
+  });
+
+  it("returns false for other statuses", () => {
+    expect(isDisputed(InvoiceStatus.Pending)).toBe(false);
+    expect(isDisputed(InvoiceStatus.Funded)).toBe(false);
+  });
+});
+
+describe("isTerminal", () => {
+  it("returns true for terminal statuses (Paid, Defaulted, Disputed)", () => {
+    expect(isTerminal(InvoiceStatus.Paid)).toBe(true);
+    expect(isTerminal(InvoiceStatus.Defaulted)).toBe(true);
+    expect(isTerminal(InvoiceStatus.Disputed)).toBe(true);
+  });
+
+  it("returns false for non-terminal statuses", () => {
+    expect(isTerminal(InvoiceStatus.Pending)).toBe(false);
+    expect(isTerminal(InvoiceStatus.Funded)).toBe(false);
+  });
+});
+
+describe("InvoiceStatusColor", () => {
+  it("has a hex color for every enum value", () => {
+    for (const status of Object.values(InvoiceStatus)) {
+      const color = InvoiceStatusColor[status];
+      expect(color).toBeDefined();
+      expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  });
+
+  it("Pending maps to an amber color", () => {
+    expect(InvoiceStatusColor[InvoiceStatus.Pending]).toBe("#F59E0B");
+  });
+
+  it("Funded maps to a blue color", () => {
+    expect(InvoiceStatusColor[InvoiceStatus.Funded]).toBe("#3B82F6");
+  });
+
+  it("Paid maps to a green color", () => {
+    expect(InvoiceStatusColor[InvoiceStatus.Paid]).toBe("#10B981");
+  });
+
+  it("Defaulted maps to a red color", () => {
+    expect(InvoiceStatusColor[InvoiceStatus.Defaulted]).toBe("#EF4444");
+  });
+
+  it("Disputed maps to a purple color", () => {
+    expect(InvoiceStatusColor[InvoiceStatus.Disputed]).toBe("#8B5CF6");
+  });
+});

--- a/sdk/src/invoice-status.ts
+++ b/sdk/src/invoice-status.ts
@@ -1,0 +1,39 @@
+export enum InvoiceStatus {
+  Pending = "Pending",
+  Funded = "Funded",
+  Paid = "Paid",
+  Defaulted = "Defaulted",
+  Disputed = "Disputed",
+}
+
+export function isPending(status: string): boolean {
+  return status === InvoiceStatus.Pending;
+}
+
+export function isFunded(status: string): boolean {
+  return status === InvoiceStatus.Funded;
+}
+
+export function isPaid(status: string): boolean {
+  return status === InvoiceStatus.Paid;
+}
+
+export function isDefaulted(status: string): boolean {
+  return status === InvoiceStatus.Defaulted;
+}
+
+export function isDisputed(status: string): boolean {
+  return status === InvoiceStatus.Disputed;
+}
+
+export function isTerminal(status: string): boolean {
+  return isPaid(status) || isDefaulted(status) || isDisputed(status);
+}
+
+export const InvoiceStatusColor: Record<string, string> = {
+  [InvoiceStatus.Pending]: "#F59E0B",
+  [InvoiceStatus.Funded]: "#3B82F6",
+  [InvoiceStatus.Paid]: "#10B981",
+  [InvoiceStatus.Defaulted]: "#EF4444",
+  [InvoiceStatus.Disputed]: "#8B5CF6",
+};

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,5 +1,3 @@
-import type { InvoiceState } from "@iln/shared";
-
 export type {
   ContractEvent,
   ContractStats,
@@ -12,7 +10,6 @@ export type {
   Token,
 } from "@iln/shared";
 
-export type InvoiceStatus = InvoiceState;
 
 export interface SubmitInvoiceParams {
   freelancer: string;


### PR DESCRIPTION
## Summary

- **#443** Add `InvoiceStatus` enum to `@iln/sdk` with all five status values (`Pending`, `Funded`, `Paid`, `Defaulted`, `Disputed`), helper predicates (`isPending`, `isFunded`, `isPaid`, `isDefaulted`, `isDisputed`, `isTerminal`), and `InvoiceStatusColor` map for UI theming. Removes the old bare type-alias and replaces it with the typed enum. Full unit test coverage included.
- **#447** Implement the missing pieces of `@iln/react`: add `ILNProvider` component (was exported but never defined), `TestWrapper` test utility (was referenced but empty), and four new hooks — `useILN` (wallet connection), `useInvoices` (paginated list), `useSubmitInvoice`, and `useFundInvoice`. Fix pre-existing runtime bug in `mocks.ts` where `InvoiceStatus` was imported as `import type` but used as a value. Tests added for every new hook.
- **#445** Enhance the indexer `GET /health` endpoint to return `{ status, db, lastSync, uptime }`: live DB connectivity check via `SELECT 1`, ISO 8601 last-sync timestamp from the `cursor` table (new `getCursorUpdatedAt()` helper in `db.ts`), and millisecond uptime since process start. Update API tests to assert all new fields.
- **#442** Add npm version, license, and CI badges to `sdk/README.md` and prepend a 5-line copy-pasteable Quick Start block above the existing Quickstart section.

## Test plan

- [ ] `InvoiceStatus` enum: `sdk/src/invoice-status.test.ts` — all enum values, all predicates, terminal check, color map hex format
- [ ] React hooks: `useILN.test.ts`, `useInvoices.test.ts`, `useSubmitInvoice.test.ts`, `useFundInvoice.test.ts` — loading state, success path, error path, pagination metadata, reset
- [ ] Indexer health: `indexer/tests/api.test.ts` — 200 status, `db: "ok"`, `lastSync: null` before first sync, ISO timestamp after `setCursorLedger`, non-negative uptime
- [ ] Package exports: `packages/react/src/index.test.ts` — all new hooks present
- [ ] CI changeset check: `.changeset/feat-442-443-445-447.md` covers both `@iln/sdk` (minor) and `@iln/react` (minor)

Closes #442
Closes #443
Closes #445
Closes #447