### PR TITLE
feat: Added sdk locale support

### DIFF
--- a/sdk/errors.ts
+++ b/sdk/errors.ts
@@ -1,20 +1,90 @@
 import enMessages from './locales/en.json'
+import esMessages from './locales/es.json'
+import frMessages from './locales/fr.json'
 
 export type ErrorMessages = typeof enMessages
 
 // Registry: locale name -> messages map
-const locales: Record<string, ErrorMessages> = { en: enMessages }
-let activeLocale = 'en'
-
-/** Register a locale and switch to it. */
-export function setLocale(locale: string, messages: ErrorMessages): void {
-  locales[locale] = messages
-  activeLocale = locale
+const locales: Record<string, ErrorMessages> = {
+  en: enMessages,
+  es: esMessages,
+  fr: frMessages,
 }
 
+/** Detects the user's system locale in browser and Node environments. */
+export function detectLocale(): string {
+  // 1. Browser context detection
+  if (typeof globalThis !== 'undefined' && globalThis.navigator) {
+    const nav = globalThis.navigator;
+    if (nav.languages && nav.languages.length > 0) {
+      for (const lang of nav.languages) {
+        const code = lang.split('-')[0].toLowerCase();
+        if (locales[code]) return code;
+      }
+    }
+    if (nav.language) {
+      const code = nav.language.split('-')[0].toLowerCase();
+      if (locales[code]) return code;
+    }
+  }
+
+  // 2. Node.js environment context detection
+  if (typeof process !== 'undefined' && process.env) {
+    const envKeys = ['LANG', 'LANGUAGE', 'LC_ALL', 'LC_MESSAGES'];
+    for (const key of envKeys) {
+      const val = process.env[key];
+      if (val) {
+        // Handle values like en_US.UTF-8, es-ES, etc.
+        const code = val.split('.')[0].split('_')[0].split('-')[0].toLowerCase();
+        if (locales[code]) return code;
+      }
+    }
+  }
+
+  // 3. Fallback to English
+  return 'en';
+}
+
+let activeLocale = detectLocale()
+
+/** Register a locale and switch to it. Optionally register new messages map. */
+export function setLocale(locale: string, messages?: ErrorMessages): void {
+  if (messages) {
+    locales[locale] = messages
+  }
+  if (locales[locale]) {
+    activeLocale = locale
+  } else {
+    activeLocale = 'en'
+  }
+}
+
+/** Retrieves translated message with fallback chain to English. */
 function getMessage(code: string): string {
-  const msgs = locales[activeLocale] ?? locales['en']
-  return (msgs as Record<string, string>)[code] ?? msgs['Unknown']
+  const activeMsgs = locales[activeLocale] ?? locales['en']
+  const enMsgs = locales['en']
+
+  // 1. Try to get translation in active locale
+  if (activeMsgs && (activeMsgs as Record<string, string>)[code]) {
+    return (activeMsgs as Record<string, string>)[code]
+  }
+
+  // 2. Fallback to English translation
+  if (enMsgs && (enMsgs as Record<string, string>)[code]) {
+    return (enMsgs as Record<string, string>)[code]
+  }
+
+  // 3. Fallback to Unknown message in active locale
+  if (activeMsgs && (activeMsgs as Record<string, string>)['Unknown']) {
+    return (activeMsgs as Record<string, string>)['Unknown']
+  }
+
+  // 4. Fallback to Unknown message in English
+  if (enMsgs && (enMsgs as Record<string, string>)['Unknown']) {
+    return (enMsgs as Record<string, string>)['Unknown']
+  }
+
+  return 'Unknown error'
 }
 
 export function mapError(err: any): Error {
@@ -28,3 +98,4 @@ export function mapError(err: any): Error {
   ;(error as any).code = code
   return error
 }
+

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -1,7 +1,7 @@
 // sdk/index.ts
 
 import { mapError } from './errors'
-export { setLocale } from './errors'
+export { setLocale, detectLocale } from './errors'
 export type { ErrorMessages } from './errors'
 
 export async function submitInvoice(invoke: any, params: {

--- a/sdk/locales/es.json
+++ b/sdk/locales/es.json
@@ -1,0 +1,8 @@
+{
+  "InvalidAmount": "Importe no válido",
+  "AlreadyFunded": "Ya financiado",
+  "NotFunded": "No financiado",
+  "InvoiceNotFound": "Factura no encontrada",
+  "NotYetDefaulted": "Aún no declarado en mora",
+  "Unknown": "Error desconocido"
+}

--- a/sdk/tests/i18n.test.ts
+++ b/sdk/tests/i18n.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest'
-import { setLocale, mapError } from '../errors'
+import { setLocale, mapError, detectLocale } from '../errors'
 import enMessages from '../locales/en.json'
 import frMessages from '../locales/fr.json'
 
@@ -60,4 +60,36 @@ describe('locale switching', () => {
     setLocale('en', enMessages)
     expect(mapError({ code: 'NotFunded' }).message).toBe('Not funded')
   })
+
+  it('supports default Spanish locale out-of-the-box', () => {
+    setLocale('es')
+    expect(mapError({ code: 'InvalidAmount' }).message).toBe('Importe no válido')
+    expect(mapError({ code: 'InvoiceNotFound' }).message).toBe('Factura no encontrada')
+  })
+
+  it('falls back to English when a message key is missing in the active locale', () => {
+    setLocale('partial-lang', {
+      InvalidAmount: 'Partial Invalid',
+      Unknown: 'Partial Unknown',
+    } as any)
+
+    // Key present in active locale:
+    expect(mapError({ code: 'InvalidAmount' }).message).toBe('Partial Invalid')
+    // Key missing in active locale, falls back to English:
+    expect(mapError({ code: 'AlreadyFunded' }).message).toBe('Already funded')
+    // Key missing in both, falls back to active locale Unknown:
+    expect(mapError({ code: 'WeirdCode' }).message).toBe('Partial Unknown')
+  })
+
+  it('detects locale from environment variables in Node context', () => {
+    const originalEnv = process.env.LANG
+    try {
+      process.env.LANG = 'fr_FR.UTF-8'
+      const detected = detectLocale()
+      expect(detected).toBe('fr')
+    } finally {
+      process.env.LANG = originalEnv
+    }
+  })
 })
+


### PR DESCRIPTION
Closes #513

---

#513 

This pull request introduces comprehensive locale and translation support to the SDK, enabling localized error messages for English, Spanish, and French languages. The implementation allows for dynamic language resolution based on the user's environment while offering a resilient fallback structure to maintain consistent error messaging.

To support Spanish natively, a new translation file sdk/locales/es.json has been created, aligning with the existing keys present in the English (en.json) and French (fr.json) translation maps. These maps translate error identifiers such as InvalidAmount, AlreadyFunded, NotFunded, InvoiceNotFound, and NotYetDefaulted into their respective translations.

The translation engine has been updated with automatic locale detection via the detectLocale() helper in sdk/errors.ts. This utility first checks browser environments using navigator.language and navigator.languages, then falls back to Node.js environments by parsing common environment variables like LANG, LANGUAGE, LC_ALL, and LC_MESSAGES. Additionally, a key-level English fallback mechanism is now in place; if a specific error key is missing in the active translation map (or if an unsupported locale is detected), the engine seamlessly falls back to English before reverting to the generic Unknown message.

Finally, detectLocale has been exported from the SDK’s main entry point to make it available to consumers. The unit test suite in sdk/tests/i18n.test.ts has also been expanded to verify the default Spanish locale resolution, key-level English fallbacks, and Node process environment detection logic.