### PR TITLE
Add SDK Integration Testing Framework

### DIFF
--- a/tests/sdk-integration/README.md
+++ b/tests/sdk-integration/README.md
@@ -1,0 +1,28 @@
+# SDK Integration Testing Helpers
+
+Utilities to help write SDK integration tests against real or mocked environments.
+
+Usage examples:
+
+- Use `MockWallet` to emulate a connected wallet and sign operations.
+- Use `withMockFetch` to stub network responses during integration tests.
+- Use `buildInvoice` to create realistic invoice payloads.
+- Use `expectValidInvoice` for helpful assertions.
+
+Example:
+
+```ts
+import { MockWallet, withMockFetch, buildInvoice, expectValidInvoice } from './src';
+
+const wallet = new MockWallet();
+await wallet.connect();
+
+const stop = withMockFetch(async (input) => {
+  return { body: { ok: true }, status: 200 };
+});
+
+const inv = buildInvoice();
+expectValidInvoice(inv);
+
+stop();
+```

--- a/tests/sdk-integration/package.json
+++ b/tests/sdk-integration/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@iln/sdk-integration-tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0",
+    "typescript": "^5.2.2"
+  }
+}

--- a/tests/sdk-integration/src/assertions.ts
+++ b/tests/sdk-integration/src/assertions.ts
@@ -1,0 +1,17 @@
+import { expect } from 'vitest';
+import type { Invoice } from './dataGenerators';
+
+export function expectValidInvoice(inv: Invoice) {
+  expect(inv).toBeTruthy();
+  expect(typeof inv.id).toBe('string');
+  expect(inv.amount).toBeGreaterThan(0);
+  expect(typeof inv.currency).toBe('string');
+  expect(new Date(inv.dueDate).toString()).not.toBe('Invalid Date');
+  expect(inv.supplier?.id).toBeTruthy();
+  expect(inv.buyer?.id).toBeTruthy();
+}
+
+export function expectNetworkCalledWith(urlPart: string, calls: Array<{ url: string }>) {
+  const found = calls.some(c => c.url.includes(urlPart));
+  expect(found).toBeTruthy();
+}

--- a/tests/sdk-integration/src/dataGenerators.ts
+++ b/tests/sdk-integration/src/dataGenerators.ts
@@ -1,0 +1,29 @@
+import { randomUUID } from 'crypto';
+
+export function buildInvoice(overrides: Partial<Invoice> = {}): Invoice {
+  const id = overrides.id ?? `inv_${randomUUID()}`;
+  const amount = overrides.amount ?? Math.floor(Math.random() * 100000) + 100;
+  const dueDate = overrides.dueDate ?? new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString();
+
+  return {
+    id,
+    amount,
+    currency: overrides.currency ?? 'USD',
+    dueDate,
+    supplier: overrides.supplier ?? { id: `supp_${randomUUID()}`, name: 'Supplier Inc' },
+    buyer: overrides.buyer ?? { id: `buyer_${randomUUID()}`, name: 'Buyer LLC' },
+    metadata: overrides.metadata ?? {},
+  };
+}
+
+export type Party = { id: string; name: string };
+
+export type Invoice = {
+  id: string;
+  amount: number;
+  currency: string;
+  dueDate: string;
+  supplier: Party;
+  buyer: Party;
+  metadata?: Record<string, unknown>;
+};

--- a/tests/sdk-integration/src/index.ts
+++ b/tests/sdk-integration/src/index.ts
@@ -1,0 +1,4 @@
+export * from './mockWallet';
+export * from './mockNetwork';
+export * from './dataGenerators';
+export * from './assertions';

--- a/tests/sdk-integration/src/mockNetwork.ts
+++ b/tests/sdk-integration/src/mockNetwork.ts
@@ -1,0 +1,24 @@
+type ResponseLike = {
+  status?: number;
+  headers?: Record<string, string>;
+  body?: unknown;
+};
+
+export function withMockFetch(
+  handler: (input: RequestInfo, init?: RequestInit) => Promise<ResponseLike> | ResponseLike
+) {
+  const originalFetch = (globalThis as any).fetch;
+
+  (globalThis as any).fetch = async (input: RequestInfo, init?: RequestInit) => {
+    const res = await handler(input, init);
+    const body = res.body === undefined ? null : res.body;
+    const headers = res.headers ?? { 'content-type': 'application/json' };
+    const responseInit: ResponseInit = { status: res.status ?? 200, headers };
+    const text = typeof body === 'string' ? body : JSON.stringify(body);
+    return new Response(text, responseInit);
+  };
+
+  return () => {
+    (globalThis as any).fetch = originalFetch;
+  };
+}

--- a/tests/sdk-integration/src/mockWallet.ts
+++ b/tests/sdk-integration/src/mockWallet.ts
@@ -1,0 +1,40 @@
+import { EventEmitter } from 'events';
+
+export interface MockWalletOptions {
+  address?: string;
+}
+
+export class MockWallet extends EventEmitter {
+  address: string;
+
+  constructor(opts: MockWalletOptions = {}) {
+    super();
+    this.address = opts.address ?? 'GMOCKWALLETADDRESS000000000000000000000';
+  }
+
+  async connect() {
+    this.emit('connect', { address: this.address });
+    return { address: this.address };
+  }
+
+  async disconnect() {
+    this.emit('disconnect');
+  }
+
+  async signTransaction(tx: unknown) {
+    // Return a lightweight mock signature structure
+    return {
+      tx,
+      signature: 'MOCK_SIGNATURE',
+      signer: this.address,
+    };
+  }
+
+  async signMessage(message: string) {
+    return {
+      message,
+      signature: 'MOCK_MESSAGE_SIGNATURE',
+      signer: this.address,
+    };
+  }
+}

--- a/tests/sdk-integration/tsconfig.json
+++ b/tests/sdk-integration/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Add a new test utilities package at tests/sdk-integration to help write SDK integration tests. Provides a realistic mock wallet provider, a fetch stub for mock network responses, test data generators (invoice builder), and helpful assertions to validate test outputs. This package is intended to make writing consistent, realistic integration tests for the SDK easy and maintainable.

What’s included: realistic mocks, data generators, and assertion helpers intended for both mocked and real-environment integration tests.

Files added:

[package.json](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

[tsconfig.json](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

[README.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

[index.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

[mockWallet.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

[mockNetwork.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

[dataGenerators.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

[assertions.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

 Closes #520