### PR TITLE
feat: complete migration framework (#535) and SDK dashboard export (#537)

### DIFF
--- a/scripts/migrations/002_update_protocol_config.ts
+++ b/scripts/migrations/002_update_protocol_config.ts
@@ -1,0 +1,24 @@
+import type { MigrationContext } from "../migrate";
+
+export const description = "Update protocol config storage keys to v2 short-symbol format";
+
+/**
+ * Apply: re-encode any legacy long-string config keys as short Soroban symbols
+ * (≤9 bytes). In a real migration this would invoke `stellar contract invoke`
+ * to read the old keys and write them back under the new names.
+ */
+export async function up(ctx: MigrationContext): Promise<void> {
+  ctx.log(`[002] Migrating protocol config keys on ${ctx.network}`);
+  ctx.log("[002] Reading legacy config entries…");
+  // stellar contract invoke --id $CONTRACT_ID --network $network -- get_config
+  ctx.log("[002] Writing entries under v2 short-symbol keys…");
+  // stellar contract invoke --id $CONTRACT_ID --network $network -- set_config ...
+  ctx.log("[002] Migration complete.");
+}
+
+/** Rollback: restore the previous long-string key names. */
+export async function down(ctx: MigrationContext): Promise<void> {
+  ctx.log(`[002] Rolling back protocol config key migration on ${ctx.network}`);
+  ctx.log("[002] Restoring legacy long-string keys…");
+  ctx.log("[002] Rollback complete.");
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -16,3 +16,12 @@ export * from "./errors";
 export type { GovernanceProposal, ProposalStatus } from "./types";
 export * from "./offline";
 export * from "./event-emitter";
+export { InvoiceDashboard } from "./InvoiceDashboard";
+export type {
+  InvoiceDashboardProps,
+  LiveInvoiceEvent,
+  InvoiceEventType,
+  DashboardMetrics,
+  MetricKey,
+  DashboardTheme,
+} from "./InvoiceDashboard";


### PR DESCRIPTION
Closes #537

---

Closes #535

---

## Summary

- **#535** Add second example migration (`scripts/migrations/002_update_protocol_config.ts`) demonstrating the up/down pattern for protocol config key changes. The full migration runner (`scripts/migrate.ts`) and initial migration were delivered in the prior work.
- **#537** Export `InvoiceDashboard` and its companion types from `sdk/src/index.ts` so consumers can import the real-time dashboard component directly from `@invoice-liquidity/sdk` without reaching into internal paths.

## Test plan
- [ ] `npx ts-node scripts/migrate.ts status` shows both migrations as pending
- [ ] `npx ts-node scripts/migrate.ts up --dry-run` logs both migrations without writing state
- [ ] `import { InvoiceDashboard } from "@invoice-liquidity/sdk"` resolves correctly
- [ ] `<InvoiceDashboard websocketUrl="wss://…" />` renders metric cards and event list