### PR TITLE
feat: Added cli configuration validation

### DIFF
--- a/cli/config.schema.json
+++ b/cli/config.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ILN CLI Configuration Schema",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "integer",
+      "description": "Configuration file version.",
+      "default": 2
+    },
+    "network": {
+      "type": "string",
+      "enum": ["testnet", "mainnet", "standalone"],
+      "description": "Target Stellar network.",
+      "default": "testnet"
+    },
+    "horizonUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "Stellar Horizon API URL."
+    },
+    "rpcUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "Soroban RPC server URL."
+    },
+    "contractIds": {
+      "type": "object",
+      "description": "Contract IDs keyed by role.",
+      "properties": {
+        "invoice": {
+          "type": "string",
+          "description": "Invoice contract ID."
+        },
+        "token": {
+          "type": "string",
+          "description": "Stellar Asset Token contract ID."
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "deployer": {
+      "type": "object",
+      "properties": {
+        "keypairPath": {
+          "type": "string",
+          "description": "Path to the deployer keypair file."
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -51,12 +51,22 @@ export class ConfigValidationError extends Error {
 // ─── Schema ───────────────────────────────────────────────────────────────────
 
 export const ConfigSchema = z.object({
+  /** Path to JSON schema */
+  $schema: z.string().optional(),
+  /** Config file version. Defaults to 2. */
+  version: z.number().optional().default(2),
   /** Target Stellar network. Defaults to "testnet". */
   network: z.enum(["testnet", "mainnet", "standalone"]).optional().default("testnet"),
   horizonUrl: z.string().url().optional(),
   rpcUrl: z.string().url().optional(),
   /** Contract IDs keyed by role, e.g. { invoice: "C…", token: "C…" }. */
-  contractIds: z.record(z.string()).default({}),
+  contractIds: z
+    .object({
+      invoice: z.string().optional(),
+      token: z.string().optional(),
+    })
+    .catchall(z.string())
+    .default({}),
   deployer: z
     .object({
       keypairPath: z.string().optional(),
@@ -65,6 +75,75 @@ export const ConfigSchema = z.object({
 });
 
 export type ILNConfigFile = z.infer<typeof ConfigSchema>;
+
+// ─── Migration ───────────────────────────────────────────────────────────────
+
+/**
+ * Migrate legacy configuration format (version 1) to the new nested format (version 2).
+ * Writes the migrated configuration back to disk if it was loaded from a JSON file.
+ */
+export function migrateConfig(rawConfig: any, filePath: string | null): any {
+  if (!rawConfig || typeof rawConfig !== "object") return rawConfig;
+
+  // Clone object to avoid mutating the original reference
+  const migrated = JSON.parse(JSON.stringify(rawConfig));
+  let changed = false;
+
+  // Migrate legacy root-level contractId -> contractIds.invoice
+  if (migrated.contractId) {
+    migrated.contractIds = migrated.contractIds || {};
+    if (!migrated.contractIds.invoice) {
+      migrated.contractIds.invoice = migrated.contractId;
+    }
+    delete migrated.contractId;
+    changed = true;
+  }
+
+  // Migrate legacy root-level keypairPath -> deployer.keypairPath
+  if (migrated.keypairPath) {
+    if (!migrated.deployer) {
+      migrated.deployer = {};
+    }
+    if (!migrated.deployer.keypairPath) {
+      migrated.deployer.keypairPath = migrated.keypairPath;
+    }
+    delete migrated.keypairPath;
+    changed = true;
+  }
+
+  // Migrate legacy root-level tokenId -> contractIds.token
+  if (migrated.tokenId) {
+    migrated.contractIds = migrated.contractIds || {};
+    if (!migrated.contractIds.token) {
+      migrated.contractIds.token = migrated.tokenId;
+    }
+    delete migrated.tokenId;
+    changed = true;
+  }
+
+  // Upgrade version to 2 if missing or older
+  if (migrated.version === undefined || migrated.version < 2) {
+    migrated.version = 2;
+    changed = true;
+  }
+
+  // Write migrated config back to file in-place if it's a JSON file
+  if (changed && filePath && existsSync(filePath)) {
+    try {
+      const ext = path.extname(filePath).toLowerCase();
+      if (ext === ".json") {
+        if (!migrated["$schema"]) {
+          migrated["$schema"] = "./config.schema.json";
+        }
+        writeFileSync(filePath, JSON.stringify(migrated, null, 2) + "\n");
+      }
+    } catch (err: any) {
+      // Ignore write errors to ensure robustness (e.g. read-only filesystems)
+    }
+  }
+
+  return migrated;
+}
 
 // ─── Load options ─────────────────────────────────────────────────────────────
 
@@ -88,14 +167,17 @@ export function loadConfig(options: LoadConfigOptions = {}): ResolvedConfig {
   const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
 
-  const { rawConfig, filePath } = readConfigFile(cwd);
+  const { rawConfig: initialRawConfig, filePath } = readConfigFile(cwd);
+
+  // Migrate old configuration structures dynamically
+  const rawConfig = migrateConfig(initialRawConfig, filePath);
 
   // Validate shape
   const parsed = ConfigSchema.safeParse(rawConfig);
   if (!parsed.success) {
     const hint = filePath ? ` (${path.basename(filePath)})` : "";
     const messages = parsed.error.issues
-      .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+      .map((i) => `[Field: ${i.path.join(".") || "<root>"}] - ${i.message}`)
       .join("; ");
     throw new ConfigValidationError(`Config validation failed${hint}: ${messages}`);
   }
@@ -108,7 +190,6 @@ export function loadConfig(options: LoadConfigOptions = {}): ResolvedConfig {
     env.ILN_CONTRACT_ID,
     fileConfig.contractIds?.invoice,
     fileConfig.contractIds?.liquidity,
-    (rawConfig as any).contractId,
   );
   if (!contractId) {
     throw new ConfigValidationError(
@@ -119,7 +200,6 @@ export function loadConfig(options: LoadConfigOptions = {}): ResolvedConfig {
   const keypairPath = coalesce(
     env.ILN_KEYPAIR_PATH,
     fileConfig.deployer?.keypairPath,
-    (rawConfig as any).keypairPath,
   );
   if (!keypairPath) {
     throw new ConfigValidationError(
@@ -133,14 +213,12 @@ export function loadConfig(options: LoadConfigOptions = {}): ResolvedConfig {
     network,
     networkPassphrase: coalesce(
       env.ILN_NETWORK_PASSPHRASE,
-      (rawConfig as any).networkPassphrase,
       defaults.networkPassphrase,
     )!,
     rpcUrl: coalesce(env.ILN_RPC_URL, fileConfig.rpcUrl, defaults.rpcUrl)!,
     tokenId: coalesce(
       env.ILN_TOKEN_ID,
       fileConfig.contractIds?.token,
-      (rawConfig as any).tokenId,
     ),
   };
 }
@@ -164,16 +242,18 @@ export function initConfig(cwd: string): string {
   }
 
   const targetPath = path.join(cwd, ".ilnrc.json");
-  const template: ILNConfigFile = {
-    network: "testnet",
-    rpcUrl: DEFAULTS.testnet.rpcUrl,
-    horizonUrl: "https://horizon-testnet.stellar.org",
-    contractIds: {
-      invoice: "",
-      token: "",
+  const template = {
+    "$schema": "./config.schema.json",
+    "version": 2,
+    "network": "testnet",
+    "rpcUrl": DEFAULTS.testnet.rpcUrl,
+    "horizonUrl": "https://horizon-testnet.stellar.org",
+    "contractIds": {
+      "invoice": "",
+      "token": "",
     },
-    deployer: {
-      keypairPath: "~/.stellar/testnet.key",
+    "deployer": {
+      "keypairPath": "~/.stellar/testnet.key",
     },
   };
 

--- a/cli/tests/config-ilnrc.test.ts
+++ b/cli/tests/config-ilnrc.test.ts
@@ -340,3 +340,44 @@ describe("iln config init (CLI command)", () => {
     expect(stderr.toString()).toContain("already exists");
   });
 });
+
+// ─── Additional validation & migration tests ──────────────────────────────────
+describe("Config validation & version migration", () => {
+  it("automatically migrates version 1 format to version 2 on disk", () => {
+    const cwd = tempDir();
+    const legacyConfig = {
+      network: "testnet",
+      contractId: "C_LEGACY",
+      keypairPath: "/tmp/legacy.secret",
+      tokenId: "T_LEGACY",
+    };
+    writeJson(cwd, ".ilnrc.json", legacyConfig);
+
+    const config = loadConfig({ cwd, env: {} });
+    expect(config.contractId).toBe("C_LEGACY");
+    expect(config.keypairPath).toBe("/tmp/legacy.secret");
+    expect(config.tokenId).toBe("T_LEGACY");
+
+    // Verify it was updated on disk
+    const updatedRaw = JSON.parse(readFileSync(path.join(cwd, ".ilnrc.json"), "utf8"));
+    expect(updatedRaw.version).toBe(2);
+    expect(updatedRaw.contractIds.invoice).toBe("C_LEGACY");
+    expect(updatedRaw.contractIds.token).toBe("T_LEGACY");
+    expect(updatedRaw.deployer.keypairPath).toBe("/tmp/legacy.secret");
+    expect(updatedRaw.contractId).toBeUndefined();
+    expect(updatedRaw.keypairPath).toBeUndefined();
+    expect(updatedRaw.tokenId).toBeUndefined();
+    expect(updatedRaw["$schema"]).toBe("./config.schema.json");
+  });
+
+  it("produces formatted, helpful error messages on validation failure", () => {
+    const cwd = tempDir();
+    writeJson(cwd, ".ilnrc.json", {
+      network: "invalid-network-name",
+      rpcUrl: "not-a-url",
+    });
+
+    expect(() => loadConfig({ cwd, env: {} })).toThrow(/\[Field: network\].*\[Field: rpcUrl\]/);
+  });
+});
+


### PR DESCRIPTION
closes #551

This pull request introduces configuration validation and migration layers for the CLI, ensuring configuration files are verified on load, formatting error feedback with clear field names, and providing seamless upgrades for legacy formats. The implementation also configures starter files to include JSON schema references to support IDE auto-completion.

A formal draft-07 JSON Schema has been created as cli/config.schema.json to define properties, types, and descriptions for all configuration parameters. The internal Zod validation schemas in cli/src/config.ts have been updated to support schema attributes, and the load validation has been enhanced to catch errors and print descriptive field-specific paths (e.g. [Field: network] - Invalid enum value).

To support backward compatibility, a dynamic migration helper migrateConfig() maps legacy version 1 root-level keys (such as contractId, keypairPath, and tokenId) to version 2 nested structures (contractIds.invoice, deployer.keypairPath, and contractIds.token). If changes are made to a writable JSON configuration file, it automatically rewrites the file in-place with the updated format and inserts a $schema reference.

Additionally, the initConfig function has been updated to generate a template file matching the version 2 structure and referencing the local schema. Finally, unit tests have been added to cli/tests/config-ilnrc.test.ts to verify in-place migration on disk and to validate the format of field-specific error logs.