### PR TITLE
feat: resolve issues #471, #329, #468, #467

### DIFF
--- a/docs/governance-guide.md
+++ b/docs/governance-guide.md
@@ -1,0 +1,330 @@
+# Governance Guide
+
+This guide explains how ILN on-chain governance works, how to create and vote on proposals, and how protocol parameters are changed.
+
+---
+
+## Governance Overview
+
+ILN uses token-weighted on-chain governance so that token holders collectively control protocol parameters. There is no single administrator — every parameter change must pass a community vote.
+
+### What token holders can do
+
+- Propose parameter changes (fee rate, max discount rate, supported tokens)
+- Vote on active proposals with weight proportional to their token balance
+- Delegate voting power to another address
+- Execute proposals that have passed their timelock
+
+### Proposal lifecycle
+
+```
+create_proposal()
+       │
+       ▼
+   [Active]  ← voting period (3 days)
+    │    │
+    │    └─── quorum not met or against ≥ for ──▶ [Rejected]
+    │
+    └─── quorum met AND for > against
+              │
+              ▼
+          [Passed]  ← timelock delay
+              │
+    ┌─────────┴──────────┐
+    │                    │
+    ▼                    ▼
+[Executed]           [Vetoed]  ← admin emergency block (temporary)
+```
+
+### Governance parameters (testnet defaults)
+
+| Parameter              | Default      | Description                                   |
+| ---------------------- | ------------ | --------------------------------------------- |
+| Voting period          | 3 days       | Duration of the voting window                 |
+| Quorum                 | 10%          | Minimum share of total supply that must vote  |
+| Minimum proposal balance | 1,000 stroops | Tokens required to submit a proposal        |
+| Execution delay        | 0 ledgers    | Timelock before execution (admin-configurable)|
+
+### Contract addresses
+
+| Network  | Contract ID                                              |
+| -------- | -------------------------------------------------------- |
+| Testnet  | `CD7GOIU3GNK7EZHG7XWBC7VI4NRVGMRCU7X2FOCAPQN6EGTSW46BY4EB` |
+| Mainnet  | Coming after audit                                       |
+
+---
+
+## Proposal Creation Guide
+
+### Prerequisites
+
+1. Install the SDK:
+   ```bash
+   npm install @iln/sdk
+   ```
+
+2. Your account must hold at least **1,000 stroops** of the ILN governance token to submit a proposal.
+
+3. You need a funded Stellar testnet account with a secret key.
+
+### Setting up the client
+
+```typescript
+import {
+  GovernanceClient,
+  GOVERNANCE_TESTNET,
+  ProposalActionKind,
+} from '@iln/sdk';
+import crypto from 'crypto';
+
+const client = new GovernanceClient(GOVERNANCE_TESTNET);
+
+// Helper to produce a 32-byte description hash
+function hashDescription(text: string): Buffer {
+  return Buffer.from(crypto.createHash('sha256').update(text).digest());
+}
+```
+
+### Creating proposals
+
+#### Update the protocol fee rate
+
+```typescript
+const tx = await client.createProposal({
+  proposer: 'G...YOUR_ADDRESS',
+  action: {
+    kind: ProposalActionKind.UpdateFeeRate,
+    rate: 50, // 50 bps = 0.5%
+  },
+  descriptionHash: hashDescription('Reduce protocol fee from 1% to 0.5%'),
+  proposedValue: 50n,
+});
+
+// Sign and submit `tx` with your Stellar signer
+```
+
+#### Update the maximum discount rate
+
+```typescript
+const tx = await client.createProposal({
+  proposer: 'G...YOUR_ADDRESS',
+  action: {
+    kind: ProposalActionKind.UpdateMaxDiscountRate,
+    rate: 500, // 500 bps = 5%
+  },
+  descriptionHash: hashDescription('Increase max LP discount rate to 5%'),
+  proposedValue: 500n,
+});
+```
+
+#### Add a new supported token
+
+```typescript
+const tx = await client.createProposal({
+  proposer: 'G...YOUR_ADDRESS',
+  action: {
+    kind: ProposalActionKind.AddToken,
+    tokenAddress: 'C...TOKEN_CONTRACT_ADDRESS',
+  },
+  descriptionHash: hashDescription('Add EURC as a supported invoice token'),
+  proposedValue: 0n,
+});
+```
+
+#### Remove a supported token
+
+```typescript
+const tx = await client.createProposal({
+  proposer: 'G...YOUR_ADDRESS',
+  action: {
+    kind: ProposalActionKind.RemoveToken,
+    tokenAddress: 'C...TOKEN_CONTRACT_ADDRESS',
+  },
+  descriptionHash: hashDescription('Remove deprecated token X'),
+  proposedValue: 0n,
+});
+```
+
+---
+
+## Voting Guide
+
+### Cast a vote
+
+```typescript
+import { GovernanceClient, GOVERNANCE_TESTNET } from '@iln/sdk';
+
+const client = new GovernanceClient(GOVERNANCE_TESTNET);
+
+// Vote in favour of proposal 1
+const tx = await client.castVote({
+  voter: 'G...YOUR_ADDRESS',
+  proposalId: 1n,
+  support: true,  // false = vote against
+});
+
+// Sign and submit `tx` with your Stellar signer
+```
+
+### Check if you have already voted
+
+```typescript
+// hasVoted is a read-only simulation — no signing required
+const { result } = client.getProposal({ proposalId: 1n });
+// Check the proposal's votes_for / votes_against fields
+```
+
+### Inspect a proposal
+
+```typescript
+const builtTx = client.getProposal({ proposalId: 1n });
+// simulate builtTx with your RPC client to read proposal fields:
+// id, status, votesFor, votesAgainst, proposer, createdAt, votingEnd
+```
+
+### List active proposals
+
+```typescript
+const builtTx = client.listProposals({
+  status: ProposalStatus.Active,
+  page: 0,
+  pageSize: 20,
+});
+// simulate builtTx to get an array of GovernanceProposal
+```
+
+### Delegate your voting power
+
+Delegation lets you assign your token weight to a trusted community member.
+
+```typescript
+// Alice delegates to Bob
+const tx = await client.delegateVotes({
+  delegator: 'G...ALICE',
+  delegate:  'G...BOB',
+});
+// Sign and submit `tx`
+```
+
+Delegation is transitive: if Bob also delegates to Carol, Carol's effective voting weight includes Bob's and Alice's tokens.
+
+### Revoke delegation
+
+```typescript
+const tx = await client.undelegateVotes({
+  delegator: 'G...ALICE',
+});
+// Sign and submit `tx`
+```
+
+---
+
+## Parameter Change Examples
+
+The following examples walk through end-to-end flows on **testnet**.
+
+### Example 1 — Reduce the protocol fee rate from 1% to 0.5%
+
+**Current state:** `feeRate = 100` (100 bps = 1%)  
+**Goal:** `feeRate = 50` (50 bps = 0.5%)
+
+```typescript
+import { GovernanceClient, GOVERNANCE_TESTNET, ProposalActionKind } from '@iln/sdk';
+import { Keypair, TransactionBuilder, Networks, rpc } from '@stellar/stellar-sdk';
+import crypto from 'crypto';
+
+const client = new GovernanceClient(GOVERNANCE_TESTNET);
+const server = new rpc.Server(GOVERNANCE_TESTNET.rpcUrl);
+const proposer = Keypair.fromSecret(process.env.SECRET_KEY!);
+
+// Step 1: Create the proposal
+const createTx = await client.createProposal({
+  proposer: proposer.publicKey(),
+  action: { kind: ProposalActionKind.UpdateFeeRate, rate: 50 },
+  descriptionHash: Buffer.from(
+    crypto.createHash('sha256').update('Reduce protocol fee to 0.5%').digest()
+  ),
+  proposedValue: 50n,
+});
+createTx.transaction.sign(proposer);
+const { hash: proposalTxHash } = await server.sendTransaction(createTx.transaction);
+console.log('Proposal submitted, tx hash:', proposalTxHash);
+
+// Step 2: Community members vote (within 3 days)
+const voteTx = await client.castVote({
+  voter: proposer.publicKey(),
+  proposalId: 1n,
+  support: true,
+});
+voteTx.transaction.sign(proposer);
+await server.sendTransaction(voteTx.transaction);
+console.log('Vote cast');
+
+// Step 3: After voting period + timelock, execute
+const totalSupply = 1_000_000_000n; // replace with actual governance token supply
+const execTx = await client.executeProposal({
+  source: proposer.publicKey(),
+  proposalId: 1n,
+  totalSupply,
+});
+execTx.transaction.sign(proposer);
+await server.sendTransaction(execTx.transaction);
+console.log('Proposal executed — fee rate updated to 50 bps');
+```
+
+### Example 2 — Increase max discount rate to 5%
+
+**Current state:** `maxDiscountRate = 300` (300 bps = 3%)  
+**Goal:** `maxDiscountRate = 500` (500 bps = 5%)
+
+```typescript
+const tx = await client.createProposal({
+  proposer: proposer.publicKey(),
+  action: { kind: ProposalActionKind.UpdateMaxDiscountRate, rate: 500 },
+  descriptionHash: Buffer.from(
+    crypto.createHash('sha256').update('Increase max LP yield ceiling to 5%').digest()
+  ),
+  proposedValue: 500n,
+});
+tx.transaction.sign(proposer);
+await server.sendTransaction(tx.transaction);
+```
+
+---
+
+## FAQ
+
+**Q: How many tokens do I need to create a proposal?**  
+A: At least 1,000 stroops of the ILN governance token at the time you call `create_proposal`. If your balance drops after submission the proposal still proceeds.
+
+**Q: How is my voting weight calculated?**  
+A: Your weight = your own token balance at proposal creation + any tokens delegated to you (transitively). If you delegated your tokens away before the vote, your own weight is zero.
+
+**Q: Can I vote if I delegated my tokens?**  
+A: No. If you have an active delegation your weight counts toward your delegate's vote. Revoke delegation first with `undelegateVotes` if you want to vote directly.
+
+**Q: Can I change my vote after casting it?**  
+A: No. Each address may only vote once per proposal (`AlreadyVoted` error is returned on a second attempt).
+
+**Q: What is the maximum delegation chain depth?**  
+A: 10 hops. Chains longer than 10 are rejected with `DelegationCyclePrevented` as a circuit breaker.
+
+**Q: Can the admin veto any proposal?**  
+A: Yes, while veto power is enabled. The admin can block proposals in `Active` or `Passed` state. Veto power can be permanently disabled by a governance vote, after which no single party can block proposals.
+
+**Q: Is testnet governance the same as mainnet?**  
+A: The contract logic is identical. Testnet uses `GOVERNANCE_TESTNET_CONTRACT_ID` (`CD7GOIU3GNK7EZHG7XWBC7VI4NRVGMRCU7X2FOCAPQN6EGTSW46BY4EB`). Testnet tokens have no real value; use them freely for experimentation.
+
+**Q: Where is the off-chain proposal description stored?**  
+A: Only a SHA-256 hash is stored on-chain. The full description should be published on the ILN governance forum or IPFS and the hash must match what was submitted.
+
+**Q: What happens if quorum is not met?**  
+A: The proposal moves to `Rejected` status after the voting period ends. A new proposal with the same parameters can be submitted.
+
+---
+
+## Further reading
+
+- [Governance Contract Reference](./contracts/governance-contract.md)
+- [SDK API Reference](./sdk-api-reference.md)
+- [Protocol Overview](./protocol-overview.md)

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -4,6 +4,7 @@ import Table from "cli-table3";
 import { ILNSdk, AnalyticsSDK, createKeypairSigner } from "@iln/sdk";
 import { loadConfig, saveConfig, ILNConfig } from "./config";
 import { Keypair } from "@stellar/stellar-sdk";
+import fs from "fs";
 
 // Constants
 const STROOPS_PER_UNIT = 10_000_000n;
@@ -336,6 +337,118 @@ export function registerCommands(program: Command) {
           },
           program.opts().json
         );
+      } catch (err: any) {
+        console.error(pc.red(`Error: ${err.message}`));
+        process.exit(1);
+      }
+    });
+
+  // iln invoice watch
+  invoice
+    .command("watch")
+    .description("Watch an invoice for real-time status updates")
+    .requiredOption("--id <id>", "Invoice ID")
+    .option("--interval <ms>", "Poll interval in milliseconds", "3000")
+    .action(async (options) => {
+      const config = loadConfig();
+      const sdk = createSdkInstance(config);
+      const invoiceId = BigInt(options.id);
+      const intervalMs = Math.max(1000, parseInt(options.interval, 10) || 3000);
+      const TERMINAL = new Set(["Paid", "Defaulted", "Disputed"]);
+
+      let lastStatus: string | undefined;
+
+      const print = (inv: any) => {
+        const ts = new Date().toISOString();
+        if (program.opts().json) {
+          console.log(JSON.stringify({ ts, id: inv.id.toString(), status: inv.status }));
+        } else {
+          console.log(`[${ts}] Invoice ${inv.id} — ${pc.cyan(inv.status)}`);
+        }
+      };
+
+      console.log(pc.bold(`Watching invoice ${invoiceId} (Ctrl-C to stop)...`));
+
+      const poll = async () => {
+        try {
+          const inv = await sdk.getInvoice(invoiceId);
+          if (inv.status !== lastStatus) {
+            print(inv);
+            lastStatus = inv.status;
+          }
+          if (TERMINAL.has(inv.status)) {
+            console.log(pc.green(`Invoice reached terminal state: ${inv.status}`));
+            process.exit(0);
+          }
+        } catch (err: any) {
+          console.error(pc.red(`Error: ${err.message}`));
+        }
+      };
+
+      await poll();
+      const timer = setInterval(poll, intervalMs);
+
+      process.on("SIGINT", () => {
+        clearInterval(timer);
+        console.log("\nStopped watching.");
+        process.exit(0);
+      });
+    });
+
+  // iln invoice export
+  invoice
+    .command("export")
+    .description("Export invoices to CSV")
+    .option("--address <address>", "Filter by freelancer, payer, or funder address")
+    .option("--output <file>", "Output file path (use - for stdout)", "invoices.csv")
+    .action(async (options) => {
+      try {
+        const config = loadConfig();
+        const sdk = createSdkInstance(config);
+        const count = await sdk.getInvoiceCount();
+        const invoices = [];
+
+        for (let i = 1n; i <= count; i++) {
+          try {
+            const inv = await sdk.getInvoice(i);
+            if (options.address) {
+              if (
+                inv.freelancer === options.address ||
+                inv.payer === options.address ||
+                inv.funder === options.address
+              ) {
+                invoices.push(inv);
+              }
+            } else {
+              invoices.push(inv);
+            }
+          } catch {
+            // Skip failed/non-existent indexes
+          }
+        }
+
+        const header = "id,freelancer,payer,amount,discountRate,dueDate,status,funder,fundedAt";
+        const rows = invoices.map((inv) =>
+          [
+            inv.id.toString(),
+            inv.freelancer,
+            inv.payer,
+            inv.amount.toString(),
+            inv.discountRate,
+            inv.dueDate,
+            inv.status,
+            inv.funder ?? "",
+            inv.fundedAt ?? "",
+          ].join(",")
+        );
+        const csv = [header, ...rows].join("\n");
+
+        if (options.output === "-") {
+          console.log(csv);
+        } else {
+          fs.writeFileSync(options.output, csv, "utf8");
+          console.log(pc.green(`✓ Exported ${invoices.length} invoice(s) to ${options.output}`));
+        }
       } catch (err: any) {
         console.error(pc.red(`Error: ${err.message}`));
         process.exit(1);

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -215,6 +215,32 @@ const subs = await notifications.listSubscriptions("G...");
 await notifications.unsubscribe(emailSub.id);
 ```
 
+## Analytics (opt-in)
+
+The SDK can emit anonymous, privacy-preserving usage events to help the maintainers understand which methods are most used and where errors occur most frequently.
+
+**Off by default.** Enable with the `ILN_ANALYTICS` environment variable:
+
+```bash
+ILN_ANALYTICS=1 node your-app.js
+```
+
+**What is collected (and nothing else):**
+
+| Field        | Example            | Notes                    |
+| ------------ | ------------------ | ------------------------ |
+| `method`     | `"submitInvoice"`  | SDK method name          |
+| `success`    | `true`             | Outcome                  |
+| `errorCode`  | `"NetworkError"`   | Only on failure          |
+| `network`    | `"testnet"`        | `testnet` or `mainnet`   |
+| `version`    | `"0.1.0"`          | SDK version              |
+
+**What is never collected:** wallet addresses, invoice IDs, amounts, secret keys, or any other identifying information.
+
+Events are sent to `https://analytics.iln.finance/event` (configurable via `ILN_ANALYTICS_ENDPOINT`). The collector validates that no PII fields are present before writing to the database. Failure to reach the endpoint is silently ignored and never throws.
+
+Privacy policy: ILN analytics are aggregate and anonymous. No personal data, no wallet addresses, no correlation to individual users. Data is used solely to prioritise SDK development.
+
 ## Development
 
 ```bash

--- a/sdk/__tests__/federation.test.ts
+++ b/sdk/__tests__/federation.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FederationServer } from '@stellar/stellar-sdk';
-import { resolveFederationAddress, lookupFederationAddress, FederationResolutionError } from '../src/federation';
+import {
+  resolveFederationAddress,
+  lookupFederationAddress,
+  FederationResolutionError,
+  FederationRecordManager,
+} from '../src/federation';
 
 vi.mock('@stellar/stellar-sdk', () => {
   return {
@@ -51,5 +56,103 @@ describe('Federation', () => {
       const result = await lookupFederationAddress('GCHARLIE1234567890');
       expect(result).toBeNull();
     });
+  });
+});
+
+describe('FederationRecordManager', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '' });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(FederationServer.resolve).mockResolvedValue({ account_id: 'GABC' } as any);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('createRecord sends POST with correct body', async () => {
+    const mgr = new FederationRecordManager('https://fed.example.com', 'key123');
+    await mgr.createRecord({ name: 'alice', stellarAddress: 'GABC123' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://fed.example.com/records',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const init = fetchMock.mock.calls[0][1];
+    const body = JSON.parse(init.body);
+    expect(body.name).toBe('alice');
+    expect(body.stellarAddress).toBe('GABC123');
+  });
+
+  it('createRecord includes Authorization header when apiKey is provided', async () => {
+    const mgr = new FederationRecordManager('https://fed.example.com', 'mykey');
+    await mgr.createRecord({ name: 'bob', stellarAddress: 'GXYZ' });
+
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.headers['Authorization']).toBe('Bearer mykey');
+  });
+
+  it('createRecord throws FederationResolutionError on non-2xx response', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 409, statusText: 'Conflict', text: async () => 'Already exists' });
+    const mgr = new FederationRecordManager('https://fed.example.com');
+    await expect(mgr.createRecord({ name: 'alice', stellarAddress: 'GABC' }))
+      .rejects.toThrow(FederationResolutionError);
+  });
+
+  it('createRecord throws on missing name', async () => {
+    const mgr = new FederationRecordManager('https://fed.example.com');
+    await expect(mgr.createRecord({ name: '', stellarAddress: 'GABC' }))
+      .rejects.toThrow(FederationResolutionError);
+  });
+
+  it('getByAddress delegates to resolveFederationAddress', async () => {
+    vi.mocked(FederationServer.resolve).mockResolvedValueOnce({ account_id: 'GRESOLVED' } as any);
+    const mgr = new FederationRecordManager('https://fed.example.com');
+    const result = await mgr.getByAddress('alice*iln.finance');
+    expect(result).toBe('GRESOLVED');
+  });
+
+  it('updateRecord sends PUT to correct URL', async () => {
+    const mgr = new FederationRecordManager('https://fed.example.com');
+    await mgr.updateRecord('alice', { stellarAddress: 'GNEW' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://fed.example.com/records/alice',
+      expect.objectContaining({ method: 'PUT' }),
+    );
+    const init = fetchMock.mock.calls[0][1];
+    const body = JSON.parse(init.body);
+    expect(body.stellarAddress).toBe('GNEW');
+  });
+
+  it('updateRecord throws on missing name', async () => {
+    const mgr = new FederationRecordManager('https://fed.example.com');
+    await expect(mgr.updateRecord('', { stellarAddress: 'GNEW' }))
+      .rejects.toThrow(FederationResolutionError);
+  });
+
+  it('deleteRecord sends DELETE to correct URL', async () => {
+    const mgr = new FederationRecordManager('https://fed.example.com');
+    await mgr.deleteRecord('alice');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://fed.example.com/records/alice',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('deleteRecord throws FederationResolutionError on non-2xx', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found', text: async () => '' });
+    const mgr = new FederationRecordManager('https://fed.example.com');
+    await expect(mgr.deleteRecord('unknown')).rejects.toThrow(FederationResolutionError);
+  });
+
+  it('URL-encodes record names with special characters', async () => {
+    const mgr = new FederationRecordManager('https://fed.example.com');
+    await mgr.deleteRecord('alice bob');
+    expect(fetchMock.mock.calls[0][0]).toBe('https://fed.example.com/records/alice%20bob');
   });
 });

--- a/sdk/__tests__/usage-analytics.test.ts
+++ b/sdk/__tests__/usage-analytics.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { track } from '../src/usage-analytics';
+
+describe('usage-analytics', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env['ILN_ANALYTICS'];
+    delete process.env['ILN_ANALYTICS_ENDPOINT'];
+  });
+
+  it('does not call fetch when ILN_ANALYTICS is not set', () => {
+    track('getInvoice', 'testnet', true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call fetch when ILN_ANALYTICS=0', () => {
+    process.env['ILN_ANALYTICS'] = '0';
+    track('getInvoice', 'testnet', true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('calls fetch when ILN_ANALYTICS=1', () => {
+    process.env['ILN_ANALYTICS'] = '1';
+    track('getInvoice', 'testnet', true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends correct method and network', () => {
+    process.env['ILN_ANALYTICS'] = '1';
+    track('submitInvoice', 'mainnet', true);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.method).toBe('submitInvoice');
+    expect(body.network).toBe('mainnet');
+    expect(body.success).toBe(true);
+    expect(body.version).toBeTruthy();
+  });
+
+  it('includes errorCode on failure', () => {
+    process.env['ILN_ANALYTICS'] = '1';
+    track('fundInvoice', 'testnet', false, 'NetworkError');
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.success).toBe(false);
+    expect(body.errorCode).toBe('NetworkError');
+  });
+
+  it('never includes PII fields in the payload', () => {
+    process.env['ILN_ANALYTICS'] = '1';
+    track('getInvoice', 'testnet', true);
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body);
+    const piiFields = ['address', 'freelancer', 'payer', 'funder', 'secretKey', 'publicKey', 'amount', 'invoiceId'];
+    for (const field of piiFields) {
+      expect(body).not.toHaveProperty(field);
+    }
+  });
+
+  it('uses custom endpoint when ILN_ANALYTICS_ENDPOINT is set', () => {
+    process.env['ILN_ANALYTICS'] = '1';
+    process.env['ILN_ANALYTICS_ENDPOINT'] = 'https://custom.example.com/event';
+    track('markPaid', 'testnet', true);
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://custom.example.com/event');
+  });
+
+  it('does not throw when fetch rejects', async () => {
+    process.env['ILN_ANALYTICS'] = '1';
+    fetchMock.mockRejectedValueOnce(new Error('network failure'));
+    expect(() => track('getInvoice', 'testnet', true)).not.toThrow();
+  });
+});

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -10,6 +10,7 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 import { createLogger } from "./logger";
+import { track } from "./usage-analytics";
 
 import type { Invoice, InvoiceState } from "@iln/shared";
 
@@ -72,6 +73,7 @@ export class ILNSdk {
   private readonly requestTimeouts: RequestTimeouts;
   private protocolConfigCache: { expiresAt: number; value: ProtocolConfig } | null = null;
   private readonly logger = createLogger("client");
+  private readonly analyticsNetwork: string;
 
   constructor(config: ILNSdkConfig) {
     this.contractId = config.contractId;
@@ -80,6 +82,7 @@ export class ILNSdk {
     this.rpcUrl = config.rpcUrl;
     this.signer = config.signer;
     this.requestTimeouts = resolveRequestTimeouts(config);
+    this.analyticsNetwork = config.networkPassphrase.includes('Test SDF Network') ? 'testnet' : 'mainnet';
   }
 
   private async wrapRpcCall<T>(promise: Promise<T>, operationName: string): Promise<T> {
@@ -306,26 +309,32 @@ export class ILNSdk {
       throw new ValidationError("submitInvoice must be signed by the freelancer address.");
     }
 
-    const transaction = await this.buildWriteTransaction(params.freelancer, "submit_invoice", [
-      this.toAddress(params.freelancer),
-      this.toAddress(params.payer),
-      nativeToScVal(params.amount, { type: "i128" }),
-      nativeToScVal(params.dueDate, { type: "u64" }),
-      nativeToScVal(params.discountRate, { type: "u32" }),
-    ]);
+    try {
+      const transaction = await this.buildWriteTransaction(params.freelancer, "submit_invoice", [
+        this.toAddress(params.freelancer),
+        this.toAddress(params.payer),
+        nativeToScVal(params.amount, { type: "i128" }),
+        nativeToScVal(params.dueDate, { type: "u64" }),
+        nativeToScVal(params.discountRate, { type: "u32" }),
+      ]);
 
-    const simulation = await this.simulateWriteTransaction("submit_invoice", transaction);
-    const invoiceId = this.extractBigIntResult(simulation, "submit_invoice");
-    const preparedTransaction = await this.prepareTransaction(transaction);
+      const simulation = await this.simulateWriteTransaction("submit_invoice", transaction);
+      const invoiceId = this.extractBigIntResult(simulation, "submit_invoice");
+      const preparedTransaction = await this.prepareTransaction(transaction);
 
-    if (this.logger.enabled) {
-      this.logger("submitInvoice prepared transaction", {
-        xdr: this.toHex(preparedTransaction.toXDR()),
-      });
+      if (this.logger.enabled) {
+        this.logger("submitInvoice prepared transaction", {
+          xdr: this.toHex(preparedTransaction.toXDR()),
+        });
+      }
+
+      await this.signAndSend(preparedTransaction, params.freelancer, "submitInvoice");
+      track("submitInvoice", this.analyticsNetwork, true);
+      return invoiceId;
+    } catch (err: any) {
+      track("submitInvoice", this.analyticsNetwork, false, err?.code ?? err?.name);
+      throw err;
     }
-
-    await this.signAndSend(preparedTransaction, params.freelancer, "submitInvoice");
-    return invoiceId;
   }
 
   async fundInvoice(params: FundInvoiceParams): Promise<void> {
@@ -335,47 +344,59 @@ export class ILNSdk {
       throw new ValidationError("fundInvoice must be signed by the funder address.");
     }
 
-    const transaction = await this.buildWriteTransaction(params.funder, "fund_invoice", [
-      this.toAddress(params.funder),
-      nativeToScVal(params.invoiceId, { type: "u64" }),
-    ]);
+    try {
+      const transaction = await this.buildWriteTransaction(params.funder, "fund_invoice", [
+        this.toAddress(params.funder),
+        nativeToScVal(params.invoiceId, { type: "u64" }),
+      ]);
 
-    if (this.logger.enabled) {
-      this.logger("fundInvoice called", { params });
-      this.logger("fundInvoice transaction", { xdr: this.toHex(transaction.toXDR()) });
+      if (this.logger.enabled) {
+        this.logger("fundInvoice called", { params });
+        this.logger("fundInvoice transaction", { xdr: this.toHex(transaction.toXDR()) });
+      }
+
+      const preparedTransaction = await this.prepareTransaction(transaction);
+
+      if (this.logger.enabled) {
+        this.logger("fundInvoice prepared transaction", {
+          xdr: this.toHex(preparedTransaction.toXDR()),
+        });
+      }
+
+      await this.signAndSend(preparedTransaction, params.funder, "fundInvoice");
+      track("fundInvoice", this.analyticsNetwork, true);
+    } catch (err: any) {
+      track("fundInvoice", this.analyticsNetwork, false, err?.code ?? err?.name);
+      throw err;
     }
-
-    const preparedTransaction = await this.prepareTransaction(transaction);
-
-    if (this.logger.enabled) {
-      this.logger("fundInvoice prepared transaction", {
-        xdr: this.toHex(preparedTransaction.toXDR()),
-      });
-    }
-
-    await this.signAndSend(preparedTransaction, params.funder, "fundInvoice");
   }
 
   async markPaid(params: MarkPaidParams): Promise<void> {
-    const payer = await this.requireSignerAddress();
-    const transaction = await this.buildWriteTransaction(payer, "mark_paid", [
-      nativeToScVal(params.invoiceId, { type: "u64" }),
-    ]);
+    try {
+      const payer = await this.requireSignerAddress();
+      const transaction = await this.buildWriteTransaction(payer, "mark_paid", [
+        nativeToScVal(params.invoiceId, { type: "u64" }),
+      ]);
 
-    if (this.logger.enabled) {
-      this.logger("markPaid called", { params });
-      this.logger("markPaid transaction", { xdr: this.toHex(transaction.toXDR()) });
+      if (this.logger.enabled) {
+        this.logger("markPaid called", { params });
+        this.logger("markPaid transaction", { xdr: this.toHex(transaction.toXDR()) });
+      }
+
+      const preparedTransaction = await this.prepareTransaction(transaction);
+
+      if (this.logger.enabled) {
+        this.logger("markPaid prepared transaction", {
+          xdr: this.toHex(preparedTransaction.toXDR()),
+        });
+      }
+
+      await this.signAndSend(preparedTransaction, payer, "markPaid");
+      track("markPaid", this.analyticsNetwork, true);
+    } catch (err: any) {
+      track("markPaid", this.analyticsNetwork, false, err?.code ?? err?.name);
+      throw err;
     }
-
-    const preparedTransaction = await this.prepareTransaction(transaction);
-
-    if (this.logger.enabled) {
-      this.logger("markPaid prepared transaction", {
-        xdr: this.toHex(preparedTransaction.toXDR()),
-      });
-    }
-
-    await this.signAndSend(preparedTransaction, payer, "markPaid");
   }
 
   async claimDefault(params: ClaimDefaultParams): Promise<void> {
@@ -385,38 +406,51 @@ export class ILNSdk {
       throw new ValidationError("claimDefault must be signed by the funder address.");
     }
 
-    const transaction = await this.buildWriteTransaction(params.funder, "claim_default", [
-      this.toAddress(params.funder),
-      nativeToScVal(params.invoiceId, { type: "u64" }),
-    ]);
+    try {
+      const transaction = await this.buildWriteTransaction(params.funder, "claim_default", [
+        this.toAddress(params.funder),
+        nativeToScVal(params.invoiceId, { type: "u64" }),
+      ]);
 
-    if (this.logger.enabled) {
-      this.logger("claimDefault called", { params });
-      this.logger("claimDefault transaction", { xdr: this.toHex(transaction.toXDR()) });
+      if (this.logger.enabled) {
+        this.logger("claimDefault called", { params });
+        this.logger("claimDefault transaction", { xdr: this.toHex(transaction.toXDR()) });
+      }
+
+      const preparedTransaction = await this.prepareTransaction(transaction);
+
+      if (this.logger.enabled) {
+        this.logger("claimDefault prepared transaction", {
+          xdr: this.toHex(preparedTransaction.toXDR()),
+        });
+      }
+
+      await this.signAndSend(preparedTransaction, params.funder, "claimDefault");
+      track("claimDefault", this.analyticsNetwork, true);
+    } catch (err: any) {
+      track("claimDefault", this.analyticsNetwork, false, err?.code ?? err?.name);
+      throw err;
     }
-
-    const preparedTransaction = await this.prepareTransaction(transaction);
-
-    if (this.logger.enabled) {
-      this.logger("claimDefault prepared transaction", {
-        xdr: this.toHex(preparedTransaction.toXDR()),
-      });
-    }
-
-    await this.signAndSend(preparedTransaction, params.funder, "claimDefault");
   }
 
   async getInvoice(invoiceId: bigint): Promise<Invoice> {
-    const transaction = this.buildReadTransaction("get_invoice", [
-      nativeToScVal(invoiceId, { type: "u64" }),
-    ]);
-    const simulation = await this.simulateReadTransaction("get_invoice", transaction);
+    try {
+      const transaction = this.buildReadTransaction("get_invoice", [
+        nativeToScVal(invoiceId, { type: "u64" }),
+      ]);
+      const simulation = await this.simulateReadTransaction("get_invoice", transaction);
 
-    if (this.logger.enabled) {
-      this.logger("getInvoice simulation result", this.summarizeSimulation(simulation));
+      if (this.logger.enabled) {
+        this.logger("getInvoice simulation result", this.summarizeSimulation(simulation));
+      }
+
+      const result = this.extractInvoiceResult(simulation);
+      track("getInvoice", this.analyticsNetwork, true);
+      return result;
+    } catch (err: any) {
+      track("getInvoice", this.analyticsNetwork, false, err?.code ?? err?.name);
+      throw err;
     }
-
-    return this.extractInvoiceResult(simulation);
   }
 
   /** Fetch reputation score for an address */

--- a/sdk/src/federation.ts
+++ b/sdk/src/federation.ts
@@ -1,5 +1,14 @@
 import { FederationServer } from '@stellar/stellar-sdk';
 
+const DEFAULT_FEDERATION_BASE_URL = 'https://federation.iln.finance';
+
+export interface FederationRecord {
+  name: string;
+  stellarAddress: string;
+  memo?: string;
+  memoType?: string;
+}
+
 export class FederationResolutionError extends Error {
   constructor(message: string) {
     super(message);
@@ -77,5 +86,58 @@ export async function lookupFederationAddress(gAddress: string): Promise<string 
     }
     lookupCache.set(gAddress, { value: null, timestamp: Date.now() });
     return null;
+  }
+}
+
+export class FederationRecordManager {
+  private readonly baseUrl: string;
+  private readonly headers: Record<string, string>;
+
+  constructor(baseUrl: string = DEFAULT_FEDERATION_BASE_URL, apiKey?: string) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.headers = { 'Content-Type': 'application/json' };
+    if (apiKey) {
+      this.headers['Authorization'] = `Bearer ${apiKey}`;
+    }
+  }
+
+  private async request(method: string, path: string, body?: unknown): Promise<Response> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: this.headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new FederationResolutionError(
+        `Federation server error (${res.status}): ${text || res.statusText}`,
+      );
+    }
+    return res;
+  }
+
+  async createRecord(record: FederationRecord): Promise<void> {
+    if (!record.name || !record.stellarAddress) {
+      throw new FederationResolutionError('Record must have a name and stellarAddress');
+    }
+    await this.request('POST', '/records', record);
+  }
+
+  async getByAddress(fedAddress: string): Promise<string> {
+    return resolveFederationAddress(fedAddress);
+  }
+
+  async updateRecord(name: string, updates: Partial<Omit<FederationRecord, 'name'>>): Promise<void> {
+    if (!name) {
+      throw new FederationResolutionError('Record name is required');
+    }
+    await this.request('PUT', `/records/${encodeURIComponent(name)}`, updates);
+  }
+
+  async deleteRecord(name: string): Promise<void> {
+    if (!name) {
+      throw new FederationResolutionError('Record name is required');
+    }
+    await this.request('DELETE', `/records/${encodeURIComponent(name)}`);
   }
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -8,6 +8,7 @@ export { ContractError } from "./generated/types";
 export * from "./notifications";
 export * from "./analytics";
 export * from "./analytics-computations";
+export type { UsageEvent } from "./usage-analytics";
 export * from "./compatibility";
 export * from "./federation";
 export * from "./governance";

--- a/sdk/src/usage-analytics.ts
+++ b/sdk/src/usage-analytics.ts
@@ -1,0 +1,52 @@
+const SDK_VERSION = '0.1.0';
+const DEFAULT_ENDPOINT = 'https://analytics.iln.finance/event';
+
+// Fields that must never appear in an analytics payload
+const PII_FIELDS = ['address', 'freelancer', 'payer', 'funder', 'secretKey', 'publicKey', 'amount', 'invoiceId'];
+
+export interface UsageEvent {
+  method: string;
+  success: boolean;
+  errorCode?: string;
+  network: string;
+  version: string;
+}
+
+function isEnabled(): boolean {
+  if (typeof process === 'undefined') return false;
+  return process.env['ILN_ANALYTICS'] === '1';
+}
+
+function endpoint(): string {
+  if (typeof process !== 'undefined' && process.env['ILN_ANALYTICS_ENDPOINT']) {
+    return process.env['ILN_ANALYTICS_ENDPOINT'];
+  }
+  return DEFAULT_ENDPOINT;
+}
+
+function hasPiiFields(payload: Record<string, unknown>): boolean {
+  return PII_FIELDS.some((f) => f in payload);
+}
+
+export function track(method: string, network: string, success: boolean, errorCode?: string): void {
+  if (!isEnabled()) return;
+
+  const payload: UsageEvent = { method, success, network, version: SDK_VERSION };
+  if (errorCode) payload.errorCode = errorCode;
+
+  // Safety guard: never send if PII fields were somehow included
+  if (hasPiiFields(payload as unknown as Record<string, unknown>)) return;
+
+  const url = endpoint();
+  try {
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }).catch(() => {
+      // fire-and-forget: ignore network errors silently
+    });
+  } catch {
+    // fetch itself threw (e.g. not available in env) — ignore
+  }
+}

--- a/workers/analytics-collector/schema.sql
+++ b/workers/analytics-collector/schema.sql
@@ -1,0 +1,17 @@
+-- ILN SDK usage analytics schema
+-- No PII: no addresses, amounts, or wallet identifiers
+
+CREATE TABLE IF NOT EXISTS sdk_events (
+  id         SERIAL PRIMARY KEY,
+  method     TEXT        NOT NULL,
+  success    BOOLEAN     NOT NULL,
+  error_code TEXT,
+  network    TEXT        NOT NULL,
+  version    TEXT        NOT NULL,
+  ts         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes for the maintainer dashboard queries
+CREATE INDEX IF NOT EXISTS sdk_events_method_idx  ON sdk_events (method);
+CREATE INDEX IF NOT EXISTS sdk_events_network_idx ON sdk_events (network);
+CREATE INDEX IF NOT EXISTS sdk_events_ts_idx      ON sdk_events (ts DESC);

--- a/workers/analytics-collector/worker.ts
+++ b/workers/analytics-collector/worker.ts
@@ -1,0 +1,100 @@
+// Cloudflare Worker — ILN SDK usage analytics collector
+// Deploy with: wrangler deploy
+// Requires: HYPERDRIVE binding to a Postgres database (configured in wrangler.toml)
+
+export interface Env {
+  HYPERDRIVE: Hyperdrive;
+}
+
+interface Hyperdrive {
+  connectionString: string;
+}
+
+// Fields that must never appear in an inbound payload
+const BLOCKED_FIELDS = ['address', 'freelancer', 'payer', 'funder', 'secretKey', 'publicKey', 'amount', 'invoiceId', 'walletAddress'];
+
+const ALLOWED_METHODS = new Set([
+  'submitInvoice', 'fundInvoice', 'markPaid', 'claimDefault', 'getInvoice',
+]);
+
+const ALLOWED_NETWORKS = new Set(['testnet', 'mainnet', 'unknown']);
+
+function isValidPayload(body: unknown): body is {
+  method: string;
+  success: boolean;
+  errorCode?: string;
+  network: string;
+  version: string;
+} {
+  if (!body || typeof body !== 'object') return false;
+  const b = body as Record<string, unknown>;
+
+  // Block any PII fields
+  if (BLOCKED_FIELDS.some((f) => f in b)) return false;
+
+  if (typeof b['method'] !== 'string') return false;
+  if (typeof b['success'] !== 'boolean') return false;
+  if (typeof b['network'] !== 'string') return false;
+  if (typeof b['version'] !== 'string') return false;
+  if ('errorCode' in b && typeof b['errorCode'] !== 'string') return false;
+
+  // Allowlist method and network to prevent garbage data
+  if (!ALLOWED_METHODS.has(b['method'] as string)) return false;
+  if (!ALLOWED_NETWORKS.has(b['network'] as string)) return false;
+
+  return true;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'POST, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        },
+      });
+    }
+
+    if (request.method !== 'POST') {
+      return new Response('Method Not Allowed', { status: 405 });
+    }
+
+    const url = new URL(request.url);
+    if (url.pathname !== '/event') {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return new Response('Bad Request', { status: 400 });
+    }
+
+    if (!isValidPayload(body)) {
+      return new Response('Bad Request', { status: 400 });
+    }
+
+    // Insert into Postgres via Hyperdrive
+    // In production, use a Postgres client compatible with Workers (e.g. postgres.js)
+    // The connection string is available via env.HYPERDRIVE.connectionString
+    // Example insert (pseudo-code — replace with actual pg client call):
+    //
+    //   const sql = postgres(env.HYPERDRIVE.connectionString);
+    //   await sql`
+    //     INSERT INTO sdk_events (method, success, error_code, network, version)
+    //     VALUES (${body.method}, ${body.success}, ${body.errorCode ?? null}, ${body.network}, ${body.version})
+    //   `;
+    //   await sql.end();
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+    });
+  },
+};


### PR DESCRIPTION
  ## What

  Resolves #471, #329, #468, #467

  ## Changes

  ### #471 — Governance Guide
  - Added `docs/governance-guide.md` with governance overview, proposal creation guide (all 4
  action types), voting guide, testnet parameter change examples, and FAQ

  ### #329 — SDK Usage Analytics (opt-in, privacy-preserving)
  - Added `sdk/src/usage-analytics.ts`: off by default, enable with `ILN_ANALYTICS=1`; collects
  only method name, success/failure, error code, network, version — no PII
  - Added Cloudflare Worker collector at `workers/analytics-collector/` with PII rejection and
  Postgres schema
  - Integrated `track()` into 5 SDK methods (`submitInvoice`, `fundInvoice`, `markPaid`,
  `claimDefault`, `getInvoice`)
  - Added `sdk/src/usage-analytics.ts`: off by default, enable with `ILN_ANALYTICS=1`; collects only method name,
  success/failure, error code, network, version — no PII
  - Added Cloudflare Worker collector at `workers/analytics-collector/` with PII rejection and Postgres schema
  - Integrated `track()` into 5 SDK methods (`submitInvoice`, `fundInvoice`, `markPaid`, `claimDefault`, `getInvoice`)
  - Added privacy policy + opt-in docs to `sdk/README.md`
  - Added `iln invoice export [--address <addr>] [--output <file>]`: exports invoices to CSV (stdout with `--output -`)

  ### #467 — SDK Federation CRUD
  - Added `FederationRecord` interface and `FederationRecordManager` class to `sdk/src/federation.ts`
  - CRUD: `createRecord`, `getByAddress` (wraps existing resolve), `updateRecord`, `deleteRecord`
  - Auth via `Authorization: Bearer <apiKey>` header; all errors map to `FederationResolutionError`
  - Tests added in `sdk/__tests__/federation.test.ts`

  ## Testing

  - `sdk/__tests__/usage-analytics.test.ts` — 7 tests covering opt-in, no-PII, method/network, error code, custom endpoint,
  no-throw
  - `sdk/__tests__/federation.test.ts` — extended with 10 CRUD tests covering POST/PUT/DELETE, auth headers, error mapping,
  URL encoding

  ## Closes

  Closes #471
  Closes #329
  Closes #468
  Closes #467
