### PR TITLE
Implement indexed webhook delivery, retry logging, and HMAC webhook s…

### DIFF
--- a/notifications/src/api.ts
+++ b/notifications/src/api.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response } from "express";
+import { randomBytes } from "crypto";
 import {
   createSubscription,
   deleteSubscriptionByAddressAndDestination,
@@ -22,6 +23,7 @@ interface SubscribeRequest {
   channel: string;
   destination: string;
   triggers: unknown;
+  webhook_secret?: string;
 }
 
 export function createApp() {
@@ -40,9 +42,9 @@ export function createApp() {
     }
 
     if (!validateChannel(body.channel)) {
-      return res
-        .status(400)
-        .json({ error: `channel must be one of: ${ALLOWED_CHANNELS.join(", ")}` });
+      return res.status(400).json({
+        error: `channel must be one of: ${ALLOWED_CHANNELS.join(", ")}`,
+      });
     }
 
     if (!body.destination || typeof body.destination !== "string") {
@@ -50,20 +52,28 @@ export function createApp() {
     }
 
     if (!Array.isArray(body.triggers) || body.triggers.length === 0) {
-      return res.status(400).json({ error: "triggers must be a non-empty array" });
+      return res
+        .status(400)
+        .json({ error: "triggers must be a non-empty array" });
     }
 
     const triggers = body.triggers as unknown[];
     if (!triggers.every(validateTrigger)) {
-      return res.status(400).json({ error: `triggers must be one of: ${ALLOWED_TRIGGERS.join(", ")}` });
+      return res.status(400).json({
+        error: `triggers must be one of: ${ALLOWED_TRIGGERS.join(", ")}`,
+      });
     }
 
     if (body.channel === "email" && !isValidEmail(body.destination)) {
-      return res.status(400).json({ error: "destination must be a valid email address" });
+      return res
+        .status(400)
+        .json({ error: "destination must be a valid email address" });
     }
 
     if (body.channel === "webhook" && !isValidUrl(body.destination)) {
-      return res.status(400).json({ error: "destination must be a valid http or https URL" });
+      return res
+        .status(400)
+        .json({ error: "destination must be a valid http or https URL" });
     }
 
     const subscription = createSubscription({
@@ -71,6 +81,12 @@ export function createApp() {
       channel: body.channel as "email" | "webhook",
       destination: body.destination,
       triggers: triggers as NotificationTrigger[],
+      webhook_secret:
+        body.channel === "webhook"
+          ? typeof body.webhook_secret === "string"
+            ? body.webhook_secret
+            : randomBytes(32).toString("hex")
+          : undefined,
     });
 
     return res.status(201).json({ subscription });
@@ -109,15 +125,34 @@ export function createApp() {
       return res.status(400).json({ error: "address is required" });
     }
 
-    const subscriptions = getSubscriptionsByAddress(address);
+    const subscriptions = getSubscriptionsByAddress(address).map((sub) => ({
+      id: sub.id,
+      stellar_address: sub.stellar_address,
+      channel: sub.channel,
+      destination: sub.destination,
+      triggers: sub.triggers,
+      created_at: sub.created_at,
+    }));
     return res.json({ subscriptions });
+  });
+
+  app.get("/subscriptions/:id/logs", (req: Request, res: Response) => {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: "Invalid subscription id" });
+    }
+
+    const logs = getWebhookDeliveryLogs(id);
+    return res.json({ logs });
   });
 
   app.post("/test-webhook", async (req: Request, res: Response) => {
     const { id } = req.body as { id: number };
 
     if (typeof id !== "number") {
-      return res.status(400).json({ error: "id is required and must be a number" });
+      return res
+        .status(400)
+        .json({ error: "id is required and must be a number" });
     }
 
     const subscription = getSubscriptionById(id);
@@ -147,15 +182,17 @@ export function createApp() {
         },
         recipientAddress: subscription.stellar_address,
         subject: "Webhook Test",
-        message: "This is a test notification from the ILN Notification Service.",
+        message:
+          "This is a test notification from the ILN Notification Service.",
         actor: "freelancer",
       });
 
       return res.json({ success: true, statusCode: 200 });
     } catch (error: any) {
-      const statusCode = error.message.includes("attempts:") ? 
-        parseInt(error.message.split(": ")[1]) || 500 : 500;
-        
+      const statusCode = error.message.includes("attempts:")
+        ? parseInt(error.message.split(": ")[1]) || 500
+        : 500;
+
       return res.json({ success: false, statusCode });
     }
   });

--- a/notifications/src/db.ts
+++ b/notifications/src/db.ts
@@ -6,6 +6,7 @@ import type {
   NotificationTrigger,
   Subscription,
   SubscriptionChannel,
+  WebhookDeliveryLog,
 } from "./types";
 
 type SQLiteDatabase = InstanceType<typeof Database>;
@@ -68,6 +69,7 @@ function runMigrations(db: SQLiteDatabase): void {
       channel         TEXT    NOT NULL CHECK (channel IN ('email', 'webhook')),
       destination     TEXT    NOT NULL,
       triggers        TEXT    NOT NULL,
+      webhook_secret  TEXT,
       created_at      INTEGER NOT NULL
     );
 
@@ -83,6 +85,22 @@ function runMigrations(db: SQLiteDatabase): void {
       UNIQUE (invoice_id, trigger, recipient_address, channel, destination)
     );
 
+    CREATE TABLE IF NOT EXISTS webhook_delivery_logs (
+      id               INTEGER PRIMARY KEY,
+      subscription_id  INTEGER NOT NULL,
+      event_id         TEXT,
+      trigger          TEXT    NOT NULL,
+      invoice_id       INTEGER NOT NULL,
+      recipient_address TEXT   NOT NULL,
+      status           TEXT    NOT NULL CHECK (status IN ('pending', 'success', 'failed')),
+      attempts         INTEGER NOT NULL,
+      response_status  INTEGER,
+      error            TEXT,
+      created_at       INTEGER NOT NULL,
+      updated_at       INTEGER NOT NULL,
+      FOREIGN KEY(subscription_id) REFERENCES subscriptions(id)
+    );
+
     CREATE INDEX IF NOT EXISTS idx_invoices_status     ON invoices(status);
     CREATE INDEX IF NOT EXISTS idx_invoices_freelancer ON invoices(freelancer);
     CREATE INDEX IF NOT EXISTS idx_invoices_payer      ON invoices(payer);
@@ -94,7 +112,7 @@ function runMigrations(db: SQLiteDatabase): void {
 }
 
 export function upsertInvoice(
-  invoice: Omit<Invoice, "created_at" | "updated_at">
+  invoice: Omit<Invoice, "created_at" | "updated_at">,
 ): void {
   const now = Date.now();
   getDb()
@@ -109,7 +127,7 @@ export function upsertInvoice(
          status    = excluded.status,
          funder    = excluded.funder,
          funded_at = excluded.funded_at,
-         updated_at = excluded.updated_at`
+         updated_at = excluded.updated_at`,
     )
     .run({
       ...invoice,
@@ -121,9 +139,9 @@ export function upsertInvoice(
 }
 
 export function getInvoiceById(id: number): Invoice | undefined {
-  return getDb()
-    .prepare("SELECT * FROM invoices WHERE id = ?")
-    .get(id) as Invoice | undefined;
+  return getDb().prepare("SELECT * FROM invoices WHERE id = ?").get(id) as
+    | Invoice
+    | undefined;
 }
 
 export function queryInvoicesByStatus(status: string): Invoice[] {
@@ -134,9 +152,8 @@ export function queryInvoicesByStatus(status: string): Invoice[] {
 
 export function hasEvent(eventId: string): boolean {
   return (
-    getDb()
-      .prepare("SELECT 1 FROM events WHERE event_id = ?")
-      .get(eventId) !== undefined
+    getDb().prepare("SELECT 1 FROM events WHERE event_id = ?").get(eventId) !==
+    undefined
   );
 }
 
@@ -153,7 +170,7 @@ export function insertEvent(event: {
       `INSERT OR IGNORE INTO events
          (event_id, event_type, invoice_id, ledger, ledger_closed_at, created_at)
        VALUES
-         (@event_id, @event_type, @invoice_id, @ledger, @ledger_closed_at, @created_at)`
+         (@event_id, @event_type, @invoice_id, @ledger, @ledger_closed_at, @created_at)`,
     )
     .run(event);
 }
@@ -172,27 +189,28 @@ export function setCursorLedger(ledger: number): void {
        VALUES (1, ?, ?)
        ON CONFLICT(id) DO UPDATE SET
          last_ledger = excluded.last_ledger,
-         updated_at  = excluded.updated_at`
+         updated_at  = excluded.updated_at`,
     )
     .run(ledger, Date.now());
 }
 
 export function createSubscription(
-  subscription: Omit<Subscription, "id" | "created_at">
+  subscription: Omit<Subscription, "id" | "created_at">,
 ): Subscription {
   const now = Date.now();
   const result = getDb()
     .prepare(
       `INSERT INTO subscriptions
-         (stellar_address, channel, destination, triggers, created_at)
-       VALUES (?, ?, ?, ?, ?)`
+         (stellar_address, channel, destination, triggers, webhook_secret, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
     )
     .run(
       subscription.stellar_address,
       subscription.channel,
       subscription.destination,
       JSON.stringify(subscription.triggers),
-      now
+      subscription.webhook_secret ?? null,
+      now,
     );
 
   return {
@@ -204,7 +222,9 @@ export function createSubscription(
 
 export function getSubscriptionsByAddress(address: string): Subscription[] {
   return getDb()
-    .prepare("SELECT * FROM subscriptions WHERE stellar_address = ? ORDER BY id ASC")
+    .prepare(
+      "SELECT * FROM subscriptions WHERE stellar_address = ? ORDER BY id ASC",
+    )
     .all(address)
     .map((row: any) => ({
       id: row.id,
@@ -212,6 +232,7 @@ export function getSubscriptionsByAddress(address: string): Subscription[] {
       channel: row.channel,
       destination: row.destination,
       triggers: JSON.parse(row.triggers),
+      webhook_secret: row.webhook_secret ?? undefined,
       created_at: row.created_at,
     })) as Subscription[];
 }
@@ -231,6 +252,7 @@ export function getSubscriptionById(id: number): Subscription | undefined {
     channel: row.channel,
     destination: row.destination,
     triggers: JSON.parse(row.triggers),
+    webhook_secret: row.webhook_secret ?? undefined,
     created_at: row.created_at,
   } as Subscription;
 }
@@ -244,14 +266,146 @@ export function deleteSubscriptionById(id: number): boolean {
 
 export function deleteSubscriptionByAddressAndDestination(
   address: string,
-  destination: string
+  destination: string,
 ): boolean {
   const result = getDb()
     .prepare(
-      "DELETE FROM subscriptions WHERE stellar_address = ? AND destination = ?"
+      "DELETE FROM subscriptions WHERE stellar_address = ? AND destination = ?",
     )
     .run(address, destination);
   return result.changes > 0;
+}
+
+export function updateSubscription(
+  id: number,
+  updates: Partial<Pick<Subscription, "webhook_secret">>,
+): boolean {
+  const fields: string[] = [];
+  const params: any[] = [];
+
+  if (updates.webhook_secret !== undefined) {
+    fields.push("webhook_secret = ?");
+    params.push(updates.webhook_secret);
+  }
+
+  if (fields.length === 0) {
+    return false;
+  }
+
+  params.push(id);
+  const result = getDb()
+    .prepare(`UPDATE subscriptions SET ${fields.join(", ")} WHERE id = ?`)
+    .run(...params);
+  return result.changes > 0;
+}
+
+export function createWebhookDeliveryLog(log: {
+  subscription_id: number;
+  event_id: string | null;
+  trigger: NotificationTrigger;
+  invoice_id: number;
+  recipient_address: string;
+  status: "pending" | "success" | "failed";
+  attempts: number;
+  response_status: number | null;
+  error: string | null;
+}): WebhookDeliveryLog {
+  const now = Date.now();
+  const result = getDb()
+    .prepare(
+      `INSERT INTO webhook_delivery_logs
+         (subscription_id, event_id, trigger, invoice_id, recipient_address,
+          status, attempts, response_status, error, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      log.subscription_id,
+      log.event_id,
+      log.trigger,
+      log.invoice_id,
+      log.recipient_address,
+      log.status,
+      log.attempts,
+      log.response_status,
+      log.error,
+      now,
+      now,
+    );
+
+  return {
+    id: Number(result.lastInsertRowid),
+    ...log,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+export function updateWebhookDeliveryLog(
+  id: number,
+  updates: Partial<
+    Pick<
+      WebhookDeliveryLog,
+      "status" | "attempts" | "response_status" | "error"
+    >
+  >,
+): void {
+  const fields: string[] = [];
+  const params: any[] = [];
+
+  if (updates.status !== undefined) {
+    fields.push("status = ?");
+    params.push(updates.status);
+  }
+  if (updates.attempts !== undefined) {
+    fields.push("attempts = ?");
+    params.push(updates.attempts);
+  }
+  if (updates.response_status !== undefined) {
+    fields.push("response_status = ?");
+    params.push(updates.response_status);
+  }
+  if (updates.error !== undefined) {
+    fields.push("error = ?");
+    params.push(updates.error);
+  }
+
+  if (fields.length === 0) {
+    return;
+  }
+
+  fields.push("updated_at = ?");
+  params.push(Date.now());
+  params.push(id);
+
+  getDb()
+    .prepare(
+      `UPDATE webhook_delivery_logs SET ${fields.join(", ")} WHERE id = ?`,
+    )
+    .run(...params);
+}
+
+export function getWebhookDeliveryLogs(
+  subscriptionId: number,
+): WebhookDeliveryLog[] {
+  return getDb()
+    .prepare(
+      "SELECT * FROM webhook_delivery_logs WHERE subscription_id = ? ORDER BY created_at DESC",
+    )
+    .all(subscriptionId)
+    .map((row: any) => ({
+      id: row.id,
+      subscription_id: row.subscription_id,
+      event_id: row.event_id,
+      trigger: row.trigger,
+      invoice_id: row.invoice_id,
+      recipient_address: row.recipient_address,
+      status: row.status,
+      attempts: row.attempts,
+      response_status: row.response_status,
+      error: row.error,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    })) as WebhookDeliveryLog[];
 }
 
 export function hasSentNotification(
@@ -259,7 +413,7 @@ export function hasSentNotification(
   trigger: NotificationTrigger,
   recipientAddress: string,
   channel: SubscriptionChannel,
-  destination: string
+  destination: string,
 ): boolean {
   return (
     getDb()
@@ -269,9 +423,10 @@ export function hasSentNotification(
            AND trigger = ?
            AND recipient_address = ?
            AND channel = ?
-           AND destination = ?`
+           AND destination = ?`,
       )
-      .get(invoiceId, trigger, recipientAddress, channel, destination) !== undefined
+      .get(invoiceId, trigger, recipientAddress, channel, destination) !==
+    undefined
   );
 }
 
@@ -281,13 +436,13 @@ export function logSentNotification(
   recipientAddress: string,
   channel: SubscriptionChannel,
   destination: string,
-  eventId?: string
+  eventId?: string,
 ): void {
   getDb()
     .prepare(
       `INSERT OR IGNORE INTO sent_notifications
          (invoice_id, trigger, recipient_address, channel, destination, event_id, sent_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       invoiceId,
@@ -296,6 +451,6 @@ export function logSentNotification(
       channel,
       destination,
       eventId ?? null,
-      Date.now()
+      Date.now(),
     );
 }

--- a/notifications/src/delivery.ts
+++ b/notifications/src/delivery.ts
@@ -1,5 +1,7 @@
+import { createHmac } from "crypto";
 import { Resend } from "resend";
 import { CONFIG } from "./config";
+import { createWebhookDeliveryLog, updateWebhookDeliveryLog } from "./db";
 import type { NotificationPayload, Subscription } from "./types";
 
 const resend = new Resend(CONFIG.resendApiKey);
@@ -10,7 +12,7 @@ function delay(ms: number): Promise<void> {
 
 export async function sendEmail(
   subscription: Subscription,
-  payload: NotificationPayload
+  payload: NotificationPayload,
 ): Promise<void> {
   await resend.emails.send({
     from: CONFIG.resendFromEmail,
@@ -23,47 +25,113 @@ export async function sendEmail(
   });
 }
 
+function getWebhookSignature(secret: string, body: string): string {
+  return createHmac("sha256", secret).update(body).digest("hex");
+}
+
 export async function sendWebhook(
   subscription: Subscription,
   payload: NotificationPayload,
-  attempt = 1
+  attempt = 1,
+  logId?: number,
 ): Promise<void> {
+  const body = JSON.stringify({
+    trigger: payload.trigger,
+    actor: payload.actor,
+    invoice: payload.invoice,
+    subject: payload.subject,
+    message: payload.message,
+    eventId: payload.eventId ?? null,
+    eventType: payload.eventType ?? null,
+  });
+
+  const id =
+    logId ??
+    createWebhookDeliveryLog({
+      subscription_id: subscription.id,
+      event_id: payload.eventId ?? null,
+      trigger: payload.trigger,
+      invoice_id: payload.invoice.id,
+      recipient_address: payload.recipientAddress,
+      status: "pending",
+      attempts: 0,
+      response_status: null,
+      error: null,
+    }).id;
+
   let response;
+  let errorMessage: string | null = null;
+
   try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-ILN-Trigger": payload.trigger,
+      "X-ILN-Recipient": payload.recipientAddress,
+    };
+
+    if (subscription.webhook_secret) {
+      headers["X-ILN-Signature"] = `sha256=${getWebhookSignature(
+        subscription.webhook_secret,
+        body,
+      )}`;
+    }
+
+    if (payload.eventId) {
+      headers["X-ILN-Event-Id"] = payload.eventId;
+    }
+
     response = await fetch(subscription.destination, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        trigger: payload.trigger,
-        actor: payload.actor,
-        invoice: payload.invoice,
-        subject: payload.subject,
-        message: payload.message,
-      }),
+      headers,
+      body,
+    });
+
+    await updateWebhookDeliveryLog(id, {
+      attempts: attempt,
+      response_status: response.status,
     });
 
     if (response.ok) {
+      await updateWebhookDeliveryLog(id, {
+        status: "success",
+      });
       return;
     }
-  } catch (error) {
-    // Network errors will be caught here and retried
-    console.error(`[delivery] Webhook fetch error on attempt ${attempt}:`, error);
+
+    errorMessage = `HTTP ${response.status}`;
+  } catch (error: any) {
+    errorMessage = error?.message ?? "Network Error";
+    console.error(
+      `[delivery] Webhook fetch error on attempt ${attempt}:`,
+      error,
+    );
   }
 
   if (attempt >= CONFIG.maxWebhookRetry) {
-    throw new Error(`Webhook failed after ${attempt} attempts: ${response?.status || 'Network Error'}`);
+    await updateWebhookDeliveryLog(id, {
+      status: "failed",
+      attempts: attempt,
+      error: errorMessage,
+    });
+    throw new Error(
+      `Webhook failed after ${attempt} attempts: ${response?.status || errorMessage}`,
+    );
   }
+
+  await updateWebhookDeliveryLog(id, {
+    attempts: attempt,
+    response_status: response?.status ?? null,
+    error: errorMessage,
+  });
 
   const backoff = CONFIG.webhookBackoffBaseMs * 2 ** (attempt - 1);
   await delay(backoff);
-  await sendWebhook(subscription, payload, attempt + 1);
+  await sendWebhook(subscription, payload, attempt + 1, id);
 }
 
 export async function deliverNotification(
   subscription: Subscription,
-  payload: NotificationPayload
+  payload: NotificationPayload,
 ): Promise<void> {
   if (subscription.channel === "email") {
     await sendEmail(subscription, payload);

--- a/notifications/src/processor.ts
+++ b/notifications/src/processor.ts
@@ -1,9 +1,23 @@
 import type { rpc } from "@stellar/stellar-sdk";
 import { scValToNative } from "@stellar/stellar-sdk";
-import { hasEvent, insertEvent, upsertInvoice, getInvoiceById, queryInvoicesByStatus, getSubscriptionsByAddress, hasSentNotification, logSentNotification } from "./db";
+import {
+  hasEvent,
+  insertEvent,
+  upsertInvoice,
+  getInvoiceById,
+  queryInvoicesByStatus,
+  getSubscriptionsByAddress,
+  hasSentNotification,
+  logSentNotification,
+} from "./db";
 import { fetchInvoice } from "./rpc";
 import { deliverNotification } from "./delivery";
-import type { Invoice, ILNEventType, NotificationTrigger, Subscription } from "./types";
+import type {
+  Invoice,
+  ILNEventType,
+  NotificationTrigger,
+  Subscription,
+} from "./types";
 import { CONFIG } from "./config";
 
 const KNOWN_EVENT_TYPES = new Set<ILNEventType>([
@@ -20,7 +34,9 @@ const EVENT_TO_TRIGGER: Record<ILNEventType, NotificationTrigger | null> = {
   defaulted: "invoice_defaulted",
 };
 
-export async function processEvent(event: rpc.Api.EventResponse): Promise<void> {
+export async function processEvent(
+  event: rpc.Api.EventResponse,
+): Promise<void> {
   if (hasEvent(event.id)) {
     return;
   }
@@ -88,7 +104,10 @@ async function notifyOverdue(): Promise<void> {
   }
 }
 
-function getNotificationTargets(trigger: NotificationTrigger, invoice: Invoice): Array<{ recipient: string; actor: "freelancer" | "lp" | "payer" }> {
+function getNotificationTargets(
+  trigger: NotificationTrigger,
+  invoice: Invoice,
+): Array<{ recipient: string; actor: "freelancer" | "lp" | "payer" }> {
   switch (trigger) {
     case "invoice_funded":
       return [
@@ -96,9 +115,10 @@ function getNotificationTargets(trigger: NotificationTrigger, invoice: Invoice):
         { recipient: invoice.payer, actor: "payer" },
       ];
     case "invoice_paid": {
-      const targets: Array<{ recipient: string; actor: "freelancer" | "lp" | "payer" }> = [
-        { recipient: invoice.freelancer, actor: "freelancer" },
-      ];
+      const targets: Array<{
+        recipient: string;
+        actor: "freelancer" | "lp" | "payer";
+      }> = [{ recipient: invoice.freelancer, actor: "freelancer" }];
       if (invoice.funder) {
         targets.push({ recipient: invoice.funder, actor: "lp" });
       }
@@ -125,7 +145,7 @@ function formatPayload(
   trigger: NotificationTrigger,
   invoice: Invoice,
   recipient: string,
-  actor: "freelancer" | "lp" | "payer"
+  actor: "freelancer" | "lp" | "payer",
 ): { subject: string; message: string } {
   switch (trigger) {
     case "invoice_funded":
@@ -159,7 +179,7 @@ function formatPayload(
       return {
         subject: `Invoice #${invoice.id} due in ${CONFIG.dueWarningHours} hours`,
         message: `Invoice #${invoice.id} is approaching its due date at ${new Date(
-          invoice.due_date * 1000
+          invoice.due_date * 1000,
         ).toISOString()}.`,
       };
     case "invoice_overdue":
@@ -175,16 +195,31 @@ function formatPayload(
   }
 }
 
+const TRIGGER_TO_EVENT_TYPE: Record<NotificationTrigger, ILNEventType | null> =
+  {
+    invoice_funded: "funded",
+    invoice_paid: "paid",
+    invoice_defaulted: "defaulted",
+    invoice_due_soon: null,
+    invoice_overdue: null,
+  };
+
+function triggerToEventType(
+  trigger: NotificationTrigger,
+): ILNEventType | undefined {
+  return TRIGGER_TO_EVENT_TYPE[trigger] ?? undefined;
+}
+
 async function dispatchNotifications(
   trigger: NotificationTrigger,
   invoice: Invoice,
-  eventId?: string
+  eventId?: string,
 ): Promise<void> {
   const targets = getNotificationTargets(trigger, invoice);
   for (const target of targets) {
     const subscriptions = getSubscriptionsByAddress(target.recipient);
     const matchingSubscriptions = subscriptions.filter((subscription) =>
-      subscription.triggers.includes(trigger)
+      subscription.triggers.includes(trigger),
     );
 
     for (const subscription of matchingSubscriptions) {
@@ -193,7 +228,7 @@ async function dispatchNotifications(
         trigger,
         target.recipient,
         subscription.channel,
-        subscription.destination
+        subscription.destination,
       );
       if (alreadySent) {
         continue;
@@ -204,6 +239,8 @@ async function dispatchNotifications(
         invoice,
         recipientAddress: target.recipient,
         actor: target.actor,
+        eventId,
+        eventType: eventId ? triggerToEventType(trigger) : undefined,
         ...formatPayload(trigger, invoice, target.recipient, target.actor),
       };
 
@@ -215,12 +252,12 @@ async function dispatchNotifications(
           target.recipient,
           subscription.channel,
           subscription.destination,
-          eventId
+          eventId,
         );
       } catch (error) {
         console.error(
           `[processor] Failed to deliver notification for invoice ${invoice.id} to ${subscription.destination}:`,
-          error
+          error,
         );
       }
     }

--- a/notifications/src/types.ts
+++ b/notifications/src/types.ts
@@ -31,6 +31,22 @@ export interface Subscription {
   destination: string;
   triggers: NotificationTrigger[];
   created_at: number;
+  webhook_secret?: string;
+}
+
+export interface WebhookDeliveryLog {
+  id: number;
+  subscription_id: number;
+  event_id: string | null;
+  trigger: NotificationTrigger;
+  invoice_id: number;
+  recipient_address: string;
+  status: "pending" | "success" | "failed";
+  attempts: number;
+  response_status: number | null;
+  error: string | null;
+  created_at: number;
+  updated_at: number;
 }
 
 export interface NotificationPayload {
@@ -40,5 +56,6 @@ export interface NotificationPayload {
   subject: string;
   message: string;
   actor: "freelancer" | "lp" | "payer";
+  eventId?: string;
   eventType?: ILNEventType;
 }


### PR DESCRIPTION
Closes #470

…igning

## Summary
<!-- Brief description of what this PR does -->

## Related Issue
Closes #

## Complexity
<!-- Check one -->
- [ ] Trivial (typo, docs, small refactor)
- [ ] Medium (new feature, non-breaking change)
- [ ] High (breaking change, core protocol logic)

## Changes Made
<!-- Bulleted list of key changes -->
- 
- 

## Test Coverage
<!-- Paste relevant test output showing coverage -->
```
cargo test
```

<details>
<summary>Test output</summary>

```
<!-- paste here -->
```
</details>

## Security Considerations
<!-- Any security implications? Contract upgrade impact? Access control changes? -->

## Checklist
- [ ] Tests pass locally (`cargo test`)
- [ ] New functionality has test coverage
- [ ] `cargo fmt` applied
- [ ] `cargo clippy` warnings resolved
- [ ] Public functions have doc comments
- [ ] Breaking changes documented in PR description
- [ ] Issue linked (Closes #)

## PR Documentation

### Summary
This PR adds webhook registration and delivery support to the notifications service with robust retry handling and HMAC signing.

### What changed
- Added `POST /subscribe` webhook registration with:
  - `stellar_address`
  - `channel`
  - `destination`
  - `triggers`
  - optional `webhook_secret` (auto-generated if omitted)
- Added webhook delivery log persistence in SQLite:
  - `webhook_delivery_logs` table
  - status tracking: `pending`, `success`, `failed`
  - attempt counts
  - response status and error details
- Implemented webhook delivery retries:
  - up to 3 attempts
  - exponential backoff
  - accurate retry/error logging
- Added HMAC-SHA256 signing for webhook payloads:
  - `X-ILN-Signature`
  - `X-ILN-Trigger`
  - `X-ILN-Recipient`
  - `X-ILN-Event-Id`
- Added safe subscription listing that hides `webhook_secret`
- Added `GET /subscriptions/:id/logs` to inspect webhook delivery history

### Files changed
- api.ts
- db.ts
- delivery.ts
- processor.ts
- types.ts

### Testing
- Verified with `npm exec vitest run`
- Result: `4 passed, 20 passed (20)`
