### PR TITLE
Implement SDK offline transaction queue

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -114,6 +114,42 @@ try {
 
 Read timeouts apply to read-only contract queries, write timeouts apply to account loading, transaction preparation, submission, and polling, and simulation timeouts apply to pre-submit simulations.
 
+## Offline Transaction Queue
+
+Use the `*OrQueue` write helpers when a browser app should keep transactions
+instead of failing immediately while offline. Queued items are persisted through
+the configured storage and submitted automatically when the SDK comes back
+online.
+
+```ts
+import { ILNSdk, ILN_TESTNET, createFreighterSigner } from "@invoice-liquidity/sdk";
+
+const sdk = new ILNSdk({
+  ...ILN_TESTNET,
+  signer: createFreighterSigner(),
+});
+
+const result = await sdk.submitInvoiceOrQueue({
+  freelancer: "G...",
+  payer: "G...",
+  amount: 25_000_000n,
+  dueDate: Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60,
+  discountRate: 300,
+});
+
+if (result.queued) {
+  console.log("Queued for reconnect:", result.item.id);
+}
+```
+
+The SDK also exports a small queue management panel:
+
+```tsx
+import { OfflineQueuePanel } from "@invoice-liquidity/sdk";
+
+<OfflineQueuePanel manager={sdk.getOfflineManager()} />;
+```
+
 ## Token Amounts
 
 SDK methods accept token amounts as `bigint` base units. USDC and EURC use 6 decimals, while XLM uses 7 decimals through the native SAC wrapper. See the [multi-token support guide](../docs/tokens/multi-token-support.md) for supported tokens, trustlines, testnet acquisition, and token-aware parsing examples.
@@ -142,6 +178,11 @@ claimDefault(params: {
   funder: string;
   invoiceId: bigint;
 }): Promise<void>;
+
+submitInvoiceOrQueue(params): Promise<{ queued: false; result: bigint } | { queued: true; item: OfflineQueueItem }>;
+fundInvoiceOrQueue(params): Promise<{ queued: false; result: void } | { queued: true; item: OfflineQueueItem }>;
+markPaidOrQueue(params): Promise<{ queued: false; result: void } | { queued: true; item: OfflineQueueItem }>;
+claimDefaultOrQueue(params): Promise<{ queued: false; result: void } | { queued: true; item: OfflineQueueItem }>;
 
 getInvoice(invoiceId: bigint): Promise<Invoice>;
 ```

--- a/sdk/src/OfflineQueuePanel.tsx
+++ b/sdk/src/OfflineQueuePanel.tsx
@@ -1,0 +1,352 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import type { OfflineQueueItem, OfflineState } from "./offline";
+
+export interface OfflineQueueController {
+  getState(): OfflineState;
+  getQueue(): ReadonlyArray<OfflineQueueItem>;
+  onStateChange(callback: (state: OfflineState) => void): () => void;
+  processQueue(): Promise<void>;
+  retryItem(id: string): Promise<void>;
+  removeItem(id: string): boolean;
+  clearQueue(): void;
+}
+
+export interface OfflineQueuePanelProps {
+  manager: OfflineQueueController;
+  title?: string;
+  className?: string;
+}
+
+const EMPTY_STATE: OfflineState = {
+  isOnline: true,
+  queueSize: 0,
+  pendingCount: 0,
+  submittingCount: 0,
+  failedCount: 0,
+  lastSyncTime: null,
+};
+
+const STATUS_COLOR: Record<OfflineQueueItem["status"], string> = {
+  pending: "#f59e0b",
+  submitting: "#2563eb",
+  failed: "#dc2626",
+  completed: "#16a34a",
+};
+
+function formatOperation(operation: string): string {
+  return operation
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, (char) => char.toUpperCase())
+    .trim();
+}
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+export function OfflineQueuePanel({
+  manager,
+  title = "Offline Queue",
+  className,
+}: OfflineQueuePanelProps): React.ReactElement {
+  const [state, setState] = useState<OfflineState>(() => manager.getState() ?? EMPTY_STATE);
+  const [items, setItems] = useState<ReadonlyArray<OfflineQueueItem>>(() => manager.getQueue());
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    setState(manager.getState());
+    setItems(manager.getQueue());
+  }, [manager]);
+
+  useEffect(() => {
+    refresh();
+    return manager.onStateChange(() => refresh());
+  }, [manager, refresh]);
+
+  const queueLabel = useMemo(() => {
+    if (state.queueSize === 0) return "No queued transactions";
+    if (state.queueSize === 1) return "1 queued transaction";
+    return `${state.queueSize} queued transactions`;
+  }, [state.queueSize]);
+
+  async function runAction(actionId: string, action: () => Promise<void> | void) {
+    setBusyAction(actionId);
+    try {
+      await action();
+      refresh();
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  return (
+    <section
+      className={className}
+      aria-label="Offline transaction queue"
+      style={styles.container}
+    >
+      <header style={styles.header}>
+        <div>
+          <h2 style={styles.title}>{title}</h2>
+          <p style={styles.subtitle}>{queueLabel}</p>
+        </div>
+        <span
+          aria-label={state.isOnline ? "Online" : "Offline"}
+          style={{
+            ...styles.networkBadge,
+            color: state.isOnline ? "#166534" : "#991b1b",
+            background: state.isOnline ? "#dcfce7" : "#fee2e2",
+          }}
+        >
+          {state.isOnline ? "Online" : "Offline"}
+        </span>
+      </header>
+
+      <dl style={styles.stats} aria-label="Queue status">
+        <div style={styles.stat}>
+          <dt style={styles.statLabel}>Pending</dt>
+          <dd style={styles.statValue}>{state.pendingCount}</dd>
+        </div>
+        <div style={styles.stat}>
+          <dt style={styles.statLabel}>Submitting</dt>
+          <dd style={styles.statValue}>{state.submittingCount}</dd>
+        </div>
+        <div style={styles.stat}>
+          <dt style={styles.statLabel}>Failed</dt>
+          <dd style={styles.statValue}>{state.failedCount}</dd>
+        </div>
+      </dl>
+
+      <div style={styles.actions}>
+        <button
+          type="button"
+          style={styles.primaryButton}
+          onClick={() => runAction("process", () => manager.processQueue())}
+          disabled={!state.isOnline || state.queueSize === 0 || busyAction !== null}
+        >
+          Submit now
+        </button>
+        <button
+          type="button"
+          style={styles.secondaryButton}
+          onClick={() => runAction("clear", () => manager.clearQueue())}
+          disabled={state.queueSize === 0 || busyAction !== null}
+        >
+          Clear
+        </button>
+      </div>
+
+      {items.length === 0 ? (
+        <div style={styles.empty} role="status">
+          Queue is clear
+        </div>
+      ) : (
+        <ul style={styles.list} aria-label="Queued transactions">
+          {items.map((item) => (
+            <li key={item.id} style={styles.item}>
+              <div style={styles.itemMain}>
+                <span
+                  aria-hidden="true"
+                  style={{
+                    ...styles.statusDot,
+                    background: STATUS_COLOR[item.status],
+                  }}
+                />
+                <div style={styles.itemText}>
+                  <strong style={styles.operation}>
+                    {formatOperation(item.operation)}
+                  </strong>
+                  <span style={styles.meta}>
+                    {item.status} · {formatDate(item.updatedAt)}
+                  </span>
+                  {item.error ? <span style={styles.error}>{item.error}</span> : null}
+                </div>
+              </div>
+              <div style={styles.itemActions}>
+                {item.status === "failed" ? (
+                  <button
+                    type="button"
+                    style={styles.linkButton}
+                    onClick={() => runAction(`retry:${item.id}`, () => manager.retryItem(item.id))}
+                    disabled={busyAction !== null || !state.isOnline}
+                  >
+                    Retry
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  style={styles.linkButton}
+                  onClick={() => runAction(`remove:${item.id}`, () => {
+                    manager.removeItem(item.id);
+                  })}
+                  disabled={busyAction !== null}
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    boxSizing: "border-box",
+    width: "100%",
+    maxWidth: 720,
+    border: "1px solid #dbe3ee",
+    borderRadius: 8,
+    padding: 16,
+    background: "#ffffff",
+    color: "#0f172a",
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  },
+  header: {
+    display: "flex",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 12,
+    marginBottom: 12,
+  },
+  title: {
+    margin: 0,
+    fontSize: 16,
+    lineHeight: 1.3,
+    fontWeight: 700,
+  },
+  subtitle: {
+    margin: "3px 0 0",
+    color: "#64748b",
+    fontSize: 13,
+  },
+  networkBadge: {
+    borderRadius: 999,
+    padding: "4px 8px",
+    fontSize: 12,
+    fontWeight: 700,
+    whiteSpace: "nowrap",
+  },
+  stats: {
+    display: "grid",
+    gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+    gap: 8,
+    margin: "0 0 12px",
+  },
+  stat: {
+    border: "1px solid #e2e8f0",
+    borderRadius: 6,
+    padding: "8px 10px",
+  },
+  statLabel: {
+    margin: 0,
+    color: "#64748b",
+    fontSize: 12,
+  },
+  statValue: {
+    margin: "2px 0 0",
+    fontSize: 18,
+    fontWeight: 700,
+  },
+  actions: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 8,
+    marginBottom: 12,
+  },
+  primaryButton: {
+    border: "1px solid #0f172a",
+    borderRadius: 6,
+    background: "#0f172a",
+    color: "#ffffff",
+    cursor: "pointer",
+    fontSize: 13,
+    fontWeight: 700,
+    padding: "7px 10px",
+  },
+  secondaryButton: {
+    border: "1px solid #cbd5e1",
+    borderRadius: 6,
+    background: "#ffffff",
+    color: "#0f172a",
+    cursor: "pointer",
+    fontSize: 13,
+    fontWeight: 700,
+    padding: "7px 10px",
+  },
+  empty: {
+    border: "1px dashed #cbd5e1",
+    borderRadius: 6,
+    color: "#64748b",
+    fontSize: 13,
+    padding: "16px 12px",
+    textAlign: "center",
+  },
+  list: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
+  },
+  item: {
+    alignItems: "center",
+    border: "1px solid #e2e8f0",
+    borderRadius: 6,
+    display: "flex",
+    gap: 12,
+    justifyContent: "space-between",
+    padding: 10,
+  },
+  itemMain: {
+    alignItems: "flex-start",
+    display: "flex",
+    gap: 10,
+    minWidth: 0,
+  },
+  statusDot: {
+    borderRadius: "50%",
+    flex: "0 0 auto",
+    height: 8,
+    marginTop: 6,
+    width: 8,
+  },
+  itemText: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    minWidth: 0,
+  },
+  operation: {
+    fontSize: 14,
+    lineHeight: 1.3,
+  },
+  meta: {
+    color: "#64748b",
+    fontSize: 12,
+  },
+  error: {
+    color: "#b91c1c",
+    fontSize: 12,
+    overflowWrap: "anywhere",
+  },
+  itemActions: {
+    display: "flex",
+    flex: "0 0 auto",
+    gap: 6,
+  },
+  linkButton: {
+    background: "transparent",
+    border: "none",
+    color: "#1d4ed8",
+    cursor: "pointer",
+    fontSize: 13,
+    fontWeight: 700,
+    padding: "4px 2px",
+  },
+};
+
+export default OfflineQueuePanel;

--- a/sdk/src/__tests__/OfflineQueuePanel.test.tsx
+++ b/sdk/src/__tests__/OfflineQueuePanel.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import { OfflineQueuePanel } from "../OfflineQueuePanel";
+import { OfflineManager, createMemoryOfflineStorage } from "../offline";
+
+function createManager() {
+  return new OfflineManager({
+    storage: createMemoryOfflineStorage(),
+    storageKey: "offline_queue_panel_test",
+    maxRetries: 1,
+  });
+}
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let root: Root;
+
+  act(() => {
+    root = createRoot(container);
+    root.render(ui);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function expectText(container: HTMLElement, text: string) {
+  expect(container.textContent).toContain(text);
+}
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find(
+    (element) => element.textContent === text,
+  );
+
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button "${text}" not found`);
+  }
+
+  return button;
+}
+
+describe("OfflineQueuePanel", () => {
+  it("renders empty queue status", () => {
+    const manager = createManager();
+    const view = render(<OfflineQueuePanel manager={manager} />);
+
+    expectText(view.container, "Offline Queue");
+    expectText(view.container, "No queued transactions");
+    expectText(view.container, "Queue is clear");
+
+    view.unmount();
+    manager.destroy();
+  });
+
+  it("renders queued transactions and clears them", async () => {
+    const manager = createManager();
+    const view = render(<OfflineQueuePanel manager={manager} />);
+
+    act(() => {
+      manager.enqueue("submitInvoice", { amount: 1000n });
+    });
+
+    expectText(view.container, "Submit Invoice");
+    expectText(view.container, "1 queued transaction");
+
+    await act(async () => {
+      buttonByText(view.container, "Clear").click();
+    });
+
+    expectText(view.container, "Queue is clear");
+    view.unmount();
+    manager.destroy();
+  });
+
+  it("removes a single queued transaction", async () => {
+    const manager = createManager();
+    const view = render(<OfflineQueuePanel manager={manager} />);
+
+    act(() => {
+      manager.enqueue("fundInvoice", { invoiceId: 1n });
+    });
+
+    expectText(view.container, "Fund Invoice");
+
+    await act(async () => {
+      buttonByText(view.container, "Remove").click();
+    });
+
+    expectText(view.container, "No queued transactions");
+    view.unmount();
+    manager.destroy();
+  });
+});

--- a/sdk/src/__tests__/offline-client.test.ts
+++ b/sdk/src/__tests__/offline-client.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { ILNSdk } from "../client";
+import { createMemoryOfflineStorage } from "../offline";
+import type { RpcServerLike } from "../types";
+
+const server = {
+  getAccount: async () => {
+    throw new Error("network should not be called while offline");
+  },
+  simulateTransaction: async () => {
+    throw new Error("network should not be called while offline");
+  },
+  prepareTransaction: async () => {
+    throw new Error("network should not be called while offline");
+  },
+  sendTransaction: async () => {
+    throw new Error("network should not be called while offline");
+  },
+  pollTransaction: async () => {
+    throw new Error("network should not be called while offline");
+  },
+} satisfies RpcServerLike;
+
+describe("ILNSdk offline queue integration", () => {
+  it("queues invoice submissions instead of touching the network while offline", async () => {
+    const client = new ILNSdk({
+      contractId: "C_TEST_CONTRACT_ID",
+      rpcUrl: "https://rpc.example.test",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      server,
+      offline: {
+        storage: createMemoryOfflineStorage(),
+        storageKey: "client_queue",
+      },
+    });
+
+    client.setOfflineQueueOnline(false);
+
+    const result = await client.submitInvoiceOrQueue({
+      freelancer: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      payer: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      amount: 1000n,
+      dueDate: 1_800_000_000,
+      discountRate: 300,
+    });
+
+    expect(result.queued).toBe(true);
+    expect(client.getOfflineState()).toMatchObject({
+      isOnline: false,
+      queueSize: 1,
+      pendingCount: 1,
+    });
+    expect(client.getOfflineQueue()[0].operation).toBe("submitInvoice");
+  });
+});

--- a/sdk/src/__tests__/offline.test.ts
+++ b/sdk/src/__tests__/offline.test.ts
@@ -1,59 +1,94 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { OfflineManager, type OfflineConfig, type OfflineQueueItem } from "../offline";
+import {
+  OfflineManager,
+  createMemoryOfflineStorage,
+  type OfflineStorage,
+} from "../offline";
 
 describe("OfflineManager", () => {
   let manager: OfflineManager;
+  let storage: OfflineStorage;
 
   beforeEach(() => {
+    storage = createMemoryOfflineStorage();
     manager = new OfflineManager({
       maxRetries: 2,
       retryDelayMs: 100,
       maxQueueSize: 5,
+      storage,
+      storageKey: "test_queue",
     });
   });
 
   afterEach(() => {
     manager.destroy();
+    vi.useRealTimers();
   });
 
   describe("constructor", () => {
-    it("should create an instance with default config", () => {
-      const m = new OfflineManager();
-      expect(m).toBeDefined();
+    it("creates an instance with default config", () => {
+      const m = new OfflineManager({ storage: createMemoryOfflineStorage() });
       expect(m.getState().isOnline).toBe(true);
       expect(m.getState().queueSize).toBe(0);
+      m.destroy();
     });
 
-    it("should create an instance with custom config", () => {
-      const m = new OfflineManager({
-        maxRetries: 5,
-        retryDelayMs: 1000,
+    it("loads persisted queue items from storage", () => {
+      const firstManager = new OfflineManager({
+        storage,
+        storageKey: "persistent_queue",
       });
-      expect(m).toBeDefined();
+
+      firstManager.enqueue("submitInvoice", {
+        amount: 1000n,
+        invoiceId: 42n,
+      });
+      firstManager.destroy();
+
+      const secondManager = new OfflineManager({
+        storage,
+        storageKey: "persistent_queue",
+      });
+
+      const [item] = secondManager.getQueue();
+      expect(secondManager.getState().queueSize).toBe(1);
+      expect(item.params).toEqual({ amount: 1000n, invoiceId: 42n });
+      secondManager.destroy();
+    });
+
+    it("ignores invalid persisted queue payloads", () => {
+      storage.setItem("bad_queue", JSON.stringify({ nope: true }));
+      const m = new OfflineManager({ storage, storageKey: "bad_queue" });
+      expect(m.getQueue()).toEqual([]);
+      m.destroy();
     });
   });
 
   describe("enqueue", () => {
-    it("should add an item to the queue", () => {
+    it("adds an item to the queue", () => {
       const item = manager.enqueue("submitInvoice", { amount: 100 });
-      expect(item).toBeDefined();
       expect(item.id).toMatch(/^offline_/);
       expect(item.operation).toBe("submitInvoice");
       expect(item.params).toEqual({ amount: 100 });
       expect(item.status).toBe("pending");
-      expect(manager.getState().queueSize).toBe(1);
+      expect(manager.getState()).toMatchObject({
+        queueSize: 1,
+        pendingCount: 1,
+        failedCount: 0,
+      });
     });
 
-    it("should throw when queue is full", () => {
-      for (let i = 0; i < 5; i++) {
+    it("throws when queue is full", () => {
+      for (let i = 0; i < 5; i += 1) {
         manager.enqueue("op", { i });
       }
+
       expect(() => manager.enqueue("op", {})).toThrow("Queue is full");
     });
   });
 
   describe("processQueue", () => {
-    it("should process pending items when online", async () => {
+    it("processes pending items when online", async () => {
       const submitFn = vi.fn().mockResolvedValue(true);
       manager.onSubmit(submitFn);
 
@@ -64,9 +99,10 @@ describe("OfflineManager", () => {
 
       expect(submitFn).toHaveBeenCalledTimes(2);
       expect(manager.getState().queueSize).toBe(0);
+      expect(manager.getState().lastSyncTime).toEqual(expect.any(Number));
     });
 
-    it("should not process when offline", async () => {
+    it("does not process when offline", async () => {
       const submitFn = vi.fn().mockResolvedValue(true);
       manager.onSubmit(submitFn);
       manager.setOnline(false);
@@ -78,72 +114,98 @@ describe("OfflineManager", () => {
       expect(manager.getState().queueSize).toBe(1);
     });
 
-    it("should retry failed submissions", async () => {
-      const submitFn = vi.fn()
-        .mockRejectedValueOnce(new Error("Network error"))
-        .mockResolvedValue(true);
-
+    it("auto-submits queued items when the SDK comes back online", async () => {
+      const submitFn = vi.fn().mockResolvedValue(true);
       manager.onSubmit(submitFn);
+      manager.setOnline(false);
       manager.enqueue("op1", {});
 
-      await manager.processQueue();
+      manager.setOnline(true);
+      await Promise.resolve();
+      await Promise.resolve();
 
-      // Should have retried once
       expect(submitFn).toHaveBeenCalledTimes(1);
-      expect(manager.getState().queueSize).toBe(1);
+      expect(manager.getState().queueSize).toBe(0);
     });
 
-    it("should mark item as failed after max retries", async () => {
-      const submitFn = vi.fn().mockRejectedValue(new Error("Always fail"));
-      manager.onSubmit(submitFn);
+    it("keeps failed submissions pending until max retries is reached", async () => {
+      const submitFn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Network error"))
+        .mockResolvedValueOnce(true);
 
+      manager.onSubmit(submitFn);
       manager.enqueue("op1", {});
+
       await manager.processQueue();
 
-      // Should have retried and failed
       expect(submitFn).toHaveBeenCalledTimes(1);
-      expect(manager.getState().failedCount).toBe(1);
+      expect(manager.getState().pendingCount).toBe(1);
+
+      await manager.processQueue();
+
+      expect(submitFn).toHaveBeenCalledTimes(2);
+      expect(manager.getState().queueSize).toBe(0);
+    });
+
+    it("marks an item as failed after max retries", async () => {
+      const failingManager = new OfflineManager({
+        maxRetries: 1,
+        storage,
+        storageKey: "fail_queue",
+      });
+      const submitFn = vi.fn().mockRejectedValue(new Error("Always fail"));
+      failingManager.onSubmit(submitFn);
+
+      failingManager.enqueue("op1", {});
+      await failingManager.processQueue();
+
+      expect(submitFn).toHaveBeenCalledTimes(1);
+      expect(failingManager.getState().failedCount).toBe(1);
+      expect(failingManager.getQueue()[0].error).toContain("Always fail");
+      failingManager.destroy();
     });
   });
 
   describe("retryItem", () => {
-    it("should retry a failed item", async () => {
-      const submitFn = vi.fn().mockResolvedValue(true);
-      manager.onSubmit(submitFn);
+    it("retries a failed item and removes it when submission succeeds", async () => {
+      const retryManager = new OfflineManager({
+        maxRetries: 1,
+        storage,
+        storageKey: "retry_queue",
+      });
+      const submitFn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Network error"))
+        .mockResolvedValueOnce(true);
+      retryManager.onSubmit(submitFn);
 
-      const item = manager.enqueue("op1", {});
-      item.status = "failed";
-      item.retries = 3;
+      const item = retryManager.enqueue("op1", {});
+      await retryManager.processQueue();
+      await retryManager.retryItem(item.id);
 
-      await manager.retryItem(item.id);
-
-      expect(item.status).toBe("pending");
-      expect(item.retries).toBe(0);
+      expect(submitFn).toHaveBeenCalledTimes(2);
+      expect(retryManager.getState().queueSize).toBe(0);
+      retryManager.destroy();
     });
 
-    it("should throw for non-existent item", async () => {
+    it("throws for non-existent items", async () => {
       await expect(manager.retryItem("nonexistent")).rejects.toThrow("not found");
     });
   });
 
-  describe("removeItem", () => {
-    it("should remove an item from the queue", () => {
+  describe("queue management", () => {
+    it("removes an item from the queue", () => {
       const item = manager.enqueue("op1", {});
-      expect(manager.getState().queueSize).toBe(1);
-
-      const removed = manager.removeItem(item.id);
-      expect(removed).toBe(true);
+      expect(manager.removeItem(item.id)).toBe(true);
       expect(manager.getState().queueSize).toBe(0);
     });
 
-    it("should return false for non-existent item", () => {
-      const removed = manager.removeItem("nonexistent");
-      expect(removed).toBe(false);
+    it("returns false when removing a non-existent item", () => {
+      expect(manager.removeItem("nonexistent")).toBe(false);
     });
-  });
 
-  describe("clearQueue", () => {
-    it("should clear all items", () => {
+    it("clears all items", () => {
       manager.enqueue("op1", {});
       manager.enqueue("op2", {});
       expect(manager.getState().queueSize).toBe(2);
@@ -151,22 +213,18 @@ describe("OfflineManager", () => {
       manager.clearQueue();
       expect(manager.getState().queueSize).toBe(0);
     });
-  });
 
-  describe("getQueue", () => {
-    it("should return a copy of the queue", () => {
+    it("returns a copy of the queue array", () => {
       manager.enqueue("op1", {});
       const queue = manager.getQueue();
-      expect(queue).toHaveLength(1);
+      (queue as unknown[]).push({ id: "fake" });
 
-      // Modifying the copy shouldn't affect the original
-      (queue as any).push({ id: "fake" });
       expect(manager.getQueue()).toHaveLength(1);
     });
   });
 
   describe("state management", () => {
-    it("should track online status", () => {
+    it("tracks online status", () => {
       expect(manager.getIsOnline()).toBe(true);
 
       manager.setOnline(false);
@@ -177,15 +235,17 @@ describe("OfflineManager", () => {
       expect(manager.getIsOnline()).toBe(true);
     });
 
-    it("should notify listeners on state change", () => {
+    it("notifies listeners on state change", () => {
       const listener = vi.fn();
       manager.onStateChange(listener);
 
       manager.enqueue("op1", {});
-      expect(listener).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ queueSize: 1 }),
+      );
     });
 
-    it("should unsubscribe listeners", () => {
+    it("unsubscribes listeners", () => {
       const listener = vi.fn();
       const unsubscribe = manager.onStateChange(listener);
 
@@ -199,13 +259,13 @@ describe("OfflineManager", () => {
   });
 
   describe("exportData", () => {
-    it("should export queue data", () => {
+    it("exports queue data", () => {
       manager.enqueue("op1", { data: "test" });
       const data = manager.exportData();
 
-      expect(data).toBeDefined();
       expect(data.queue).toHaveLength(1);
       expect(data.queue[0].operation).toBe("op1");
+      expect(data.state.queueSize).toBe(1);
     });
   });
 });

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -13,6 +13,11 @@ import { createLogger } from "./logger";
 import { track } from "./usage-analytics";
 import { Cache, type CacheOptions } from "./cache";
 import { Validators } from "./validators";
+import {
+  OfflineManager,
+  type OfflineQueueItem,
+  type OfflineState,
+} from "./offline";
 
 import type { Invoice, InvoiceState } from "@iln/shared";
 
@@ -35,7 +40,6 @@ import type {
 
 import { openSSE } from "./stream";
 import { ILNEventEmitter } from "./event-emitter";
-import type { InvoiceEventData, WalletEventData, ErrorEventData } from "./event-emitter";
 
 export type EventCallback = (event: ContractEvent) => void | Promise<void>;
 export type Unsubscribe = () => void;
@@ -62,6 +66,16 @@ const READ_ACCOUNT = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 const POLL_ATTEMPTS = 20;
 const PROTOCOL_CONFIG_CACHE_MS = 5 * 60 * 1000;
 
+export type OfflineTransactionOperation =
+  | "submitInvoice"
+  | "fundInvoice"
+  | "markPaid"
+  | "claimDefault";
+
+export type OfflineTransactionResult<T> =
+  | { queued: false; result: T }
+  | { queued: true; item: OfflineQueueItem };
+
 type PreparedTransactionLike = { toXDR(): string };
 type BuiltTransaction = ReturnType<TransactionBuilder["build"]>;
 type TransactionOperation = Parameters<TransactionBuilder["addOperation"]>[0];
@@ -84,6 +98,7 @@ export class ILNSdk {
   private readonly analyticsNetwork: string;
   private readonly cache: Cache<unknown>;
   private readonly cacheEnabled: boolean;
+  private readonly offlineManager: OfflineManager;
 
   constructor(config: ILNSdkConfig) {
     this.contractId = config.contractId;
@@ -97,6 +112,8 @@ export class ILNSdk {
     const cacheConfig = config.cache ?? { ttl: 60000, storage: "memory", enabled: true };
     this.cache = new Cache(cacheConfig);
     this.cacheEnabled = cacheConfig.enabled ?? true;
+    this.offlineManager = new OfflineManager(config.offline);
+    this.offlineManager.onSubmit((item) => this.submitQueuedOfflineItem(item));
   }
 
   private async wrapRpcCall<T>(promise: Promise<T>, operationName: string): Promise<T> {
@@ -533,6 +550,12 @@ export class ILNSdk {
     }
   }
 
+  async submitInvoiceOrQueue(
+    params: SubmitInvoiceParams,
+  ): Promise<OfflineTransactionResult<bigint>> {
+    return this.runOrQueue("submitInvoice", params, () => this.submitInvoice(params));
+  }
+
   async fundInvoice(params: FundInvoiceParams): Promise<void> {
     Validators.assertValid(Validators.validateFunding(params), "fundInvoice");
     
@@ -573,6 +596,12 @@ export class ILNSdk {
     }
   }
 
+  async fundInvoiceOrQueue(
+    params: FundInvoiceParams,
+  ): Promise<OfflineTransactionResult<void>> {
+    return this.runOrQueue("fundInvoice", params, () => this.fundInvoice(params));
+  }
+
   async markPaid(params: MarkPaidParams): Promise<void> {
     Validators.assertValid(Validators.validatePayment(params), "markPaid");
     
@@ -607,6 +636,12 @@ export class ILNSdk {
     }
   }
 
+  async markPaidOrQueue(
+    params: MarkPaidParams,
+  ): Promise<OfflineTransactionResult<void>> {
+    return this.runOrQueue("markPaid", params, () => this.markPaid(params));
+  }
+
   async claimDefault(params: ClaimDefaultParams): Promise<void> {
     const signerAddress = await this.requireSignerAddress();
 
@@ -638,6 +673,88 @@ export class ILNSdk {
     } catch (err: any) {
       track("claimDefault", this.analyticsNetwork, false, err?.code ?? err?.name);
       throw err;
+    }
+  }
+
+  async claimDefaultOrQueue(
+    params: ClaimDefaultParams,
+  ): Promise<OfflineTransactionResult<void>> {
+    return this.runOrQueue("claimDefault", params, () => this.claimDefault(params));
+  }
+
+  queueOfflineTransaction(
+    operation: OfflineTransactionOperation,
+    params: unknown,
+  ): OfflineQueueItem {
+    return this.offlineManager.enqueue(operation, params);
+  }
+
+  getOfflineManager(): OfflineManager {
+    return this.offlineManager;
+  }
+
+  getOfflineState(): OfflineState {
+    return this.offlineManager.getState();
+  }
+
+  getOfflineQueue(): ReadonlyArray<OfflineQueueItem> {
+    return this.offlineManager.getQueue();
+  }
+
+  processOfflineQueue(): Promise<void> {
+    return this.offlineManager.processQueue();
+  }
+
+  retryOfflineQueueItem(id: string): Promise<void> {
+    return this.offlineManager.retryItem(id);
+  }
+
+  removeOfflineQueueItem(id: string): boolean {
+    return this.offlineManager.removeItem(id);
+  }
+
+  clearOfflineQueue(): void {
+    this.offlineManager.clearQueue();
+  }
+
+  setOfflineQueueOnline(online: boolean): void {
+    this.offlineManager.setOnline(online);
+  }
+
+  private async runOrQueue<T>(
+    operation: OfflineTransactionOperation,
+    params: unknown,
+    submit: () => Promise<T>,
+  ): Promise<OfflineTransactionResult<T>> {
+    if (!this.offlineManager.getIsOnline()) {
+      return {
+        queued: true,
+        item: this.offlineManager.enqueue(operation, params),
+      };
+    }
+
+    return {
+      queued: false,
+      result: await submit(),
+    };
+  }
+
+  private async submitQueuedOfflineItem(item: OfflineQueueItem): Promise<boolean> {
+    switch (item.operation as OfflineTransactionOperation) {
+      case "submitInvoice":
+        await this.submitInvoice(item.params as SubmitInvoiceParams);
+        return true;
+      case "fundInvoice":
+        await this.fundInvoice(item.params as FundInvoiceParams);
+        return true;
+      case "markPaid":
+        await this.markPaid(item.params as MarkPaidParams);
+        return true;
+      case "claimDefault":
+        await this.claimDefault(item.params as ClaimDefaultParams);
+        return true;
+      default:
+        throw new Error(`Unsupported offline operation: ${item.operation}`);
     }
   }
 
@@ -968,9 +1085,13 @@ export class ILNSdk {
         "discountRate",
       ),
       status: this.parseStatus(nativeInvoice.status),
-      funder: nativeInvoice.funder == null ? null : this.toStringValue(nativeInvoice.funder, "funder"),
+      funder:
+        nativeInvoice.funder === null || nativeInvoice.funder === undefined
+          ? null
+          : this.toStringValue(nativeInvoice.funder, "funder"),
       fundedAt:
-        nativeInvoice.funded_at == null && nativeInvoice.fundedAt == null
+        (nativeInvoice.funded_at === null || nativeInvoice.funded_at === undefined) &&
+        (nativeInvoice.fundedAt === null || nativeInvoice.fundedAt === undefined)
           ? null
           : this.toNumberValue(nativeInvoice.funded_at ?? nativeInvoice.fundedAt, "fundedAt"),
     };

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -14,6 +14,11 @@ export * from "./federation";
 export * from "./governance";
 export * from "./errors";
 export * from "./offline";
+export { OfflineQueuePanel } from "./OfflineQueuePanel";
+export type {
+  OfflineQueueController,
+  OfflineQueuePanelProps,
+} from "./OfflineQueuePanel";
 export * from "./event-emitter";
 export * from "./recovery";
 export * from "./plugins";

--- a/sdk/src/offline.ts
+++ b/sdk/src/offline.ts
@@ -17,6 +17,7 @@ export interface OfflineQueueItem {
   operation: string;
   params: unknown;
   timestamp: number;
+  updatedAt: number;
   retries: number;
   maxRetries: number;
   status: "pending" | "submitting" | "failed" | "completed";
@@ -46,7 +47,9 @@ export interface OfflineState {
   isOnline: boolean;
   queueSize: number;
   pendingCount: number;
+  submittingCount: number;
   failedCount: number;
+  lastSyncTime: number | null;
 }
 
 export type StateChangeCallback = (state: OfflineState) => void;
@@ -61,15 +64,91 @@ const DEFAULT_CONFIG: Required<OfflineConfig> = {
   retryDelayMs: 5000,
   maxQueueSize: 100,
   storageKey: "iln_offline_queue",
-  storage: typeof localStorage !== "undefined" ? localStorage : createMemoryStorage(),
+  storage: getDefaultStorage(),
 };
 
-function createMemoryStorage(): OfflineStorage {
+export function createMemoryOfflineStorage(): OfflineStorage {
   const store = new Map<string, string>();
   return {
     getItem: (key) => store.get(key) ?? null,
     setItem: (key, value) => store.set(key, value),
     removeItem: (key) => store.delete(key),
+  };
+}
+
+function getDefaultStorage(): OfflineStorage {
+  return typeof localStorage !== "undefined" ? localStorage : createMemoryOfflineStorage();
+}
+
+function detectOnline(): boolean {
+  if (typeof navigator !== "undefined" && typeof navigator.onLine === "boolean") {
+    return navigator.onLine;
+  }
+
+  return true;
+}
+
+function stringifyQueue(queue: OfflineQueueItem[]): string {
+  return JSON.stringify(queue, (_key, value) => {
+    if (typeof value === "bigint") {
+      return { __ilnBigInt: value.toString() };
+    }
+
+    return value;
+  });
+}
+
+function parseQueue(value: string): OfflineQueueItem[] {
+  const parsed = JSON.parse(value, (_key, item) => {
+    if (
+      item &&
+      typeof item === "object" &&
+      typeof item.__ilnBigInt === "string" &&
+      Object.keys(item).length === 1
+    ) {
+      return BigInt(item.__ilnBigInt);
+    }
+
+    return item;
+  });
+
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  return parsed
+    .map(normalizeQueueItem)
+    .filter((item): item is OfflineQueueItem => item !== null);
+}
+
+function normalizeQueueItem(value: unknown): OfflineQueueItem | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const item = value as Partial<OfflineQueueItem>;
+  if (
+    typeof item.id !== "string" ||
+    typeof item.operation !== "string" ||
+    typeof item.timestamp !== "number"
+  ) {
+    return null;
+  }
+
+  const status = item.status === "failed" || item.status === "completed"
+    ? item.status
+    : "pending";
+
+  return {
+    id: item.id,
+    operation: item.operation,
+    params: item.params,
+    timestamp: item.timestamp,
+    updatedAt: typeof item.updatedAt === "number" ? item.updatedAt : item.timestamp,
+    retries: typeof item.retries === "number" ? item.retries : 0,
+    maxRetries: typeof item.maxRetries === "number" ? item.maxRetries : DEFAULT_CONFIG.maxRetries,
+    status,
+    error: typeof item.error === "string" ? item.error : undefined,
   };
 }
 
@@ -80,10 +159,12 @@ function createMemoryStorage(): OfflineStorage {
 export class OfflineManager {
   private queue: OfflineQueueItem[] = [];
   private config: Required<OfflineConfig>;
-  private isOnline: boolean = typeof navigator !== "undefined" ? navigator.onLine : true;
+  private isOnline: boolean = detectOnline();
+  private lastSyncTime: number | null = null;
   private listeners: Set<StateChangeCallback> = new Set();
   private submitCallback: SubmitCallback | null = null;
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private isProcessing = false;
 
   constructor(config: OfflineConfig = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config };
@@ -116,7 +197,9 @@ export class OfflineManager {
       isOnline: this.isOnline,
       queueSize: this.queue.length,
       pendingCount: this.queue.filter((i) => i.status === "pending").length,
+      submittingCount: this.queue.filter((i) => i.status === "submitting").length,
       failedCount: this.queue.filter((i) => i.status === "failed").length,
+      lastSyncTime: this.lastSyncTime,
     };
   }
 
@@ -133,6 +216,7 @@ export class OfflineManager {
       operation,
       params,
       timestamp: Date.now(),
+      updatedAt: Date.now(),
       retries: 0,
       maxRetries: this.config.maxRetries,
       status: "pending",
@@ -142,7 +226,7 @@ export class OfflineManager {
     this.saveQueue();
     this.notifyListeners();
 
-    logger.debug(`Enqueued operation: ${operation} (id: ${item.id})`);
+    logger(`Enqueued operation: ${operation} (id: ${item.id})`);
     return item;
   }
 
@@ -150,38 +234,47 @@ export class OfflineManager {
    * Manually trigger processing of the queue.
    */
   async processQueue(): Promise<void> {
-    if (!this.isOnline || !this.submitCallback) {
+    if (!this.isOnline || !this.submitCallback || this.isProcessing) {
       return;
     }
 
-    const pending = this.queue.filter((i) => i.status === "pending");
+    this.isProcessing = true;
 
-    for (const item of pending) {
-      if (!this.isOnline) break;
+    try {
+      const pending = this.queue.filter((i) => i.status === "pending");
 
-      item.status = "submitting";
-      this.notifyListeners();
+      for (const item of pending) {
+        if (!this.isOnline) break;
 
-      try {
-        const success = await this.submitCallback(item);
-        if (success) {
-          item.status = "completed";
-          logger.debug(`Successfully submitted: ${item.operation} (id: ${item.id})`);
-        } else {
-          this.handleFailedSubmission(item, "Submission returned false");
+        item.status = "submitting";
+        item.updatedAt = Date.now();
+        this.saveQueue();
+        this.notifyListeners();
+
+        try {
+          const success = await this.submitCallback(item);
+          if (success) {
+            item.status = "completed";
+            item.updatedAt = Date.now();
+            this.lastSyncTime = item.updatedAt;
+            logger(`Successfully submitted: ${item.operation} (id: ${item.id})`);
+          } else {
+            this.handleFailedSubmission(item, "Submission returned false");
+          }
+        } catch (error) {
+          this.handleFailedSubmission(item, String(error));
         }
-      } catch (error) {
-        this.handleFailedSubmission(item, String(error));
+
+        this.saveQueue();
+        this.notifyListeners();
       }
 
+      this.queue = this.queue.filter((i) => i.status !== "completed");
       this.saveQueue();
       this.notifyListeners();
+    } finally {
+      this.isProcessing = false;
     }
-
-    // Clean up completed items
-    this.queue = this.queue.filter((i) => i.status !== "completed");
-    this.saveQueue();
-    this.notifyListeners();
   }
 
   /**
@@ -196,6 +289,7 @@ export class OfflineManager {
     item.status = "pending";
     item.retries = 0;
     item.error = undefined;
+    item.updatedAt = Date.now();
     this.saveQueue();
     this.notifyListeners();
 
@@ -220,6 +314,7 @@ export class OfflineManager {
    */
   clearQueue(): void {
     this.queue = [];
+    this.config.storage.removeItem(this.config.storageKey);
     this.saveQueue();
     this.notifyListeners();
   }
@@ -248,10 +343,10 @@ export class OfflineManager {
     this.notifyListeners();
 
     if (online) {
-      logger.info("SDK is back online, processing queue...");
+      logger("SDK is back online, processing queue...");
       this.processQueue();
     } else {
-      logger.info("SDK is offline, operations will be queued");
+      logger("SDK is offline, operations will be queued");
     }
   }
 
@@ -260,7 +355,7 @@ export class OfflineManager {
    */
   exportData(): { queue: OfflineQueueItem[]; state: OfflineState } {
     return {
-      queue: this.getQueue(),
+      queue: [...this.getQueue()],
       state: this.getState(),
     };
   }
@@ -299,13 +394,14 @@ export class OfflineManager {
   private handleFailedSubmission(item: OfflineQueueItem, error: string): void {
     item.retries++;
     item.error = error;
+    item.updatedAt = Date.now();
 
     if (item.retries >= item.maxRetries) {
       item.status = "failed";
-      logger.error(`Failed to submit ${item.operation} after ${item.retries} retries: ${error}`);
+      logger(`Failed to submit ${item.operation} after ${item.retries} retries: ${error}`);
     } else {
       item.status = "pending";
-      logger.warn(`Retry ${item.retries}/${item.maxRetries} for ${item.operation}: ${error}`);
+      logger(`Retry ${item.retries}/${item.maxRetries} for ${item.operation}: ${error}`);
 
       // Schedule retry
       if (this.retryTimer) clearTimeout(this.retryTimer);
@@ -323,20 +419,20 @@ export class OfflineManager {
     try {
       const stored = this.config.storage.getItem(this.config.storageKey);
       if (stored) {
-        this.queue = JSON.parse(stored);
-        logger.debug(`Loaded ${this.queue.length} items from storage`);
+        this.queue = parseQueue(stored);
+        logger(`Loaded ${this.queue.length} items from storage`);
       }
     } catch (error) {
-      logger.error(`Failed to load queue from storage: ${error}`);
+      logger(`Failed to load queue from storage: ${error}`);
       this.queue = [];
     }
   }
 
   private saveQueue(): void {
     try {
-      this.config.storage.setItem(this.config.storageKey, JSON.stringify(this.queue));
+      this.config.storage.setItem(this.config.storageKey, stringifyQueue(this.queue));
     } catch (error) {
-      logger.error(`Failed to save queue to storage: ${error}`);
+      logger(`Failed to save queue to storage: ${error}`);
     }
   }
 
@@ -346,7 +442,7 @@ export class OfflineManager {
       try {
         listener(state);
       } catch (error) {
-        logger.error(`Error in state change listener: ${error}`);
+        logger(`Error in state change listener: ${error}`);
       }
     }
   }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,3 +1,5 @@
+import type { OfflineConfig } from "./offline";
+
 export type {
   ContractEvent,
   ContractStats,
@@ -92,6 +94,7 @@ export interface ILNSdkConfig {
     simulationMs?: number;
   };
   cache?: CacheConfig;
+  offline?: OfflineConfig;
 }
 
 export interface NetworkConfig {
@@ -216,26 +219,6 @@ export interface CircuitBreakerState {
   failures: number;
   lastFailureTime: number | null;
   state: "closed" | "open" | "half-open";
-}
-
-export interface OfflineConfig {
-  maxQueueSize: number;
-  retryIntervalMs: number;
-  maxRetries: number;
-}
-
-export interface OfflineQueueItem {
-  id: string;
-  operation: string;
-  params: unknown;
-  timestamp: number;
-  retries: number;
-}
-
-export interface OfflineState {
-  isOnline: boolean;
-  queueSize: number;
-  lastSyncTime: number | null;
 }
 
 export interface ValidationResult {

--- a/sdk/vitest.config.ts
+++ b/sdk/vitest.config.ts
@@ -5,6 +5,7 @@ export default mergeConfig(base, {
   test: {
     include: [
       "src/**/*.test.ts",
+      "src/**/*.test.tsx",
       "__tests__/**/*.test.ts",
       "tests/**/*.test.ts",
       "../packages/sdk/tests/**/*.test.ts",


### PR DESCRIPTION
Closes #580.

This adds an offline transaction queue to the SDK so browser apps can keep write operations when connectivity drops and submit them again after reconnect.

What changed:
- added persistent offline queue storage with bigint-safe serialization
- wired queue helpers into the SDK: submit/fund/mark-paid/claim-default OrQueue methods
- added reconnect processing, retry, remove, clear, and queue status APIs
- added a small React queue management panel for reviewing and managing queued transactions
- documented the queue flow in the SDK README

Checked locally:
- `npx vitest run src/__tests__/offline.test.ts src/__tests__/offline-client.test.ts src/__tests__/OfflineQueuePanel.test.tsx`
- `npx eslint src/offline.ts src/client.ts src/types.ts src/index.ts src/OfflineQueuePanel.tsx src/__tests__/offline.test.ts src/__tests__/offline-client.test.ts src/__tests__/OfflineQueuePanel.test.tsx`

Note: the SDK-wide `tsc --noEmit` still reports existing unrelated type errors in the repo, mostly around older exports, Stellar SDK types, and shared event types. I kept this PR focused on the offline queue.