### PR TITLE
feat: resolve issues #515 #516 #517 #518 — plugin system, error recovery, monitoring, securiity guide

### DIFF
--- a/docs/_meta.json
+++ b/docs/_meta.json
@@ -11,5 +11,6 @@
   "mutation-testing": "Mutation Testing",
   "cross-repo-sync": "Cross-Repo Sync",
   "branch-protection": "Branch Protection",
-  "project-board": "Project Board"
+  "project-board": "Project Board",
+  "security-guide": "Security Guide"
 }

--- a/docs/security-guide.md
+++ b/docs/security-guide.md
@@ -1,0 +1,222 @@
+# Security Guide
+
+This guide covers the security measures built into the Invoice Liquidity Network (ILN), how to report vulnerabilities, best practices for integrators, audit information, and the incident response process.
+
+For the protocol-level attack surface analysis, see the [Threat Model](./threat-model.md).
+For package provenance verification, see [Security](./security.md).
+
+---
+
+## Security Overview
+
+ILN protects three classes of assets:
+
+| Asset | Protection mechanism |
+|---|---|
+| On-chain funds (XLM, USDC) | Smart contract authorization; only the designated account can sign |
+| Transaction integrity | Transactions are built, simulated, and submitted from the same validated object |
+| Off-chain service data | Rate limiting, request timeouts, pagination caps, and input validation at API boundaries |
+
+**Trust model:**
+
+- Users sign transactions locally in their own wallet. The SDK never holds private keys.
+- Off-chain services (indexer, notifications) observe on-chain events but are not authoritative for balances or final state — only the network is.
+- Every API response, SDK input, and wallet connection is treated as potentially attacker-controlled until validated.
+- SLSA Level 3 provenance attestations are published with every SDK release, proving that packages were built by the official GitHub Actions workflow and not from a developer machine.
+
+---
+
+## Vulnerability Reporting Process
+
+**Do not disclose vulnerabilities publicly until a fix has been issued.**
+
+### How to report
+
+| Channel | Details |
+|---|---|
+| GitHub Security Advisory | Open a private advisory at the repository's **Security** tab → **Report a vulnerability** |
+| Email | security@invoiceliquidity.network |
+
+### What to include
+
+- A detailed description of the vulnerability.
+- Step-by-step reproduction instructions.
+- Estimated impact (funds at risk, affected users, protocol scope).
+- Any potential mitigations you have identified.
+
+### Response timeline
+
+| Stage | SLA |
+|---|---|
+| Acknowledgment | Within 48 hours |
+| Triage and severity assignment | Within 5 business days |
+| Fix for Critical severity | Within 14 days |
+| Fix for High severity | Within 30 days |
+| Fix for Medium/Low severity | Best effort in the next release cycle |
+
+### Severity classification
+
+| Severity | Definition |
+|---|---|
+| Critical | Fund drainage from smart contracts, authentication bypass, total system compromise |
+| High | Significant data breach, unauthorized state manipulation with limited financial impact |
+| Medium | Denial of service, localized data leaks |
+| Low | UI spoofing, minor bugs with no direct financial or data impact |
+
+### Bug bounty
+
+Valid Critical vulnerabilities reported privately that result in a patch may be eligible for a bug bounty reward, determined on a case-by-case basis.
+
+Researchers who responsibly disclose vulnerabilities are acknowledged in `HALL_OF_FAME.md`.
+
+---
+
+## Security Best Practices
+
+### For SDK integrators
+
+**Transaction validation**
+
+- Always re-simulate a transaction before presenting it to the user for signing. Never trust a simulation result cached from an earlier operation.
+- Validate the source account, fee, time bounds, and memo fields before signing. The SDK rejects unexpected values, but host applications should apply their own checks.
+
+```typescript
+// Build and simulate in the same call to avoid stale state
+const { transaction } = await sdk.buildWriteTransaction(...);
+// Inspect before presenting to user wallet
+```
+
+**Wallet provider verification**
+
+- Detect the Freighter wallet via its published extension ID, not via duck-typing on `window.freighter`.
+- Do not trust wallet providers injected by unknown browser extensions.
+
+**Dependency management**
+
+- Pin your lockfile (`pnpm-lock.yaml` or equivalent) and review changes to transitive dependencies on every update.
+- Verify SDK package provenance after install:
+
+```bash
+npm audit signatures @invoice-liquidity/sdk
+```
+
+Expected output:
+```
+1 package has a verified registry signature
+1 package has a verified attestation
+```
+
+**Environment variables**
+
+- Never commit `.env` files or private keys to version control.
+- Use short-lived credentials for signing on CI/CD. Rotate secrets immediately if they are accidentally exposed.
+- Separate read-only RPC endpoints from write endpoints in production.
+
+### For node operators and self-hosters
+
+**Rate limiting**
+
+The indexer and notifications services enforce per-IP request quotas. Configure `RATE_LIMIT_WHITELIST` with your own monitoring IPs so health checks are not throttled.
+
+```env
+RATE_LIMIT_WHITELIST=10.0.0.5,10.0.0.6
+```
+
+**Network hardening**
+
+- Do not expose the Soroban RPC port (8000) or the node communication port (11626) to the public internet.
+- Place the indexer and notifications API behind a reverse proxy that terminates TLS.
+
+**Database**
+
+- Restrict filesystem permissions on `indexer.db` and `notifications.sqlite` to the service user.
+- Include database files in your backup and incident recovery plan.
+
+---
+
+## Audit Information
+
+### Package provenance (SLSA Level 3)
+
+All ILN npm packages (`@invoice-liquidity/sdk`, `@invoice-liquidity/cli`) are published with [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) provenance attestations. Each attestation links the published tarball to the exact GitHub Actions workflow run and commit SHA that built it.
+
+**Verify via npm:**
+
+```bash
+npm audit signatures @invoice-liquidity/sdk
+```
+
+**Verify via GitHub CLI:**
+
+```bash
+gh attestation verify \
+  $(npm pack @invoice-liquidity/sdk --dry-run 2>/dev/null | tail -1) \
+  --repo Invoice-Liquidity-Network/Invoice-Liquidity-Network
+```
+
+A successful verification prints the attestation details including the workflow run URL and commit SHA.
+
+### Smart contract audits
+
+The Soroban smart contract is the authoritative source for on-chain state. Before each major protocol version, the contract is reviewed for:
+
+- Authorization logic and account validation
+- State transition correctness (invoice lifecycle)
+- Integer overflow and arithmetic edge cases
+- Reentrancy and cross-contract call risks
+
+Audit reports are published in the repository under `contracts/audits/` when available. The current audit status for the deployed contract version is documented in [Deployment Infrastructure](./deployment/infrastructure.md).
+
+### Dependency scanning
+
+CI runs `pnpm audit` and license compliance checks on every pull request. The workflow enforces an 80% test-coverage floor and includes mutation testing to validate test quality.
+
+---
+
+## Incident Response
+
+### Step 1 — Detect
+
+Monitor service health using `scripts/monitor.sh`. Integrate it into your CI and alerting pipeline. Signs of an active incident include:
+
+- Unexpected fund movements on-chain.
+- Health check failures for the indexer or notifications service.
+- Anomalous error rates in SDK operations.
+- Reports from users via GitHub Security Advisories or the security email.
+
+### Step 2 — Contain
+
+- Pause new invoice submissions and funding operations in the frontend if funds are at risk.
+- Isolate the affected service (indexer, notifications, or the contract) by cutting its network access without stopping other components.
+- Capture logs and database snapshots before any remediation so evidence is preserved.
+
+### Step 3 — Report
+
+- Open a private GitHub Security Advisory immediately, even if the full scope is unknown.
+- Notify the security team at security@invoiceliquidity.network with the initial assessment.
+- Do not post details in public channels (Discord, Twitter, GitHub Issues) until a fix is deployed.
+
+### Step 4 — Remediate
+
+- Develop and test the fix in a private branch.
+- For smart contract vulnerabilities: coordinate an emergency contract upgrade or governance proposal.
+- For SDK vulnerabilities: publish a patched release with SLSA attestation and notify downstream integrators via the security advisory.
+- For off-chain service vulnerabilities: deploy the patched service and rotate any compromised credentials.
+
+### Step 5 — Disclose
+
+After the fix is deployed and downstream integrators have had time to update:
+
+1. Publish the GitHub Security Advisory publicly.
+2. Add the reporting researcher to `HALL_OF_FAME.md`.
+3. Publish a post-mortem summarizing the timeline, root cause, and mitigations taken.
+
+---
+
+## Related Documents
+
+- [Threat Model](./threat-model.md) — full attack surface analysis across SDK, frontend, API, and governance
+- [Security](./security.md) — package provenance and SLSA Level 3 verification details
+- [SECURITY.md](../SECURITY.md) — root-level security policy and supported versions
+- [CI/CD](./ci-cd.md) — how security checks are enforced in the pipeline
+- [Deployment Infrastructure](./deployment/infrastructure.md) — production hardening checklist

--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scripts/monitor.sh
+# Checks health and performance of ILN services: indexer and notifications.
+# Exits 0 if all services are healthy, 1 if any check fails.
+
+set -eo pipefail
+
+INDEXER_PORT="${INDEXER_PORT:-3001}"
+NOTIFICATIONS_PORT="${NOTIFICATIONS_PORT:-4001}"
+INDEXER_URL="http://localhost:${INDEXER_PORT}/health"
+NOTIFICATIONS_URL="http://localhost:${NOTIFICATIONS_PORT}/health"
+
+FAILURES=0
+
+check_dependencies() {
+    for cmd in curl jq; do
+        if ! command -v "$cmd" &> /dev/null; then
+            echo "Error: $cmd is required but not installed."
+            exit 1
+        fi
+    done
+}
+
+alert() {
+    local message="$1"
+    echo "🚨 ALERT: $message"
+    if [ -n "${ALERT_WEBHOOK_URL:-}" ]; then
+        curl -sf -X POST "${ALERT_WEBHOOK_URL}" \
+            -H "Content-Type: application/json" \
+            -d "{\"text\":\"${message}\"}" > /dev/null || true
+    fi
+}
+
+check_service() {
+    local name="$1"
+    local url="$2"
+    local response
+    local status_field
+
+    echo ""
+    echo "Checking $name at $url..."
+
+    if response=$(curl -sf --max-time 5 "$url" 2>/dev/null); then
+        status_field=$(echo "$response" | jq -r '.status // "unknown"' 2>/dev/null || echo "unknown")
+        local db_field
+        db_field=$(echo "$response" | jq -r '.db // "unknown"' 2>/dev/null || echo "unknown")
+        if [ "$status_field" = "ok" ]; then
+            echo "  ✅ $name: healthy (status=$status_field, db=$db_field)"
+        else
+            echo "  ⚠️  $name: degraded (status=$status_field, db=$db_field)"
+            alert "$name health check returned status=$status_field"
+            FAILURES=$((FAILURES + 1))
+        fi
+    else
+        echo "  ❌ $name: unreachable"
+        alert "$name is unreachable at $url"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+check_performance() {
+    local name="$1"
+    local url="$2"
+    local response_time
+
+    if response_time=$(curl -o /dev/null -s -w "%{time_total}" --max-time 10 "$url" 2>/dev/null); then
+        echo "  ⏱  $name response time: ${response_time}s"
+    else
+        echo "  ⚠️  $name: could not measure response time"
+    fi
+}
+
+# Main
+check_dependencies
+
+echo "================================"
+echo "   ILN Service Monitor"
+echo "================================"
+
+check_service "Indexer" "$INDEXER_URL"
+check_performance "Indexer" "$INDEXER_URL"
+
+check_service "Notifications" "$NOTIFICATIONS_URL"
+check_performance "Notifications" "$NOTIFICATIONS_URL"
+
+echo ""
+echo "================================"
+if [ "$FAILURES" -eq 0 ]; then
+    echo "✅ All services healthy."
+    exit 0
+else
+    echo "❌ $FAILURES service(s) failed health checks."
+    exit 1
+fi

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -16,6 +16,8 @@ export * from "./errors";
 export type { GovernanceProposal, ProposalStatus } from "./types";
 export * from "./offline";
 export * from "./event-emitter";
+export * from "./recovery";
+export * from "./plugins";
 export { InvoiceDashboard } from "./InvoiceDashboard";
 export type {
   InvoiceDashboardProps,

--- a/sdk/src/plugins.test.ts
+++ b/sdk/src/plugins.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from "vitest";
+import type { PluginContext, ILNPlugin } from "./plugins";
+import { PluginRegistry } from "./plugins";
+import { ILNEventEmitter } from "./event-emitter";
+
+function makeEmitter() {
+  return new ILNEventEmitter();
+}
+
+describe("PluginRegistry", () => {
+  it("registers a plugin and calls install", async () => {
+    const emitter = makeEmitter();
+    const registry = new PluginRegistry(emitter);
+    const install = vi.fn();
+    const plugin: ILNPlugin = { name: "test-plugin", install };
+
+    await registry.register(plugin);
+
+    expect(install).toHaveBeenCalledOnce();
+    expect(registry.has("test-plugin")).toBe(true);
+    expect(registry.list()).toContain("test-plugin");
+  });
+
+  it("registers plugin without install hook", async () => {
+    const registry = new PluginRegistry(makeEmitter());
+    await expect(
+      registry.register({ name: "no-install" }),
+    ).resolves.toBeUndefined();
+    expect(registry.has("no-install")).toBe(true);
+  });
+
+  it("throws on duplicate registration", async () => {
+    const registry = new PluginRegistry(makeEmitter());
+    const plugin: ILNPlugin = { name: "dup" };
+
+    await registry.register(plugin);
+    await expect(registry.register(plugin)).rejects.toThrow(/already registered/);
+  });
+
+  it("unregisters a plugin and calls destroy", async () => {
+    const registry = new PluginRegistry(makeEmitter());
+    const destroy = vi.fn();
+    const plugin: ILNPlugin = { name: "removable", destroy };
+
+    await registry.register(plugin);
+    await registry.unregister("removable");
+
+    expect(destroy).toHaveBeenCalledOnce();
+    expect(registry.has("removable")).toBe(false);
+    expect(registry.list()).not.toContain("removable");
+  });
+
+  it("throws when unregistering unknown plugin", async () => {
+    const registry = new PluginRegistry(makeEmitter());
+    await expect(registry.unregister("ghost")).rejects.toThrow(/not registered/);
+  });
+
+  it("list() returns registered plugin names in order", async () => {
+    const registry = new PluginRegistry(makeEmitter());
+    await registry.register({ name: "alpha" });
+    await registry.register({ name: "beta" });
+    expect(registry.list()).toEqual(["alpha", "beta"]);
+  });
+
+  it("fires onBeforeOperation hooks in registration order", async () => {
+    const calls: string[] = [];
+    const registry = new PluginRegistry(makeEmitter());
+
+    await registry.register({
+      name: "a",
+      onBeforeOperation: async () => {
+        calls.push("a");
+      },
+    });
+    await registry.register({
+      name: "b",
+      onBeforeOperation: async () => {
+        calls.push("b");
+      },
+    });
+
+    await registry.runBeforeOperation("submitInvoice", {});
+    expect(calls).toEqual(["a", "b"]);
+  });
+
+  it("fires onAfterOperation hooks", async () => {
+    const calls: string[] = [];
+    const registry = new PluginRegistry(makeEmitter());
+
+    await registry.register({
+      name: "logger-plugin",
+      onAfterOperation: async (name) => {
+        calls.push(name as string);
+      },
+    });
+
+    await registry.runAfterOperation("fundInvoice", { id: 1n });
+    expect(calls).toEqual(["fundInvoice"]);
+  });
+
+  it("fires onError hooks", async () => {
+    const errors: unknown[] = [];
+    const registry = new PluginRegistry(makeEmitter());
+
+    await registry.register({
+      name: "err-tracker",
+      onError: async (_name, error) => {
+        errors.push(error);
+      },
+    });
+
+    const err = new Error("rpc failed");
+    await registry.runOnError("submitInvoice", err);
+    expect(errors).toContain(err);
+  });
+
+  it("swallows errors from individual plugins without stopping others", async () => {
+    const calls: string[] = [];
+    const registry = new PluginRegistry(makeEmitter());
+
+    await registry.register({
+      name: "bad",
+      onAfterOperation: () => {
+        throw new Error("plugin error");
+      },
+    });
+    await registry.register({
+      name: "good",
+      onAfterOperation: async () => {
+        calls.push("good");
+      },
+    });
+
+    await expect(
+      registry.runAfterOperation("fundInvoice", { id: 1n }),
+    ).resolves.toBeUndefined();
+    expect(calls).toContain("good");
+  });
+
+  it("passes config to PluginContext", async () => {
+    let receivedConfig: Record<string, unknown> | undefined;
+    const registry = new PluginRegistry(makeEmitter());
+
+    await registry.register(
+      {
+        name: "configured",
+        install(ctx: PluginContext) {
+          receivedConfig = ctx.config;
+        },
+      },
+      { apiKey: "secret", timeout: 5000 },
+    );
+
+    expect(receivedConfig).toEqual({ apiKey: "secret", timeout: 5000 });
+  });
+
+  it("passes emitter on PluginContext", async () => {
+    const emitter = makeEmitter();
+    const registry = new PluginRegistry(emitter);
+    let ctxEmitter: unknown;
+
+    await registry.register({
+      name: "emitter-check",
+      install(ctx) {
+        ctxEmitter = ctx.emitter;
+      },
+    });
+
+    expect(ctxEmitter).toBe(emitter);
+  });
+
+  it("skips hooks not defined on plugin", async () => {
+    const registry = new PluginRegistry(makeEmitter());
+    await registry.register({ name: "minimal" }); // no hooks defined
+
+    await expect(
+      registry.runBeforeOperation("getProtocolConfig", {}),
+    ).resolves.toBeUndefined();
+    await expect(
+      registry.runAfterOperation("getProtocolConfig", {}),
+    ).resolves.toBeUndefined();
+    await expect(
+      registry.runOnError("getProtocolConfig", new Error("err")),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/sdk/src/plugins.ts
+++ b/sdk/src/plugins.ts
@@ -1,0 +1,106 @@
+import { createLogger } from "./logger";
+import type { ILNEventEmitter } from "./event-emitter";
+
+const logger = createLogger("plugins");
+
+export interface PluginContext {
+  readonly logger: (msg: string, data?: unknown) => void;
+  readonly emitter: ILNEventEmitter;
+  readonly config: Record<string, unknown>;
+}
+
+export interface ILNPlugin {
+  name: string;
+  version?: string;
+  install?(ctx: PluginContext): void | Promise<void>;
+  onBeforeOperation?(name: string, params: unknown): void | Promise<void>;
+  onAfterOperation?(name: string, result: unknown): void | Promise<void>;
+  onError?(name: string, error: unknown): void | Promise<void>;
+  destroy?(): void | Promise<void>;
+}
+
+type RegistryEntry = { plugin: ILNPlugin; ctx: PluginContext };
+
+type DispatchableHook = keyof Pick<
+  ILNPlugin,
+  "onBeforeOperation" | "onAfterOperation" | "onError"
+>;
+
+export class PluginRegistry {
+  private readonly plugins: Map<string, RegistryEntry> = new Map();
+  private readonly emitter: ILNEventEmitter;
+
+  constructor(emitter: ILNEventEmitter) {
+    this.emitter = emitter;
+  }
+
+  async register(
+    plugin: ILNPlugin,
+    config?: Record<string, unknown>,
+  ): Promise<void> {
+    if (this.plugins.has(plugin.name)) {
+      throw new Error(`Plugin "${plugin.name}" is already registered.`);
+    }
+
+    const ctx: PluginContext = {
+      logger: (msg, data) => {
+        if (logger.enabled) logger(`[${plugin.name}] ${msg}`, data);
+      },
+      emitter: this.emitter,
+      config: config ?? {},
+    };
+
+    await plugin.install?.(ctx);
+    this.plugins.set(plugin.name, { plugin, ctx });
+    logger(
+      `registered: ${plugin.name}${plugin.version ? `@${plugin.version}` : ""}`,
+    );
+  }
+
+  async unregister(name: string): Promise<void> {
+    const entry = this.plugins.get(name);
+    if (!entry) {
+      throw new Error(`Plugin "${name}" is not registered.`);
+    }
+    await entry.plugin.destroy?.();
+    this.plugins.delete(name);
+    logger(`unregistered: ${name}`);
+  }
+
+  has(name: string): boolean {
+    return this.plugins.has(name);
+  }
+
+  list(): string[] {
+    return Array.from(this.plugins.keys());
+  }
+
+  private async runHook(
+    hookName: DispatchableHook,
+    ...args: unknown[]
+  ): Promise<void> {
+    for (const { plugin } of this.plugins.values()) {
+      const hook = plugin[hookName] as
+        | ((...a: unknown[]) => void | Promise<void>)
+        | undefined;
+      if (!hook) continue;
+      try {
+        await hook.call(plugin, ...args);
+      } catch {
+        // swallow per-plugin errors — one bad plugin must not affect others
+      }
+    }
+  }
+
+  async runBeforeOperation(name: string, params: unknown): Promise<void> {
+    return this.runHook("onBeforeOperation", name, params);
+  }
+
+  async runAfterOperation(name: string, result: unknown): Promise<void> {
+    return this.runHook("onAfterOperation", name, result);
+  }
+
+  async runOnError(name: string, error: unknown): Promise<void> {
+    return this.runHook("onError", name, error);
+  }
+}

--- a/sdk/src/recovery.test.ts
+++ b/sdk/src/recovery.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  isRetryableError,
+  withRetry,
+  CircuitBreaker,
+  CircuitOpenError,
+} from "./recovery";
+import {
+  NetworkError,
+  ValidationError,
+  WalletNotConnectedError,
+  InsufficientBalanceError,
+  InvalidDiscountRateError,
+  TokenMismatchError,
+  PayerReputationTooLowError,
+  GenericContractError,
+  ILNError,
+} from "./errors";
+import { TimeoutError } from "./timeouts";
+
+describe("isRetryableError", () => {
+  it("retries NetworkError", () => {
+    expect(isRetryableError(new NetworkError())).toBe(true);
+  });
+
+  it("retries TimeoutError", () => {
+    expect(isRetryableError(new TimeoutError("op", 5000))).toBe(true);
+  });
+
+  it("retries ILNError with SIMULATION_FAILED code", () => {
+    const simulationErr = new ILNError(
+      "simulation failed",
+      "SIMULATION_FAILED",
+      "retry",
+    );
+    expect(isRetryableError(simulationErr)).toBe(true);
+  });
+
+  it("does not retry ValidationError", () => {
+    expect(isRetryableError(new ValidationError())).toBe(false);
+  });
+
+  it("does not retry WalletNotConnectedError", () => {
+    expect(isRetryableError(new WalletNotConnectedError())).toBe(false);
+  });
+
+  it("does not retry InsufficientBalanceError", () => {
+    expect(isRetryableError(new InsufficientBalanceError())).toBe(false);
+  });
+
+  it("does not retry InvalidDiscountRateError", () => {
+    expect(isRetryableError(new InvalidDiscountRateError())).toBe(false);
+  });
+
+  it("does not retry TokenMismatchError", () => {
+    expect(isRetryableError(new TokenMismatchError())).toBe(false);
+  });
+
+  it("does not retry PayerReputationTooLowError", () => {
+    expect(isRetryableError(new PayerReputationTooLowError())).toBe(false);
+  });
+
+  it("does not retry GenericContractError", () => {
+    expect(isRetryableError(new GenericContractError("raw xdr"))).toBe(false);
+  });
+
+  it("does not retry unrecognized ILNError subclasses", () => {
+    class CustomILNError extends ILNError {
+      constructor() {
+        super("custom", "CUSTOM", "fix it");
+        Object.setPrototypeOf(this, new.target.prototype);
+      }
+    }
+    expect(isRetryableError(new CustomILNError())).toBe(false);
+  });
+
+  it("retries unknown non-ILN errors", () => {
+    expect(isRetryableError(new Error("unexpected"))).toBe(true);
+    expect(isRetryableError("string error")).toBe(true);
+    expect(isRetryableError(null)).toBe(true);
+  });
+});
+
+describe("withRetry", () => {
+  // Use initialDelayMs: 0 so retries resolve immediately without fake timers
+
+  it("returns result on first success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn, { maxAttempts: 3 });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on retryable error and succeeds", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new NetworkError())
+      .mockResolvedValue("ok");
+
+    const result = await withRetry(fn, {
+      maxAttempts: 3,
+      initialDelayMs: 0,
+      jitter: false,
+    });
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws immediately on non-retryable error", async () => {
+    const fn = vi.fn().mockRejectedValue(new ValidationError("bad input"));
+
+    await expect(
+      withRetry(fn, { maxAttempts: 3, initialDelayMs: 0, jitter: false }),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws after exhausting maxAttempts on retryable error", async () => {
+    const fn = vi.fn().mockRejectedValue(new NetworkError());
+
+    await expect(
+      withRetry(fn, { maxAttempts: 3, initialDelayMs: 0, jitter: false }),
+    ).rejects.toBeInstanceOf(NetworkError);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("respects custom retryIf — always retry", async () => {
+    const fn = vi.fn().mockRejectedValue(new ValidationError());
+
+    await expect(
+      withRetry(fn, {
+        maxAttempts: 3,
+        initialDelayMs: 0,
+        jitter: false,
+        retryIf: () => true,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("respects custom retryIf — never retry", async () => {
+    const fn = vi.fn().mockRejectedValue(new NetworkError());
+
+    await expect(
+      withRetry(fn, {
+        maxAttempts: 3,
+        initialDelayMs: 0,
+        jitter: false,
+        retryIf: () => false,
+      }),
+    ).rejects.toBeInstanceOf(NetworkError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("CircuitBreaker", () => {
+  it("starts CLOSED", () => {
+    const cb = new CircuitBreaker();
+    expect(cb.getState()).toBe("CLOSED");
+  });
+
+  it("transitions CLOSED → OPEN after failureThreshold failures", async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 3 });
+    const fn = vi.fn().mockRejectedValue(new NetworkError());
+
+    for (let i = 0; i < 3; i++) {
+      await expect(cb.execute(fn)).rejects.toBeInstanceOf(NetworkError);
+    }
+
+    expect(cb.getState()).toBe("OPEN");
+  });
+
+  it("resets failure count on success in CLOSED state", async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 3 });
+    const failFn = vi.fn().mockRejectedValue(new NetworkError());
+    const succFn = vi.fn().mockResolvedValue("ok");
+
+    await expect(cb.execute(failFn)).rejects.toBeInstanceOf(NetworkError);
+    await expect(cb.execute(failFn)).rejects.toBeInstanceOf(NetworkError);
+    await cb.execute(succFn); // resets failure count
+
+    // Two more failures needed to trip (not just 1)
+    await expect(cb.execute(failFn)).rejects.toBeInstanceOf(NetworkError);
+    expect(cb.getState()).toBe("CLOSED");
+  });
+
+  it("throws CircuitOpenError when OPEN and cooldown not elapsed", async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 60_000 });
+    const fn = vi.fn().mockRejectedValue(new NetworkError());
+
+    await expect(cb.execute(fn)).rejects.toBeInstanceOf(NetworkError);
+    expect(cb.getState()).toBe("OPEN");
+
+    await expect(cb.execute(fn)).rejects.toBeInstanceOf(CircuitOpenError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("transitions OPEN → HALF_OPEN after cooldown elapsed", async () => {
+    vi.useFakeTimers();
+    const cb = new CircuitBreaker({
+      failureThreshold: 1,
+      cooldownMs: 1000,
+      successThreshold: 10,
+    });
+    const failFn = vi.fn().mockRejectedValue(new NetworkError());
+
+    await expect(cb.execute(failFn)).rejects.toBeInstanceOf(NetworkError);
+    expect(cb.getState()).toBe("OPEN");
+
+    vi.advanceTimersByTime(1001);
+
+    const succFn = vi.fn().mockResolvedValue("ok");
+    await cb.execute(succFn); // enters HALF_OPEN and records 1 success
+    expect(cb.getState()).toBe("HALF_OPEN");
+
+    vi.useRealTimers();
+  });
+
+  it("transitions HALF_OPEN → CLOSED after successThreshold successes", async () => {
+    vi.useFakeTimers();
+    const cb = new CircuitBreaker({
+      failureThreshold: 1,
+      cooldownMs: 1000,
+      successThreshold: 2,
+    });
+    const failFn = vi.fn().mockRejectedValue(new NetworkError());
+    const succFn = vi.fn().mockResolvedValue("ok");
+
+    await expect(cb.execute(failFn)).rejects.toBeInstanceOf(NetworkError);
+    vi.advanceTimersByTime(1001);
+
+    await cb.execute(succFn); // 1st success in HALF_OPEN
+    await cb.execute(succFn); // 2nd success → CLOSED
+    expect(cb.getState()).toBe("CLOSED");
+
+    vi.useRealTimers();
+  });
+
+  it("transitions HALF_OPEN → OPEN on any failure", async () => {
+    vi.useFakeTimers();
+    const cb = new CircuitBreaker({
+      failureThreshold: 1,
+      cooldownMs: 1000,
+      successThreshold: 2,
+    });
+    const failFn = vi.fn().mockRejectedValue(new NetworkError());
+
+    await expect(cb.execute(failFn)).rejects.toBeInstanceOf(NetworkError);
+    vi.advanceTimersByTime(1001);
+
+    // probe fails in HALF_OPEN → back to OPEN
+    await expect(cb.execute(failFn)).rejects.toBeInstanceOf(NetworkError);
+    expect(cb.getState()).toBe("OPEN");
+
+    // Cooldown resets — immediate retry is blocked
+    await expect(cb.execute(failFn)).rejects.toBeInstanceOf(CircuitOpenError);
+
+    vi.useRealTimers();
+  });
+
+  it("reset() returns to CLOSED and clears counters", async () => {
+    const cb = new CircuitBreaker({ failureThreshold: 1 });
+    const fn = vi.fn().mockRejectedValue(new NetworkError());
+
+    await expect(cb.execute(fn)).rejects.toBeInstanceOf(NetworkError);
+    expect(cb.getState()).toBe("OPEN");
+
+    cb.reset();
+    expect(cb.getState()).toBe("CLOSED");
+
+    const succFn = vi.fn().mockResolvedValue("ok");
+    await expect(cb.execute(succFn)).resolves.toBe("ok");
+  });
+
+  it("CircuitOpenError has correct code", () => {
+    const err = new CircuitOpenError();
+    expect(err.code).toBe("CIRCUIT_OPEN");
+    expect(err).toBeInstanceOf(ILNError);
+  });
+});

--- a/sdk/src/recovery.ts
+++ b/sdk/src/recovery.ts
@@ -1,0 +1,186 @@
+import { createLogger } from "./logger";
+import {
+  ILNError,
+  NetworkError,
+  ValidationError,
+  WalletNotConnectedError,
+  InsufficientBalanceError,
+  InvalidDiscountRateError,
+  TokenMismatchError,
+  PayerReputationTooLowError,
+  GenericContractError,
+} from "./errors";
+import { TimeoutError } from "./timeouts";
+
+const logger = createLogger("recovery");
+
+export interface RetryOptions {
+  maxAttempts: number;
+  initialDelayMs: number;
+  maxDelayMs: number;
+  backoffFactor: number;
+  jitter: boolean;
+  retryIf?: (err: unknown) => boolean;
+}
+
+export interface CircuitBreakerOptions {
+  failureThreshold: number;
+  successThreshold: number;
+  cooldownMs: number;
+}
+
+export type CircuitBreakerState = "CLOSED" | "OPEN" | "HALF_OPEN";
+
+const DEFAULT_RETRY: RetryOptions = {
+  maxAttempts: 3,
+  initialDelayMs: 500,
+  maxDelayMs: 30_000,
+  backoffFactor: 2,
+  jitter: true,
+};
+
+const DEFAULT_CIRCUIT_BREAKER: Required<CircuitBreakerOptions> = {
+  failureThreshold: 5,
+  successThreshold: 2,
+  cooldownMs: 60_000,
+};
+
+export function isRetryableError(err: unknown): boolean {
+  if (err instanceof NetworkError) return true;
+  if (err instanceof TimeoutError) return true;
+  // SimulationError (code "SIMULATION_FAILED") is retryable — check by code
+  // since the compiled JS output may be stale and missing this class.
+  if (err instanceof ILNError && err.code === "SIMULATION_FAILED") return true;
+  // All other known ILN business/contract errors are non-retryable by default.
+  // Callers can override per-operation via RetryOptions.retryIf.
+  if (err instanceof ValidationError) return false;
+  if (err instanceof WalletNotConnectedError) return false;
+  if (err instanceof InsufficientBalanceError) return false;
+  if (err instanceof InvalidDiscountRateError) return false;
+  if (err instanceof TokenMismatchError) return false;
+  if (err instanceof PayerReputationTooLowError) return false;
+  if (err instanceof GenericContractError) return false;
+  if (err instanceof ILNError) return false;
+  // Non-ILN errors (raw fetch failures, runtime errors) are assumed transient.
+  return true;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options?: Partial<RetryOptions>,
+): Promise<T> {
+  const opts: RetryOptions = { ...DEFAULT_RETRY, ...options };
+  const shouldRetry = opts.retryIf ?? isRetryableError;
+
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt === opts.maxAttempts) throw err;
+      if (!shouldRetry(err)) throw err;
+
+      let delay = Math.min(
+        opts.initialDelayMs * Math.pow(opts.backoffFactor, attempt - 1),
+        opts.maxDelayMs,
+      );
+      if (opts.jitter) {
+        delay = delay * (0.5 + Math.random() * 0.5);
+      }
+
+      logger(
+        `retry ${attempt}/${opts.maxAttempts - 1} after ${Math.round(delay)}ms`,
+        { error: err instanceof Error ? err.message : String(err) },
+      );
+
+      await sleep(delay);
+    }
+  }
+
+  throw new Error("withRetry: unexpected exit");
+}
+
+export class CircuitOpenError extends ILNError {
+  constructor() {
+    super(
+      "Circuit breaker is open; requests are temporarily blocked.",
+      "CIRCUIT_OPEN",
+      "Wait for the cooldown period to elapse, then retry your request.",
+    );
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class CircuitBreaker {
+  private state: CircuitBreakerState = "CLOSED";
+  private failureCount = 0;
+  private successCount = 0;
+  private openedAt: number | null = null;
+  private readonly options: Required<CircuitBreakerOptions>;
+
+  constructor(options?: Partial<CircuitBreakerOptions>) {
+    this.options = { ...DEFAULT_CIRCUIT_BREAKER, ...options };
+  }
+
+  getState(): CircuitBreakerState {
+    return this.state;
+  }
+
+  reset(): void {
+    this.state = "CLOSED";
+    this.failureCount = 0;
+    this.successCount = 0;
+    this.openedAt = null;
+    logger("circuit breaker reset to CLOSED");
+  }
+
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.state === "OPEN") {
+      const elapsed = Date.now() - (this.openedAt ?? 0);
+      if (elapsed < this.options.cooldownMs) {
+        throw new CircuitOpenError();
+      }
+      this.state = "HALF_OPEN";
+      this.successCount = 0;
+      logger("circuit breaker → HALF_OPEN");
+    }
+
+    try {
+      const result = await fn();
+
+      if (this.state === "HALF_OPEN") {
+        this.successCount++;
+        if (this.successCount >= this.options.successThreshold) {
+          this.state = "CLOSED";
+          this.failureCount = 0;
+          this.successCount = 0;
+          this.openedAt = null;
+          logger("circuit breaker → CLOSED");
+        }
+      } else {
+        this.failureCount = 0;
+      }
+
+      return result;
+    } catch (err) {
+      if (this.state === "HALF_OPEN") {
+        this.state = "OPEN";
+        this.openedAt = Date.now();
+        this.successCount = 0;
+        logger("circuit breaker → OPEN (from HALF_OPEN)");
+      } else {
+        this.failureCount++;
+        if (this.failureCount >= this.options.failureThreshold) {
+          this.state = "OPEN";
+          this.openedAt = Date.now();
+          this.failureCount = 0;
+          logger("circuit breaker → OPEN");
+        }
+      }
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
  Resolves #515, #516, #517, #518.

  - #515 SDK Plugin System — new sdk/src/plugins.ts with ILNPlugin interface, PluginContext, and PluginRegistry. Supports
  lifecycle hooks (install, onBeforeOperation, onAfterOperation, onError, destroy). Hook errors are swallowed per-plugin so
  one bad plugin cannot break SDK operations. Tested in sdk/src/plugins.test.ts.
  - #517 SDK Error Recovery — new sdk/src/recovery.ts with isRetryableError classifier, withRetry<T> (exponential backoff +
  optional jitter), full CircuitBreaker state machine (CLOSED → OPEN → HALF_OPEN → CLOSED, including HALF_OPEN → OPEN on
  failure), and CircuitOpenError. Tested in sdk/src/recovery.test.ts.
  - #516 Monitoring Script — new scripts/monitor.sh. Checks indexer (/health on port 3001) and notifications (/health on
  port 4001), measures response times, optionally POSTs to ALERT_WEBHOOK_URL, prints a summary table, and exits 1 when any
  check fails. Uses conditional if curl (not set -e propagation) so all services are checked before the summary fires.
  - #518 Security Guide — new docs/security-guide.md covering security overview, vulnerability reporting process (48h ACK /
  14-day Critical SLA), actionable best practices (transaction validation, wallet provider verification, dependency pinning,
  env hygiene), SLSA Level 3 audit info with verification commands, and a 5-step incident response process.

  Test plan

  - [x] sdk/src/recovery.test.ts — 27 tests covering isRetryableError, withRetry (success, retry, abort, custom retryIf), and
  all CircuitBreaker state transitions
  - [x] sdk/src/plugins.test.ts — 13 tests covering register/unregister, duplicate rejection, hook dispatch order, error
  swallowing, config/emitter on context
  - [x] All 40 new tests pass
  - [ ] Run bash scripts/monitor.sh against live services to verify health checks and alert webhook
  - [ ] Review docs/security-guide.md for accuracy against current deployment

  Closes

  Closes #515
  Closes #516
  Closes #517
  Closes #518