### PR TITLE
feat: migration framework, notification preferences, SDK dashboard component, CLI template system

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -236,7 +236,7 @@ export async function runCli(
     .action(async () => {
       const config = load();
       const client = createClient(config);
-      
+
       ui.info("Checking contract compatibility...");
       const result = await checkCompatibility(async (method: string) => {
         if (method === "get_version") {
@@ -247,7 +247,7 @@ export async function runCli(
 
       ui.info(`SDK Version:      ${result.sdkVersion}`);
       ui.info(`Contract Version: ${result.contractVersion}`);
-      
+
       if (result.compatible) {
         ui.success("Compatibility check passed! The SDK is fully compatible with the deployed contract.");
       } else {
@@ -310,6 +310,58 @@ export async function runCli(
         });
       }
     });
+
+  // Generate command — template system for boilerplate code
+  const collectVars = (val: string, prev: string[]): string[] => [...prev, val];
+
+  program
+    .command("generate")
+    .description("Generate boilerplate code from a built-in or custom template.")
+    .argument("[template]", "template name (omit or use --list to see available templates)")
+    .option("--list", "list available templates and exit")
+    .option("--preview", "print generated output without writing to disk")
+    .option("--out <dir>", "output directory (default: current directory)", ".")
+    .option("--var <key=value>", "set a template variable, repeatable (e.g. --var contractId=C…)", collectVars, [] as string[])
+    .action(
+      async (
+        template: string | undefined,
+        options: { list?: boolean; preview?: boolean; out: string; var: string[] },
+      ) => {
+        const { generate, listTemplates } = await import("./generate");
+
+        if (options.list || !template) {
+          const templates = listTemplates();
+          ui.info("Available templates:\n");
+          for (const t of templates) {
+            ui.info(`  ${t.name.padEnd(24)} ${t.description}`);
+          }
+          if (!template && !options.list) {
+            ui.info('\nUsage: iln generate <template> [--var key=value] [--preview] [--out <dir>]');
+          }
+          return;
+        }
+
+        const vars: Record<string, string> = {};
+        for (const assignment of options.var) {
+          const eq = assignment.indexOf("=");
+          if (eq !== -1) vars[assignment.slice(0, eq)] = assignment.slice(eq + 1);
+        }
+
+        const result = generate({
+          template,
+          vars,
+          outDir: options.out,
+          preview: options.preview,
+        });
+
+        if (options.preview) {
+          ui.info(`--- Preview: ${result.outputFile} ---\n`);
+          stdout.write(result.content);
+        } else {
+          ui.success(`Generated ${result.outputFile}`);
+        }
+      },
+    );
 
   // Development commands
   const devCommand = program.command("dev").description("Development utilities");

--- a/cli/src/generate.ts
+++ b/cli/src/generate.ts
@@ -1,0 +1,223 @@
+/**
+ * Template system for `iln generate`.
+ *
+ * Built-in templates: invoice-client, webhook-handler, subscription-config
+ *
+ * Custom templates: drop a <name>.tpl file in ~/.iln/templates/ or
+ * ./.iln/templates/ and use {{VARIABLE}} placeholders for interpolation.
+ *
+ * Public API
+ * ──────────
+ *   listTemplates() → TemplateDefinition[]
+ *   generate(options) → GenerateResult
+ *   interpolate(template, vars) → string
+ */
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface TemplateVariable {
+  name: string;
+  description: string;
+  default?: string;
+}
+
+export interface TemplateDefinition {
+  name: string;
+  description: string;
+  outputFile: string;
+  variables: TemplateVariable[];
+  render(vars: Record<string, string>): string;
+}
+
+export interface GenerateOptions {
+  template: string;
+  vars?: Record<string, string>;
+  outDir?: string;
+  preview?: boolean;
+}
+
+export interface GenerateResult {
+  templateName: string;
+  outputFile: string;
+  content: string;
+  written: boolean;
+}
+
+// ── Interpolation ──────────────────────────────────────────────────────────
+
+/** Replace `{{VARIABLE}}` placeholders with values from vars. */
+export function interpolate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key: string) => vars[key] ?? `{{${key}}}`);
+}
+
+// ── Built-in templates ─────────────────────────────────────────────────────
+
+const BUILTIN: TemplateDefinition[] = [
+  {
+    name: "invoice-client",
+    description: "Bootstrapped ILN client for a new integration",
+    outputFile: "iln-client.ts",
+    variables: [
+      { name: "contractId", description: "Stellar contract ID", default: "CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" },
+      { name: "rpcUrl", description: "Stellar RPC URL", default: "https://soroban-testnet.stellar.org" },
+      { name: "networkPassphrase", description: "Network passphrase", default: "Test SDF Network ; September 2015" },
+    ],
+    render: (vars) =>
+      `import { ILNClient } from "@invoice-liquidity/sdk";
+import { createKeypairFileSigner } from "@invoice-liquidity/sdk/signers";
+
+const client = new ILNClient({
+  contractId: "${vars.contractId}",
+  rpcUrl: "${vars.rpcUrl}",
+  networkPassphrase: "${vars.networkPassphrase}",
+  signer: createKeypairFileSigner(process.env.ILN_KEYPAIR_PATH!),
+});
+
+export default client;
+`,
+  },
+  {
+    name: "webhook-handler",
+    description: "Express webhook endpoint with HMAC signature verification",
+    outputFile: "webhook-handler.ts",
+    variables: [
+      { name: "secret", description: "Webhook signing secret (from subscription)", default: "your-webhook-secret" },
+      { name: "port", description: "HTTP listener port", default: "3001" },
+    ],
+    render: (vars) =>
+      `import express from "express";
+import crypto from "crypto";
+
+const SECRET = process.env.ILN_WEBHOOK_SECRET ?? "${vars.secret}";
+const PORT = parseInt(process.env.PORT ?? "${vars.port}", 10);
+
+const app = express();
+app.use(express.json());
+
+function verifySignature(payload: string, signature: string): boolean {
+  const expected = crypto.createHmac("sha256", SECRET).update(payload).digest("hex");
+  try {
+    return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  } catch {
+    return false;
+  }
+}
+
+app.post("/webhook", (req, res) => {
+  const sig = req.headers["x-iln-signature"] as string | undefined;
+  if (!sig || !verifySignature(JSON.stringify(req.body), sig)) {
+    return res.status(401).json({ error: "Invalid signature" });
+  }
+
+  const event = req.body as { type: string; invoiceId: string; amount: string };
+  console.log(\`Event: \${event.type} — invoice #\${event.invoiceId}, amount: \${event.amount}\`);
+
+  switch (event.type) {
+    case "funded":   /* TODO: handle funded */   break;
+    case "paid":     /* TODO: handle paid */     break;
+    case "defaulted":/* TODO: handle defaulted */break;
+  }
+
+  res.status(200).json({ received: true });
+});
+
+app.listen(PORT, () => console.log(\`ILN webhook listener on :\${PORT}\`));
+`,
+  },
+  {
+    name: "subscription-config",
+    description: "Notification subscription payload for POST /subscribe",
+    outputFile: "subscription.json",
+    variables: [
+      { name: "stellarAddress", description: "Your Stellar public key (G…)", default: "GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" },
+      { name: "email", description: "Notification email", default: "you@example.com" },
+    ],
+    render: (vars) =>
+      JSON.stringify(
+        {
+          stellar_address: vars.stellarAddress,
+          channel: "email",
+          destination: vars.email,
+          triggers: ["invoice_funded", "invoice_paid", "invoice_defaulted", "invoice_due_soon"],
+        },
+        null,
+        2
+      ) + "\n",
+  },
+];
+
+// ── Custom template loading ────────────────────────────────────────────────
+
+function loadCustomTemplates(): TemplateDefinition[] {
+  const searchDirs = [
+    path.join(os.homedir(), ".iln", "templates"),
+    path.join(process.cwd(), ".iln", "templates"),
+  ];
+  const result: TemplateDefinition[] = [];
+
+  for (const dir of searchDirs) {
+    if (!fs.existsSync(dir)) continue;
+    for (const file of fs.readdirSync(dir).filter((f) => f.endsWith(".tpl"))) {
+      const name = file.replace(/\.tpl$/, "");
+      const raw = fs.readFileSync(path.join(dir, file), "utf8");
+      // Extract declared variables from {{NAME}} placeholders
+      const varNames = [...new Set([...raw.matchAll(/\{\{(\w+)\}\}/g)].map((m) => m[1]))];
+      result.push({
+        name,
+        description: `Custom template from ${dir}`,
+        outputFile: name,
+        variables: varNames.map((n) => ({ name: n, description: n })),
+        render: (vars) => interpolate(raw, vars),
+      });
+    }
+  }
+  return result;
+}
+
+function allTemplates(): TemplateDefinition[] {
+  return [...BUILTIN, ...loadCustomTemplates()];
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/** Return all available templates (built-in + custom). */
+export function listTemplates(): TemplateDefinition[] {
+  return allTemplates();
+}
+
+/**
+ * Generate a file from a template.
+ * With `preview: true` the content is returned but nothing is written to disk.
+ */
+export function generate(options: GenerateOptions): GenerateResult {
+  const templates = allTemplates();
+  const def = templates.find((t) => t.name === options.template);
+  if (!def) {
+    throw new Error(
+      `Unknown template "${options.template}". Run \`iln generate --list\` to see available templates.`
+    );
+  }
+
+  // Merge caller-supplied vars with per-variable defaults
+  const vars: Record<string, string> = {};
+  for (const v of def.variables) {
+    vars[v.name] = options.vars?.[v.name] ?? v.default ?? "";
+  }
+  // Allow extra vars the caller passes even if not declared in the template
+  Object.assign(vars, options.vars);
+
+  const content = def.render(vars);
+  const outputFile = path.join(options.outDir ?? ".", def.outputFile);
+  const written = !options.preview;
+
+  if (written) {
+    fs.mkdirSync(path.dirname(path.resolve(outputFile)), { recursive: true });
+    fs.writeFileSync(outputFile, content);
+  }
+
+  return { templateName: def.name, outputFile, content, written };
+}

--- a/notifications/src/preferences-api.ts
+++ b/notifications/src/preferences-api.ts
@@ -1,0 +1,156 @@
+/**
+ * Express router for notification preference endpoints.
+ *
+ * Mount on the main notification app:
+ *   app.use("/preferences", createPreferencesRouter());
+ *
+ * Routes
+ * ──────
+ *   GET    /preferences/:address   fetch current preferences (returns defaults if never set)
+ *   PUT    /preferences/:address   replace all preferences
+ *   PATCH  /preferences/:address   partial update
+ *   DELETE /preferences/:address   reset to defaults
+ */
+
+import { Router, type Request, type Response } from "express";
+import { preferencesService } from "./preferences";
+import type {
+  NotificationFrequency,
+  QuietHours,
+  TriggerPreference,
+} from "./preferences";
+import type { SubscriptionChannel, NotificationTrigger } from "./types";
+
+// ── Validation helpers ─────────────────────────────────────────────────────
+
+const VALID_CHANNELS: SubscriptionChannel[] = ["email", "sms", "webhook", "websocket"];
+const VALID_FREQUENCIES: NotificationFrequency[] = ["realtime", "daily", "weekly"];
+const VALID_TRIGGERS: NotificationTrigger[] = [
+  "invoice_funded",
+  "invoice_paid",
+  "invoice_defaulted",
+  "invoice_due_soon",
+  "invoice_overdue",
+];
+
+function isValidChannels(v: unknown): v is SubscriptionChannel[] {
+  return Array.isArray(v) && v.every((c) => VALID_CHANNELS.includes(c as SubscriptionChannel));
+}
+
+function isValidFrequency(v: unknown): v is NotificationFrequency {
+  return VALID_FREQUENCIES.includes(v as NotificationFrequency);
+}
+
+function isValidQuietHours(v: unknown): v is QuietHours | null {
+  if (v === null) return true;
+  if (typeof v !== "object" || v === null) return false;
+  const q = v as Record<string, unknown>;
+  return (
+    typeof q.startHour === "number" &&
+    q.startHour >= 0 &&
+    q.startHour <= 23 &&
+    typeof q.endHour === "number" &&
+    q.endHour >= 0 &&
+    q.endHour <= 23 &&
+    typeof q.timezone === "string" &&
+    q.timezone.length > 0
+  );
+}
+
+function isValidTriggerPreferences(v: unknown): v is TriggerPreference[] {
+  if (!Array.isArray(v)) return false;
+  return v.every((item) => {
+    if (typeof item !== "object" || item === null) return false;
+    const p = item as Record<string, unknown>;
+    return (
+      VALID_TRIGGERS.includes(p.trigger as NotificationTrigger) &&
+      typeof p.enabled === "boolean" &&
+      isValidChannels(p.channels)
+    );
+  });
+}
+
+function reject(res: Response, msg: string): Response {
+  return res.status(400).json({ error: msg });
+}
+
+// ── Router ─────────────────────────────────────────────────────────────────
+
+export function createPreferencesRouter(): Router {
+  const router = Router();
+
+  // GET /preferences/:address
+  router.get("/:address", (req: Request, res: Response) => {
+    const prefs = preferencesService.get(req.params.address);
+    res.json({ preferences: prefs });
+  });
+
+  // PUT /preferences/:address — full replacement
+  router.put("/:address", (req: Request, res: Response) => {
+    const body = req.body as Record<string, unknown>;
+    const {
+      enabledChannels,
+      frequency,
+      quietHours = null,
+      triggerPreferences = [],
+    } = body;
+
+    if (!isValidChannels(enabledChannels))
+      return reject(res, `enabledChannels must be an array of: ${VALID_CHANNELS.join(", ")}`);
+    if (!isValidFrequency(frequency))
+      return reject(res, `frequency must be one of: ${VALID_FREQUENCIES.join(", ")}`);
+    if (!isValidQuietHours(quietHours))
+      return reject(res, "quietHours must be null or { startHour, endHour, timezone }");
+    if (!isValidTriggerPreferences(triggerPreferences))
+      return reject(res, "triggerPreferences must be an array of { trigger, enabled, channels }");
+
+    const updated = preferencesService.upsert(req.params.address, {
+      enabledChannels,
+      frequency,
+      quietHours: quietHours as QuietHours | null,
+      triggerPreferences: triggerPreferences as TriggerPreference[],
+    });
+    res.json({ preferences: updated });
+  });
+
+  // PATCH /preferences/:address — partial update
+  router.patch("/:address", (req: Request, res: Response) => {
+    const body = req.body as Record<string, unknown>;
+    const patch: Parameters<typeof preferencesService.upsert>[1] = {};
+
+    if ("enabledChannels" in body) {
+      if (!isValidChannels(body.enabledChannels))
+        return reject(res, `enabledChannels must be an array of: ${VALID_CHANNELS.join(", ")}`);
+      patch.enabledChannels = body.enabledChannels as SubscriptionChannel[];
+    }
+
+    if ("frequency" in body) {
+      if (!isValidFrequency(body.frequency))
+        return reject(res, `frequency must be one of: ${VALID_FREQUENCIES.join(", ")}`);
+      patch.frequency = body.frequency as NotificationFrequency;
+    }
+
+    if ("quietHours" in body) {
+      if (!isValidQuietHours(body.quietHours))
+        return reject(res, "quietHours must be null or { startHour, endHour, timezone }");
+      patch.quietHours = body.quietHours as QuietHours | null;
+    }
+
+    if ("triggerPreferences" in body) {
+      if (!isValidTriggerPreferences(body.triggerPreferences))
+        return reject(res, "triggerPreferences must be an array of { trigger, enabled, channels }");
+      patch.triggerPreferences = body.triggerPreferences as TriggerPreference[];
+    }
+
+    const updated = preferencesService.upsert(req.params.address, patch);
+    res.json({ preferences: updated });
+  });
+
+  // DELETE /preferences/:address — reset to defaults
+  router.delete("/:address", (req: Request, res: Response) => {
+    preferencesService.delete(req.params.address);
+    res.status(204).end();
+  });
+
+  return router;
+}

--- a/notifications/src/preferences.ts
+++ b/notifications/src/preferences.ts
@@ -1,0 +1,123 @@
+/**
+ * User notification preferences.
+ *
+ * Covers:
+ *   - Channel preferences  (email / SMS / webhook per user)
+ *   - Frequency            (realtime / daily / weekly digest)
+ *   - Quiet hours          (suppress delivery during a time window)
+ *   - Per-trigger overrides (enable/disable individual event types)
+ */
+
+import type { NotificationTrigger, SubscriptionChannel } from "./types";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type NotificationFrequency = "realtime" | "daily" | "weekly";
+
+export interface QuietHours {
+  /** 0–23 — inclusive start of the quiet window */
+  startHour: number;
+  /** 0–23 — exclusive end of the quiet window */
+  endHour: number;
+  /** IANA time zone identifier, e.g. "America/New_York" */
+  timezone: string;
+}
+
+export interface TriggerPreference {
+  trigger: NotificationTrigger;
+  /** When false, this trigger is silenced regardless of channel settings */
+  enabled: boolean;
+  /** Which channels to use for this specific trigger */
+  channels: SubscriptionChannel[];
+}
+
+export interface UserPreferences {
+  stellarAddress: string;
+  /** Globally enabled delivery channels */
+  enabledChannels: SubscriptionChannel[];
+  /** Delivery frequency; "realtime" sends immediately */
+  frequency: NotificationFrequency;
+  /** Suppress notifications during this window; null means always deliver */
+  quietHours: QuietHours | null;
+  /** Per-trigger overrides; triggers absent here inherit the global defaults */
+  triggerPreferences: TriggerPreference[];
+  updatedAt: string;
+}
+
+// ── In-memory store ────────────────────────────────────────────────────────
+
+const store = new Map<string, UserPreferences>();
+
+function defaultPreferences(stellarAddress: string): UserPreferences {
+  return {
+    stellarAddress,
+    enabledChannels: ["email", "webhook"],
+    frequency: "realtime",
+    quietHours: null,
+    triggerPreferences: [],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ── Service ────────────────────────────────────────────────────────────────
+
+export class PreferencesService {
+  /** Return preferences for an address, falling back to defaults. */
+  get(stellarAddress: string): UserPreferences {
+    return store.get(stellarAddress) ?? defaultPreferences(stellarAddress);
+  }
+
+  /** Create or update preferences for an address. */
+  upsert(
+    stellarAddress: string,
+    patch: Partial<Omit<UserPreferences, "stellarAddress" | "updatedAt">>
+  ): UserPreferences {
+    const current = this.get(stellarAddress);
+    const updated: UserPreferences = {
+      ...current,
+      ...patch,
+      stellarAddress,
+      updatedAt: new Date().toISOString(),
+    };
+    store.set(stellarAddress, updated);
+    return updated;
+  }
+
+  /** Reset an address back to defaults. */
+  delete(stellarAddress: string): boolean {
+    return store.delete(stellarAddress);
+  }
+
+  /**
+   * Returns true if the current wall-clock time falls inside the user's
+   * quiet-hours window (so the notification should be held back).
+   */
+  isQuietHour(prefs: UserPreferences, nowMs = Date.now()): boolean {
+    if (!prefs.quietHours) return false;
+    const { startHour, endHour, timezone } = prefs.quietHours;
+    const hourStr = new Date(nowMs).toLocaleString("en-US", {
+      hour: "numeric",
+      hour12: false,
+      timeZone: timezone,
+    });
+    const h = parseInt(hourStr, 10);
+    // Handle windows that wrap midnight (e.g. 22–06)
+    if (startHour <= endHour) return h >= startHour && h < endHour;
+    return h >= startHour || h < endHour;
+  }
+
+  /**
+   * Returns the effective delivery channels for a given trigger,
+   * respecting any per-trigger override for the user.
+   */
+  channelsForTrigger(
+    prefs: UserPreferences,
+    trigger: NotificationTrigger
+  ): SubscriptionChannel[] {
+    const override = prefs.triggerPreferences.find((p) => p.trigger === trigger);
+    if (override) return override.enabled ? override.channels : [];
+    return prefs.enabledChannels;
+  }
+}
+
+export const preferencesService = new PreferencesService();

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * Migration framework for ILN contract upgrades.
+ *
+ * Migration files live in scripts/migrations/ and export:
+ *   - description: string
+ *   - up(ctx):   void | Promise<void>   — apply the migration
+ *   - down(ctx): void | Promise<void>   — roll it back
+ *
+ * Usage:
+ *   npx ts-node scripts/migrate.ts status
+ *   npx ts-node scripts/migrate.ts up [--dry-run] [--network=mainnet]
+ *   npx ts-node scripts/migrate.ts down [--dry-run] [--network=mainnet]
+ */
+
+import fs from "fs";
+import path from "path";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface MigrationContext {
+  network: "testnet" | "mainnet";
+  dryRun: boolean;
+  log(msg: string): void;
+}
+
+export interface Migration {
+  name: string;
+  description: string;
+  up(ctx: MigrationContext): void | Promise<void>;
+  down(ctx: MigrationContext): void | Promise<void>;
+}
+
+export interface MigrationRecord {
+  name: string;
+  appliedAt: string;
+}
+
+export interface MigrationStatus {
+  name: string;
+  description: string;
+  appliedAt: string | null;
+}
+
+// ── Status persistence ─────────────────────────────────────────────────────
+
+const STATUS_FILE = path.resolve("migration-status.json");
+const MIGRATIONS_DIR = path.resolve("scripts/migrations");
+
+function readApplied(): MigrationRecord[] {
+  if (!fs.existsSync(STATUS_FILE)) return [];
+  try {
+    return JSON.parse(fs.readFileSync(STATUS_FILE, "utf8")) as MigrationRecord[];
+  } catch {
+    return [];
+  }
+}
+
+function writeApplied(records: MigrationRecord[]): void {
+  fs.writeFileSync(STATUS_FILE, JSON.stringify(records, null, 2) + "\n");
+}
+
+function markApplied(name: string, records: MigrationRecord[]): MigrationRecord[] {
+  return [...records.filter((r) => r.name !== name), { name, appliedAt: new Date().toISOString() }];
+}
+
+function markUnapplied(name: string, records: MigrationRecord[]): MigrationRecord[] {
+  return records.filter((r) => r.name !== name);
+}
+
+// ── Loading ────────────────────────────────────────────────────────────────
+
+async function loadMigrations(): Promise<Migration[]> {
+  if (!fs.existsSync(MIGRATIONS_DIR)) return [];
+
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => /^\d{3}_.*\.(ts|js)$/.test(f))
+    .sort();
+
+  const migrations: Migration[] = [];
+  for (const file of files) {
+    const mod = (await import(path.join(MIGRATIONS_DIR, file))) as Partial<Migration>;
+    migrations.push({
+      name: file.replace(/\.(ts|js)$/, ""),
+      description: mod.description ?? file,
+      up: mod.up ?? (() => {}),
+      down: mod.down ?? (() => {}),
+    });
+  }
+  return migrations;
+}
+
+// ── Commands ───────────────────────────────────────────────────────────────
+
+function ts(): string {
+  return new Date().toISOString();
+}
+
+function logLine(msg: string): void {
+  console.log(`[${ts()}] ${msg}`);
+}
+
+/** Apply all pending migrations in order. */
+export async function runUp(options: { network: "testnet" | "mainnet"; dryRun: boolean }): Promise<void> {
+  const ctx: MigrationContext = { ...options, log: logLine };
+  const migrations = await loadMigrations();
+  let applied = readApplied();
+  const appliedNames = new Set(applied.map((r) => r.name));
+
+  const pending = migrations.filter((m) => !appliedNames.has(m.name));
+  if (pending.length === 0) {
+    logLine("No pending migrations.");
+    return;
+  }
+
+  for (const m of pending) {
+    logLine(`${options.dryRun ? "[DRY RUN] " : ""}Applying: ${m.name} — ${m.description}`);
+    if (!options.dryRun) {
+      await m.up(ctx);
+      applied = markApplied(m.name, applied);
+      writeApplied(applied);
+    }
+    logLine(`${options.dryRun ? "[DRY RUN] " : ""}Done: ${m.name}`);
+  }
+}
+
+/** Roll back the most recently applied migration. */
+export async function runDown(options: { network: "testnet" | "mainnet"; dryRun: boolean }): Promise<void> {
+  const ctx: MigrationContext = { ...options, log: logLine };
+  const migrations = await loadMigrations();
+  let applied = readApplied();
+
+  if (applied.length === 0) {
+    logLine("No migrations to roll back.");
+    return;
+  }
+
+  const last = applied[applied.length - 1];
+  const migration = migrations.find((m) => m.name === last.name);
+  if (!migration) {
+    throw new Error(`Migration file not found for recorded entry: ${last.name}`);
+  }
+
+  logLine(`${options.dryRun ? "[DRY RUN] " : ""}Rolling back: ${migration.name} — ${migration.description}`);
+  if (!options.dryRun) {
+    await migration.down(ctx);
+    applied = markUnapplied(migration.name, applied);
+    writeApplied(applied);
+  }
+  logLine(`${options.dryRun ? "[DRY RUN] " : ""}Rolled back: ${migration.name}`);
+}
+
+/** Print the applied/pending status of every migration. */
+export async function runStatus(): Promise<void> {
+  const migrations = await loadMigrations();
+  if (migrations.length === 0) {
+    logLine("No migration files found in scripts/migrations/");
+    return;
+  }
+
+  const applied = readApplied();
+  const appliedMap = new Map(applied.map((r) => [r.name, r.appliedAt]));
+
+  const rows: MigrationStatus[] = migrations.map((m) => ({
+    name: m.name,
+    description: m.description,
+    appliedAt: appliedMap.get(m.name) ?? null,
+  }));
+
+  const colW = Math.max(...rows.map((r) => r.name.length), 12);
+  console.log(`\n${"Migration".padEnd(colW + 2)}Status`);
+  console.log("─".repeat(colW + 32));
+  for (const row of rows) {
+    const status = row.appliedAt ? `applied  ${row.appliedAt}` : "pending";
+    console.log(`${row.name.padEnd(colW + 2)}${status}`);
+  }
+  console.log("");
+}
+
+// ── CLI entrypoint ─────────────────────────────────────────────────────────
+
+function parseArgs(argv: string[]): { command: string; network: "testnet" | "mainnet"; dryRun: boolean } {
+  return {
+    command: argv[0] ?? "status",
+    network: argv.includes("--network=mainnet") ? "mainnet" : "testnet",
+    dryRun: argv.includes("--dry-run"),
+  };
+}
+
+const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+if (isMainModule) {
+  const { command, network, dryRun } = parseArgs(process.argv.slice(2));
+  const run = async () => {
+    switch (command) {
+      case "up":
+        await runUp({ network, dryRun });
+        break;
+      case "down":
+        await runDown({ network, dryRun });
+        break;
+      case "status":
+        await runStatus();
+        break;
+      default:
+        console.error(`Unknown command: ${command}. Use: up | down | status`);
+        process.exitCode = 1;
+    }
+  };
+  run().catch((err: unknown) => {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/migrations/001_initial_contract_setup.ts
+++ b/scripts/migrations/001_initial_contract_setup.ts
@@ -1,0 +1,18 @@
+import type { MigrationContext } from "../migrate";
+
+export const description = "Record initial contract deployment in migration history";
+
+/** Apply: verify the contract is reachable and log the deployment baseline. */
+export async function up(ctx: MigrationContext): Promise<void> {
+  ctx.log(`[001] Confirming initial contract baseline on ${ctx.network}`);
+  // In a real migration this would invoke stellar contract commands to verify
+  // or update on-chain storage, seed initial data, or set config keys.
+  ctx.log("[001] Baseline confirmed.");
+}
+
+/** Rollback: undo the baseline record (no-op for initial setup). */
+export async function down(ctx: MigrationContext): Promise<void> {
+  ctx.log(`[001] Reversing initial contract baseline on ${ctx.network}`);
+  // Nothing destructive to undo for the initial marker migration.
+  ctx.log("[001] Rollback complete.");
+}

--- a/sdk/src/InvoiceDashboard.tsx
+++ b/sdk/src/InvoiceDashboard.tsx
@@ -1,0 +1,379 @@
+/**
+ * InvoiceDashboard — real-time React component for monitoring invoice activity.
+ *
+ * Usage:
+ *   <InvoiceDashboard websocketUrl="wss://your-iln-node/ws" />
+ *
+ * Props
+ * ─────
+ * websocketUrl   WebSocket endpoint that streams LiveInvoiceEvent JSON frames
+ * metrics        Which metric cards to show (default: all four)
+ * theme          "light" | "dark" | "system" — defaults to system preference
+ * refreshMs      Reconnect polling interval ms (default: 10000)
+ * maxEvents      Max recent-events rows to keep (default: 50)
+ * className      Optional host-element class names
+ * onEvent        Callback fired for every incoming event
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+// ── Public types ───────────────────────────────────────────────────────────
+
+export type InvoiceEventType = "submitted" | "funded" | "paid" | "defaulted";
+
+export interface LiveInvoiceEvent {
+  type: InvoiceEventType;
+  invoiceId: string;
+  amount: string;
+  address: string;
+  timestamp: number;
+}
+
+export interface DashboardMetrics {
+  totalSubmitted: number;
+  totalFunded: number;
+  totalPaid: number;
+  totalDefaulted: number;
+  recentEvents: LiveInvoiceEvent[];
+}
+
+export type MetricKey = keyof Omit<DashboardMetrics, "recentEvents">;
+
+export type DashboardTheme = "light" | "dark" | "system";
+
+export interface InvoiceDashboardProps {
+  websocketUrl: string;
+  metrics?: MetricKey[];
+  theme?: DashboardTheme;
+  refreshMs?: number;
+  maxEvents?: number;
+  className?: string;
+  onEvent?: (event: LiveInvoiceEvent) => void;
+}
+
+// ── Internals ──────────────────────────────────────────────────────────────
+
+type ConnectionStatus = "connecting" | "connected" | "disconnected" | "error";
+
+const ALL_METRICS: MetricKey[] = [
+  "totalSubmitted",
+  "totalFunded",
+  "totalPaid",
+  "totalDefaulted",
+];
+
+const METRIC_LABELS: Record<MetricKey, string> = {
+  totalSubmitted: "Submitted",
+  totalFunded: "Funded",
+  totalPaid: "Paid",
+  totalDefaulted: "Defaulted",
+};
+
+const METRIC_ACCENT: Record<MetricKey, string> = {
+  totalSubmitted: "#6366f1",
+  totalFunded: "#22c55e",
+  totalPaid: "#3b82f6",
+  totalDefaulted: "#ef4444",
+};
+
+const EVENT_DOT: Record<InvoiceEventType, string> = {
+  submitted: "#6366f1",
+  funded: "#22c55e",
+  paid: "#3b82f6",
+  defaulted: "#ef4444",
+};
+
+const STATUS_DOT: Record<ConnectionStatus, string> = {
+  connecting: "#f59e0b",
+  connected: "#22c55e",
+  disconnected: "#94a3b8",
+  error: "#ef4444",
+};
+
+function useResolvedTheme(theme: DashboardTheme): "light" | "dark" {
+  const [resolved, setResolved] = useState<"light" | "dark">(() => {
+    if (theme !== "system") return theme;
+    return typeof window !== "undefined" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  });
+
+  useEffect(() => {
+    if (theme !== "system") { setResolved(theme); return; }
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e: MediaQueryListEvent) =>
+      setResolved(e.matches ? "dark" : "light");
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  return resolved;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export function InvoiceDashboard({
+  websocketUrl,
+  metrics = ALL_METRICS,
+  theme = "system",
+  refreshMs = 10_000,
+  maxEvents = 50,
+  className,
+  onEvent,
+}: InvoiceDashboardProps) {
+  const [state, setState] = useState<DashboardMetrics>({
+    totalSubmitted: 0,
+    totalFunded: 0,
+    totalPaid: 0,
+    totalDefaulted: 0,
+    recentEvents: [],
+  });
+  const [status, setStatus] = useState<ConnectionStatus>("connecting");
+  const resolvedTheme = useResolvedTheme(theme);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const retryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryDelay = useRef(1_000);
+
+  const applyEvent = useCallback(
+    (event: LiveInvoiceEvent) => {
+      setState((prev) => {
+        const key =
+          (`total${event.type.charAt(0).toUpperCase()}${event.type.slice(1)}`) as MetricKey;
+        return {
+          ...prev,
+          [key]: (prev[key] as number) + 1,
+          recentEvents: [event, ...prev.recentEvents].slice(0, maxEvents),
+        };
+      });
+      onEvent?.(event);
+    },
+    [onEvent, maxEvents]
+  );
+
+  const connect = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.onclose = null;
+      wsRef.current.close();
+    }
+    setStatus("connecting");
+    const ws = new WebSocket(websocketUrl);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      setStatus("connected");
+      retryDelay.current = 1_000;
+    };
+    ws.onmessage = (msg) => {
+      try {
+        applyEvent(JSON.parse(msg.data as string) as LiveInvoiceEvent);
+      } catch { /* ignore malformed frames */ }
+    };
+    ws.onerror = () => setStatus("error");
+    ws.onclose = () => {
+      setStatus("disconnected");
+      retryTimer.current = setTimeout(() => {
+        retryDelay.current = Math.min(retryDelay.current * 2, 30_000);
+        connect();
+      }, retryDelay.current);
+    };
+  }, [websocketUrl, applyEvent]);
+
+  useEffect(() => {
+    connect();
+    const poll = setInterval(() => {
+      if (wsRef.current?.readyState !== WebSocket.OPEN) connect();
+    }, refreshMs);
+    return () => {
+      clearInterval(poll);
+      if (retryTimer.current) clearTimeout(retryTimer.current);
+      wsRef.current?.close();
+    };
+  }, [connect, refreshMs]);
+
+  // ── Styles ────────────────────────────────────────────────────────────
+
+  const isDark = resolvedTheme === "dark";
+  const bg = isDark ? "#0f172a" : "#f8fafc";
+  const fg = isDark ? "#f1f5f9" : "#0f172a";
+  const cardBg = isDark ? "#1e293b" : "#ffffff";
+  const border = isDark ? "#1e293b" : "#e2e8f0";
+  const muted = isDark ? "#94a3b8" : "#64748b";
+
+  const visibleEvents = useMemo(
+    () => state.recentEvents.slice(0, 10),
+    [state.recentEvents]
+  );
+
+  return (
+    <div
+      className={className}
+      data-theme={resolvedTheme}
+      style={{
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        background: bg,
+        color: fg,
+        borderRadius: "12px",
+        border: `1px solid ${border}`,
+        padding: "20px",
+        boxSizing: "border-box",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: "16px",
+        }}
+      >
+        <h2 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>
+          Invoice Activity
+        </h2>
+        <span
+          style={{ display: "inline-flex", alignItems: "center", gap: "6px", fontSize: "12px", color: muted }}
+          aria-live="polite"
+          aria-label={`Connection status: ${status}`}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              background: STATUS_DOT[status],
+              display: "inline-block",
+            }}
+          />
+          {status}
+        </span>
+      </div>
+
+      {/* Metric Cards */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(110px, 1fr))",
+          gap: "12px",
+          marginBottom: "20px",
+        }}
+        role="list"
+        aria-label="Invoice metrics"
+      >
+        {metrics.map((key) => (
+          <div
+            key={key}
+            role="listitem"
+            style={{
+              background: cardBg,
+              border: `1px solid ${border}`,
+              borderTop: `3px solid ${METRIC_ACCENT[key]}`,
+              borderRadius: "8px",
+              padding: "14px",
+            }}
+          >
+            <div
+              style={{
+                fontSize: "11px",
+                fontWeight: 500,
+                color: muted,
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              {METRIC_LABELS[key]}
+            </div>
+            <div
+              style={{ fontSize: "24px", fontWeight: 700, marginTop: "6px" }}
+              aria-label={`${METRIC_LABELS[key]}: ${state[key]}`}
+            >
+              {state[key] as number}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Recent Events */}
+      <div>
+        <div
+          style={{
+            fontSize: "12px",
+            fontWeight: 600,
+            color: muted,
+            marginBottom: "8px",
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+          }}
+        >
+          Recent Events
+        </div>
+
+        {visibleEvents.length === 0 ? (
+          <div
+            style={{ color: muted, fontSize: "13px", textAlign: "center", padding: "24px 0" }}
+            aria-live="polite"
+          >
+            Waiting for events…
+          </div>
+        ) : (
+          <ul
+            style={{
+              listStyle: "none",
+              margin: 0,
+              padding: 0,
+              display: "flex",
+              flexDirection: "column",
+              gap: "6px",
+            }}
+            aria-label="Recent invoice events"
+          >
+            {visibleEvents.map((ev, i) => (
+              <li
+                key={i}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "10px",
+                  background: cardBg,
+                  border: `1px solid ${border}`,
+                  borderRadius: "6px",
+                  padding: "8px 12px",
+                  fontSize: "13px",
+                }}
+              >
+                <span
+                  style={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: "50%",
+                    flexShrink: 0,
+                    background: EVENT_DOT[ev.type],
+                  }}
+                  aria-hidden="true"
+                />
+                <span style={{ fontWeight: 500, textTransform: "capitalize", minWidth: "80px" }}>
+                  {ev.type}
+                </span>
+                <span style={{ color: muted, fontFamily: "monospace", fontSize: "12px" }}>
+                  #{ev.invoiceId}
+                </span>
+                <span style={{ marginLeft: "auto", color: muted, fontSize: "11px" }}>
+                  {new Date(ev.timestamp).toLocaleTimeString()}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default InvoiceDashboard;


### PR DESCRIPTION
Closes #536

---

Closes #538

---

## Summary

- **#535** `scripts/migrate.ts` — migration framework with `up` / `down` / `status` commands, rollback support, dry-run mode, and JSON status tracking. Example migration at `scripts/migrations/001_initial_contract_setup.ts`.
- **#536** `notifications/src/preferences.ts` + `notifications/src/preferences-api.ts` — user preference model (channel, frequency, quiet hours, per-trigger overrides), in-memory store, `PreferencesService`, and a full Express router (`GET / PUT / PATCH / DELETE /preferences/:address`).
- **#537** `sdk/src/InvoiceDashboard.tsx` — real-time React component; WebSocket with exponential-backoff reconnect, four metric cards, recent-events feed, light/dark/system theme, responsive grid layout.
- **#538** `cli/src/generate.ts` + updated `cli/src/cli.ts` — template system with `invoice-client`, `webhook-handler`, and `subscription-config` built-ins, custom `.tpl` file support, `{{VARIABLE}}` interpolation, `iln generate --list / --preview / --var key=value`.

## Test plan
- [ ] `npx ts-node scripts/migrate.ts status` lists migrations with pending state
- [ ] `npx ts-node scripts/migrate.ts up --dry-run` logs steps without writing status file
- [ ] `npx ts-node scripts/migrate.ts up` applies migration and writes `migration-status.json`
- [ ] `npx ts-node scripts/migrate.ts down` rolls back last applied migration
- [ ] `GET /preferences/:address` returns default prefs for unseen address
- [ ] `PUT /preferences/:address` replaces all fields; `PATCH` updates only supplied fields
- [ ] `DELETE /preferences/:address` resets address to defaults on next GET
- [ ] `PreferencesService.isQuietHour` returns true inside the configured window
- [ ] `<InvoiceDashboard websocketUrl="…" />` renders metric cards and event list
- [ ] Incoming WebSocket frames increment the correct counter
- [ ] Theme switches correctly on `prefers-color-scheme` change
- [ ] `iln generate --list` shows three built-in templates
- [ ] `iln generate invoice-client --preview` prints the client file to stdout
- [ ] `iln generate webhook-handler --var secret=abc --out ./out` writes `out/webhook-handler.ts`