### PR TITLE
feat: add SDK React components, profiling script, testing utilities, and notification rate limiting

### DIFF
--- a/.changeset/feat-583-584-585-586.md
+++ b/.changeset/feat-583-584-585-586.md
@@ -1,0 +1,11 @@
+---
+"@iln/react": minor
+"@iln/test-utils": minor
+---
+
+feat: add SDK React components, performance profiling script, testing utilities, and notification rate limiting
+
+- (#583) Add five reusable React components to `@iln/react`: `InvoiceCard`, `StatusBadge`, `AddressDisplay`, `AmountDisplay`, and `ThemeProvider` with CSS-variable-based theming
+- (#584) Add `scripts/profile.ts` performance profiler with execution time and memory measurement, bottleneck detection, and Markdown + JSON report generation
+- (#585) Extend `@iln/test-utils` with `createMockILNClient`, typed assertion helpers (`assertValidInvoice`, `assertInvoiceStatus`, `assertAmountClose`, `assertRejects`, `assertSortedByAmountDesc`), and `setupILNTestEnvironment` test setup utility
+- (#586) Add in-memory sliding-window rate limiter (`RateLimiter`) to the notifications service with per-user and per-channel limits, `X-RateLimit-*` response headers, and graceful 429 degradation

--- a/notifications/src/__tests__/rate-limiter.test.ts
+++ b/notifications/src/__tests__/rate-limiter.test.ts
@@ -1,0 +1,121 @@
+process.env.NOTIFICATIONS_RPC_URL = "http://localhost:8000";
+process.env.NOTIFICATIONS_CONTRACT_ID = "GTESTCONTRACT";
+process.env.NOTIFICATIONS_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+process.env.RESEND_API_KEY = "test-api-key";
+
+import { beforeEach, describe, expect, it } from "vitest";
+import request from "supertest";
+import Database from "better-sqlite3";
+import { createApp } from "../api";
+import { createDb, setDb } from "../db";
+import { RateLimiter } from "../rate-limiter";
+
+describe("RateLimiter unit", () => {
+  it("allows requests within the limit", () => {
+    const rl = new RateLimiter({ perUserLimit: 3, perChannelLimit: 10, windowMs: 60_000 });
+    const r1 = rl.check("user1", "email");
+    expect(r1.allowed).toBe(true);
+    expect(r1.remaining).toBe(2);
+
+    const r2 = rl.check("user1", "email");
+    expect(r2.allowed).toBe(true);
+    expect(r2.remaining).toBe(1);
+  });
+
+  it("blocks when per-user limit is exceeded", () => {
+    const rl = new RateLimiter({ perUserLimit: 2, perChannelLimit: 100, windowMs: 60_000 });
+    rl.check("user1", "email");
+    rl.check("user1", "email");
+    const r = rl.check("user1", "email");
+    expect(r.allowed).toBe(false);
+    expect(r.remaining).toBe(0);
+  });
+
+  it("blocks when per-channel limit is exceeded", () => {
+    const rl = new RateLimiter({ perUserLimit: 100, perChannelLimit: 2, windowMs: 60_000 });
+    rl.check("user1", "webhook");
+    rl.check("user2", "webhook");
+    const r = rl.check("user3", "webhook");
+    expect(r.allowed).toBe(false);
+    expect(r.remaining).toBe(0);
+  });
+
+  it("tracks different users independently", () => {
+    const rl = new RateLimiter({ perUserLimit: 2, perChannelLimit: 100, windowMs: 60_000 });
+    rl.check("userA", "email");
+    rl.check("userA", "email");
+    const blocked = rl.check("userA", "email");
+    expect(blocked.allowed).toBe(false);
+
+    const other = rl.check("userB", "email");
+    expect(other.allowed).toBe(true);
+  });
+
+  it("sets limit and resetAt in result", () => {
+    const rl = new RateLimiter({ perUserLimit: 5, perChannelLimit: 10, windowMs: 60_000 });
+    const r = rl.check("user1", "email");
+    expect(r.limit).toBe(5);
+    expect(typeof r.resetAt).toBe("number");
+    expect(r.resetAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it("resets a user bucket", () => {
+    const rl = new RateLimiter({ perUserLimit: 1, perChannelLimit: 100, windowMs: 60_000 });
+    rl.check("user1", "email");
+    const blocked = rl.check("user1", "email");
+    expect(blocked.allowed).toBe(false);
+
+    rl.reset("user1");
+    const after = rl.check("user1", "email");
+    expect(after.allowed).toBe(true);
+  });
+});
+
+describe("Rate limit headers and 429 response in API", () => {
+  let db: InstanceType<typeof Database>;
+  let app: ReturnType<typeof createApp>;
+
+  beforeEach(() => {
+    // Use very small limits so tests can exercise 429 without many requests.
+    process.env.RATE_LIMIT_PER_USER = "2";
+    process.env.RATE_LIMIT_PER_CHANNEL = "100";
+    process.env.RATE_LIMIT_WINDOW_MS = "60000";
+
+    db = createDb(":memory:");
+    setDb(db);
+    app = createApp();
+  });
+
+  it("includes rate limit headers on /subscribe", async () => {
+    const res = await request(app).post("/subscribe").send({
+      stellar_address: "GABCD1234",
+      channel: "email",
+      destination: "user@example.com",
+      triggers: ["invoice_funded"],
+    });
+
+    expect(res.headers["x-ratelimit-limit"]).toBeDefined();
+    expect(res.headers["x-ratelimit-remaining"]).toBeDefined();
+    expect(res.headers["x-ratelimit-reset"]).toBeDefined();
+    expect(Number(res.headers["x-ratelimit-remaining"])).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns 429 after per-user limit is reached", async () => {
+    const addr = "GLIMITUSER";
+    const sub = {
+      stellar_address: addr,
+      channel: "email",
+      destination: "limit@example.com",
+      triggers: ["invoice_funded"],
+    };
+
+    // Exhaust the 2-request limit.
+    await request(app).post("/subscribe").send(sub);
+    await request(app).post("/subscribe").send({ ...sub, destination: "limit2@example.com" });
+    const res = await request(app).post("/subscribe").send({ ...sub, destination: "limit3@example.com" });
+
+    expect(res.status).toBe(429);
+    expect(res.body.error).toMatch(/rate limit/i);
+    expect(res.body.retryAfter).toBeTypeOf("number");
+  });
+});

--- a/notifications/src/api.ts
+++ b/notifications/src/api.ts
@@ -1,5 +1,6 @@
-import express, { Request, Response } from "express";
+import express, { Request, Response, NextFunction } from "express";
 import { randomBytes } from "crypto";
+import { RateLimiter } from "./rate-limiter";
 import {
   createSubscription,
   deleteSubscriptionByAddressAndDestination,
@@ -31,6 +32,34 @@ interface SubscribeRequest {
   webhook_secret?: string;
 }
 
+const rateLimiter = new RateLimiter({
+  perUserLimit: parseInt(process.env.RATE_LIMIT_PER_USER ?? "60", 10),
+  perChannelLimit: parseInt(process.env.RATE_LIMIT_PER_CHANNEL ?? "200", 10),
+  windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS ?? "60000", 10),
+});
+
+function applyRateLimit(req: Request, res: Response, next: NextFunction): void {
+  const userId = (req.body as any)?.stellar_address as string | undefined
+    ?? req.params.address
+    ?? req.ip
+    ?? "anonymous";
+  const channel = (req.body as any)?.channel as string | undefined ?? "api";
+  const result = rateLimiter.check(userId, channel);
+
+  res.setHeader("X-RateLimit-Limit", String(result.limit));
+  res.setHeader("X-RateLimit-Remaining", String(result.remaining));
+  res.setHeader("X-RateLimit-Reset", String(result.resetAt));
+
+  if (!result.allowed) {
+    res.status(429).json({
+      error: "Too many requests — rate limit exceeded. Please try again later.",
+      retryAfter: result.resetAt,
+    });
+    return;
+  }
+  next();
+}
+
 export function createApp() {
   const app = express();
   app.use(express.json());
@@ -39,7 +68,7 @@ export function createApp() {
     res.json({ status: "ok" });
   });
 
-  app.post("/subscribe", (req: Request, res: Response) => {
+  app.post("/subscribe", applyRateLimit, (req: Request, res: Response) => {
     const body = req.body as SubscribeRequest;
 
     if (!body?.stellar_address || typeof body.stellar_address !== "string") {
@@ -155,7 +184,7 @@ export function createApp() {
     return res.json({ logs });
   });
 
-  app.post("/test-webhook", async (req: Request, res: Response) => {
+  app.post("/test-webhook", applyRateLimit, async (req: Request, res: Response) => {
     const { id } = req.body as { id: number };
 
     if (typeof id !== "number") {

--- a/notifications/src/rate-limiter.ts
+++ b/notifications/src/rate-limiter.ts
@@ -1,0 +1,106 @@
+export interface RateLimitConfig {
+  /** Maximum requests per window per user. */
+  perUserLimit: number;
+  /** Maximum requests per window per channel. */
+  perChannelLimit: number;
+  /** Sliding window length in milliseconds. */
+  windowMs: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  /** Configured limit for this bucket. */
+  limit: number;
+  /** Remaining requests in the current window. */
+  remaining: number;
+  /** Unix timestamp (seconds) when the window resets. */
+  resetAt: number;
+}
+
+interface Bucket {
+  timestamps: number[];
+  windowMs: number;
+  limit: number;
+}
+
+function checkBucket(bucket: Bucket, now: number): RateLimitResult {
+  // Evict timestamps outside the current window.
+  const windowStart = now - bucket.windowMs;
+  bucket.timestamps = bucket.timestamps.filter((t) => t > windowStart);
+
+  const resetAt = bucket.timestamps.length > 0
+    ? Math.ceil((bucket.timestamps[0] + bucket.windowMs) / 1000)
+    : Math.ceil((now + bucket.windowMs) / 1000);
+
+  if (bucket.timestamps.length >= bucket.limit) {
+    return {
+      allowed: false,
+      limit: bucket.limit,
+      remaining: 0,
+      resetAt,
+    };
+  }
+
+  bucket.timestamps.push(now);
+  return {
+    allowed: true,
+    limit: bucket.limit,
+    remaining: bucket.limit - bucket.timestamps.length,
+    resetAt,
+  };
+}
+
+export class RateLimiter {
+  private userBuckets = new Map<string, Bucket>();
+  private channelBuckets = new Map<string, Bucket>();
+  private config: RateLimitConfig;
+
+  constructor(config: RateLimitConfig) {
+    this.config = config;
+  }
+
+  check(userId: string, channel: string): RateLimitResult {
+    const now = Date.now();
+
+    // Per-user check.
+    if (!this.userBuckets.has(userId)) {
+      this.userBuckets.set(userId, {
+        timestamps: [],
+        windowMs: this.config.windowMs,
+        limit: this.config.perUserLimit,
+      });
+    }
+    const userResult = checkBucket(this.userBuckets.get(userId)!, now);
+    if (!userResult.allowed) return userResult;
+
+    // Per-channel check.
+    const channelKey = `${channel}`;
+    if (!this.channelBuckets.has(channelKey)) {
+      this.channelBuckets.set(channelKey, {
+        timestamps: [],
+        windowMs: this.config.windowMs,
+        limit: this.config.perChannelLimit,
+      });
+    }
+    const channelResult = checkBucket(this.channelBuckets.get(channelKey)!, now);
+    if (!channelResult.allowed) {
+      // Roll back the user-bucket timestamp we just inserted.
+      const ub = this.userBuckets.get(userId)!;
+      ub.timestamps.pop();
+      return channelResult;
+    }
+
+    // Return the more-restrictive remaining of the two buckets.
+    return {
+      allowed: true,
+      limit: Math.min(userResult.limit, channelResult.limit),
+      remaining: Math.min(userResult.remaining, channelResult.remaining),
+      resetAt: Math.max(userResult.resetAt, channelResult.resetAt),
+    };
+  }
+
+  /** Remove all tracking data for a user (e.g. on unsubscribe). */
+  reset(userId: string): void {
+    this.userBuckets.delete(userId);
+  }
+}

--- a/packages/react/src/components/AddressDisplay.tsx
+++ b/packages/react/src/components/AddressDisplay.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+
+export interface AddressDisplayProps {
+  address: string;
+  /** Characters to show at start and end (default 6). */
+  truncateChars?: number;
+  /** Show copy button (default true). */
+  copyable?: boolean;
+  className?: string;
+}
+
+function truncate(addr: string, chars: number): string {
+  if (addr.length <= chars * 2 + 3) return addr;
+  return `${addr.slice(0, chars)}...${addr.slice(-chars)}`;
+}
+
+export const AddressDisplay: React.FC<AddressDisplayProps> = ({
+  address,
+  truncateChars = 6,
+  copyable = true,
+  className,
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable — fail silently
+    }
+  };
+
+  return (
+    <span
+      className={className}
+      title={address}
+      style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: 'monospace', fontSize: 13 }}
+    >
+      {truncate(address, truncateChars)}
+      {copyable && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label={copied ? 'Copied' : 'Copy address'}
+          style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, fontSize: 12, color: '#6B7280' }}
+        >
+          {copied ? '✓' : '⎘'}
+        </button>
+      )}
+    </span>
+  );
+};

--- a/packages/react/src/components/AmountDisplay.tsx
+++ b/packages/react/src/components/AmountDisplay.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export interface AmountDisplayProps {
+  /** Raw amount in stroops (1 XLM = 10_000_000 stroops). */
+  amount: bigint | number;
+  /** Token symbol shown after the value (default "XLM"). */
+  symbol?: string;
+  /** Decimal places (default 7 for Stellar native). */
+  decimals?: number;
+  /** Locale string for number formatting (default "en-US"). */
+  locale?: string;
+  className?: string;
+}
+
+export const AmountDisplay: React.FC<AmountDisplayProps> = ({
+  amount,
+  symbol = 'XLM',
+  decimals = 7,
+  locale = 'en-US',
+  className,
+}) => {
+  const divisor = 10 ** decimals;
+  const value = Number(amount) / divisor;
+  const formatted = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: decimals,
+  }).format(value);
+
+  return (
+    <span className={className} style={{ fontVariantNumeric: 'tabular-nums' }}>
+      {formatted}
+      {symbol && (
+        <span style={{ marginLeft: 4, fontSize: '0.85em', color: '#6B7280', fontWeight: 500 }}>{symbol}</span>
+      )}
+    </span>
+  );
+};

--- a/packages/react/src/components/InvoiceCard.tsx
+++ b/packages/react/src/components/InvoiceCard.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import type { Invoice } from '@invoice-liquidity/sdk';
+import { StatusBadge } from './StatusBadge';
+import { AddressDisplay } from './AddressDisplay';
+import { AmountDisplay } from './AmountDisplay';
+import { useILNTheme } from './ThemeProvider';
+
+export interface InvoiceCardProps {
+  invoice: Invoice;
+  /** Called when the user clicks the card. */
+  onClick?: (invoice: Invoice) => void;
+  className?: string;
+}
+
+function formatDueDate(ts: number): string {
+  return new Date(ts * 1000).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export const InvoiceCard: React.FC<InvoiceCardProps> = ({ invoice, onClick, className }) => {
+  const theme = useILNTheme();
+
+  const cardStyle: React.CSSProperties = {
+    background: theme.colorBg,
+    border: `1px solid ${theme.colorBorder}`,
+    borderRadius: theme.borderRadius,
+    padding: '16px 20px',
+    fontFamily: theme.fontFamily,
+    color: theme.colorText,
+    cursor: onClick ? 'pointer' : undefined,
+    transition: 'box-shadow 0.15s ease',
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    color: theme.colorTextMuted,
+    marginBottom: 2,
+  };
+
+  const valueStyle: React.CSSProperties = {
+    fontSize: 14,
+    fontWeight: 500,
+  };
+
+  return (
+    <div
+      className={className}
+      style={cardStyle}
+      onClick={onClick ? () => onClick(invoice) : undefined}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') onClick(invoice); } : undefined}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 12 }}>
+        <span style={{ fontSize: 16, fontWeight: 700 }}>Invoice #{String(invoice.id)}</span>
+        <StatusBadge status={invoice.status as any} />
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '10px 24px' }}>
+        <div>
+          <div style={labelStyle}>Issuer</div>
+          <div style={valueStyle}>
+            <AddressDisplay address={invoice.issuer as unknown as string ?? ''} />
+          </div>
+        </div>
+
+        <div>
+          <div style={labelStyle}>Payer</div>
+          <div style={valueStyle}>
+            <AddressDisplay address={invoice.payer as unknown as string ?? ''} />
+          </div>
+        </div>
+
+        <div>
+          <div style={labelStyle}>Amount</div>
+          <div style={{ ...valueStyle, fontWeight: 700, color: theme.colorPrimary }}>
+            <AmountDisplay amount={invoice.amount as unknown as bigint} />
+          </div>
+        </div>
+
+        <div>
+          <div style={labelStyle}>Due Date</div>
+          <div style={valueStyle}>{formatDueDate(invoice.dueDate as unknown as number)}</div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/react/src/components/StatusBadge.tsx
+++ b/packages/react/src/components/StatusBadge.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import type { InvoiceStatus } from '../../../sdk/src/types';
+
+export interface StatusBadgeProps {
+  status: InvoiceStatus;
+  className?: string;
+}
+
+const STYLE_MAP: Record<InvoiceStatus, { bg: string; text: string; label: string }> = {
+  Pending:   { bg: '#FEF9C3', text: '#854D0E', label: 'Pending' },
+  Funded:    { bg: '#DCFCE7', text: '#166534', label: 'Funded' },
+  Paid:      { bg: '#DBEAFE', text: '#1E40AF', label: 'Paid' },
+  Defaulted: { bg: '#FEE2E2', text: '#991B1B', label: 'Defaulted' },
+};
+
+export const StatusBadge: React.FC<StatusBadgeProps> = ({ status, className }) => {
+  const style = STYLE_MAP[status] ?? { bg: '#F3F4F6', text: '#374151', label: status };
+  return (
+    <span
+      className={className}
+      style={{
+        display: 'inline-block',
+        padding: '2px 10px',
+        borderRadius: 9999,
+        fontSize: 12,
+        fontWeight: 600,
+        backgroundColor: style.bg,
+        color: style.text,
+      }}
+    >
+      {style.label}
+    </span>
+  );
+};

--- a/packages/react/src/components/ThemeProvider.tsx
+++ b/packages/react/src/components/ThemeProvider.tsx
@@ -1,0 +1,68 @@
+import React, { createContext, useContext, useMemo } from 'react';
+
+export interface ILNTheme {
+  colorPrimary: string;
+  colorSuccess: string;
+  colorWarning: string;
+  colorDanger: string;
+  colorText: string;
+  colorTextMuted: string;
+  colorBg: string;
+  colorBorder: string;
+  borderRadius: string;
+  fontFamily: string;
+}
+
+const DEFAULT_THEME: ILNTheme = {
+  colorPrimary: '#2563EB',
+  colorSuccess: '#16A34A',
+  colorWarning: '#D97706',
+  colorDanger: '#DC2626',
+  colorText: '#111827',
+  colorTextMuted: '#6B7280',
+  colorBg: '#FFFFFF',
+  colorBorder: '#E5E7EB',
+  borderRadius: '8px',
+  fontFamily: 'system-ui, -apple-system, sans-serif',
+};
+
+const ThemeContext = createContext<ILNTheme>(DEFAULT_THEME);
+
+export interface ThemeProviderProps {
+  theme?: Partial<ILNTheme>;
+  children: React.ReactNode;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({ theme, children }) => {
+  const merged = useMemo<ILNTheme>(
+    () => ({ ...DEFAULT_THEME, ...theme }),
+    [theme]
+  );
+
+  const cssVars = useMemo(
+    () =>
+      ({
+        '--iln-color-primary': merged.colorPrimary,
+        '--iln-color-success': merged.colorSuccess,
+        '--iln-color-warning': merged.colorWarning,
+        '--iln-color-danger': merged.colorDanger,
+        '--iln-color-text': merged.colorText,
+        '--iln-color-text-muted': merged.colorTextMuted,
+        '--iln-color-bg': merged.colorBg,
+        '--iln-color-border': merged.colorBorder,
+        '--iln-border-radius': merged.borderRadius,
+        '--iln-font-family': merged.fontFamily,
+      } as React.CSSProperties),
+    [merged]
+  );
+
+  return (
+    <ThemeContext.Provider value={merged}>
+      <div style={cssVars}>{children}</div>
+    </ThemeContext.Provider>
+  );
+};
+
+export function useILNTheme(): ILNTheme {
+  return useContext(ThemeContext);
+}

--- a/packages/react/src/components/components.test.tsx
+++ b/packages/react/src/components/components.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StatusBadge } from './StatusBadge';
+import { AddressDisplay } from './AddressDisplay';
+import { AmountDisplay } from './AmountDisplay';
+import { ThemeProvider, useILNTheme } from './ThemeProvider';
+import { InvoiceCard } from './InvoiceCard';
+
+const STELLAR_ADDRESS = 'GDRMKYQMTNZ3XPRF7K7L3PFBJQI2S2Y2E3KJQF3KHKY3XT3LZXG3G5X2';
+
+const mockInvoice = {
+  id: 1n,
+  issuer: STELLAR_ADDRESS,
+  payer: 'GDELEGATE_ADDRESS1234567890123456789012345678901234567890',
+  amount: 1_000_000_000n,
+  discountRate: 300,
+  dueDate: 1735689600,
+  status: 'Funded',
+  fundedBy: 'G_LP_ADDRESS',
+  token: 'USDC_CONTRACT_ID',
+} as any;
+
+describe('StatusBadge', () => {
+  it.each([
+    ['Pending', 'Pending'],
+    ['Funded', 'Funded'],
+    ['Paid', 'Paid'],
+    ['Defaulted', 'Defaulted'],
+  ] as const)('renders %s status', (status, label) => {
+    render(<StatusBadge status={status} />);
+    expect(screen.getByText(label)).toBeTruthy();
+  });
+
+  it('applies className', () => {
+    const { container } = render(<StatusBadge status="Pending" className="my-badge" />);
+    expect(container.querySelector('.my-badge')).toBeTruthy();
+  });
+});
+
+describe('AddressDisplay', () => {
+  it('truncates long addresses', () => {
+    render(<AddressDisplay address={STELLAR_ADDRESS} />);
+    expect(screen.queryByText(STELLAR_ADDRESS)).toBeFalsy();
+    expect(screen.getByTitle(STELLAR_ADDRESS)).toBeTruthy();
+  });
+
+  it('shows full address when short', () => {
+    render(<AddressDisplay address="GABC" />);
+    expect(screen.getByText('GABC')).toBeTruthy();
+  });
+
+  it('renders copy button by default', () => {
+    render(<AddressDisplay address={STELLAR_ADDRESS} />);
+    expect(screen.getByRole('button', { name: /copy/i })).toBeTruthy();
+  });
+
+  it('hides copy button when copyable=false', () => {
+    render(<AddressDisplay address={STELLAR_ADDRESS} copyable={false} />);
+    expect(screen.queryByRole('button')).toBeFalsy();
+  });
+});
+
+describe('AmountDisplay', () => {
+  it('converts stroops to XLM and shows symbol', () => {
+    render(<AmountDisplay amount={10_000_000n} />);
+    expect(screen.getByText(/1\.00/)).toBeTruthy();
+    expect(screen.getByText('XLM')).toBeTruthy();
+  });
+
+  it('uses custom symbol', () => {
+    render(<AmountDisplay amount={10_000_000n} symbol="USDC" />);
+    expect(screen.getByText('USDC')).toBeTruthy();
+  });
+
+  it('accepts number amounts', () => {
+    render(<AmountDisplay amount={10_000_000} symbol="XLM" />);
+    expect(screen.getByText(/1\.00/)).toBeTruthy();
+  });
+});
+
+describe('ThemeProvider', () => {
+  it('renders children', () => {
+    render(
+      <ThemeProvider>
+        <span>child</span>
+      </ThemeProvider>
+    );
+    expect(screen.getByText('child')).toBeTruthy();
+  });
+
+  it('merges custom theme values', () => {
+    const ThemeConsumer: React.FC = () => {
+      const theme = useILNTheme();
+      return <span data-testid="color">{theme.colorPrimary}</span>;
+    };
+    render(
+      <ThemeProvider theme={{ colorPrimary: '#FF0000' }}>
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('color').textContent).toBe('#FF0000');
+  });
+});
+
+describe('InvoiceCard', () => {
+  it('renders invoice id and status', () => {
+    render(
+      <ThemeProvider>
+        <InvoiceCard invoice={mockInvoice} />
+      </ThemeProvider>
+    );
+    expect(screen.getByText('Invoice #1')).toBeTruthy();
+    expect(screen.getByText('Funded')).toBeTruthy();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(
+      <ThemeProvider>
+        <InvoiceCard invoice={mockInvoice} onClick={onClick} />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledWith(mockInvoice);
+  });
+
+  it('renders amount and addresses', () => {
+    render(
+      <ThemeProvider>
+        <InvoiceCard invoice={mockInvoice} />
+      </ThemeProvider>
+    );
+    expect(screen.getByText(/100\.00/)).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: /copy/i }).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,0 +1,6 @@
+export * from './NotificationCenter';
+export * from './InvoiceCard';
+export * from './StatusBadge';
+export * from './AddressDisplay';
+export * from './AmountDisplay';
+export * from './ThemeProvider';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -44,4 +44,4 @@ export type {
 } from './hooks';
 
 // Components
-export * from './components/NotificationCenter';
+export * from './components';

--- a/packages/test-utils/src/assertions.ts
+++ b/packages/test-utils/src/assertions.ts
@@ -1,0 +1,72 @@
+import { expect } from 'vitest';
+import type { Invoice, InvoiceStatus } from '../../../sdk/src/types';
+import type { GovernanceProposal } from '../../../sdk/src/governance-types';
+
+/** Assert that an invoice has all required fields with correct types. */
+export function assertValidInvoice(invoice: unknown): asserts invoice is Invoice {
+  expect(invoice).toBeTruthy();
+  const inv = invoice as Record<string, unknown>;
+  expect(typeof inv.id === 'bigint' || typeof inv.id === 'number').toBe(true);
+  expect(typeof inv.freelancer).toBe('string');
+  expect(typeof inv.payer).toBe('string');
+  expect(typeof inv.amount === 'bigint' || typeof inv.amount === 'number').toBe(true);
+  expect(typeof inv.dueDate).toBe('number');
+  expect(typeof inv.discountRate).toBe('number');
+  expect(['Pending', 'Funded', 'Paid', 'Defaulted']).toContain(inv.status);
+}
+
+/** Assert that an invoice has a specific status. */
+export function assertInvoiceStatus(invoice: Invoice, status: InvoiceStatus): void {
+  expect((invoice as any).status).toBe(status);
+}
+
+/** Assert that an invoice amount matches within a tolerance (handles BigInt). */
+export function assertAmountClose(
+  actual: bigint | number,
+  expected: bigint | number,
+  toleranceBps = 1n
+): void {
+  const a = typeof actual === 'bigint' ? actual : BigInt(Math.round(actual));
+  const e = typeof expected === 'bigint' ? expected : BigInt(Math.round(expected));
+  const diff = a > e ? a - e : e - a;
+  expect(diff).toBeLessThanOrEqual(toleranceBps);
+}
+
+/** Assert that a governance proposal is in an active/voteable state. */
+export function assertProposalActive(proposal: GovernanceProposal): void {
+  expect(proposal).toBeTruthy();
+  expect(typeof proposal.id === 'bigint' || typeof proposal.id === 'number').toBe(true);
+  expect(proposal.votingEnd).toBeGreaterThan(0);
+}
+
+/** Assert that an async function rejects with an error whose message matches the pattern. */
+export async function assertRejects(
+  fn: () => Promise<unknown>,
+  pattern?: string | RegExp
+): Promise<void> {
+  let threw = false;
+  let err: Error | undefined;
+  try {
+    await fn();
+  } catch (e: any) {
+    threw = true;
+    err = e;
+  }
+  expect(threw).toBe(true);
+  if (pattern) {
+    if (typeof pattern === 'string') {
+      expect(err?.message ?? '').toContain(pattern);
+    } else {
+      expect(err?.message ?? '').toMatch(pattern);
+    }
+  }
+}
+
+/** Assert that an array of invoices is sorted by amount descending. */
+export function assertSortedByAmountDesc(invoices: Invoice[]): void {
+  for (let i = 1; i < invoices.length; i++) {
+    const prev = BigInt((invoices[i - 1] as any).amount ?? 0);
+    const curr = BigInt((invoices[i] as any).amount ?? 0);
+    expect(prev >= curr).toBe(true);
+  }
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,1 +1,4 @@
-export * from './factories'
+export * from './factories';
+export * from './mocks';
+export * from './assertions';
+export * from './setup';

--- a/packages/test-utils/src/mocks.ts
+++ b/packages/test-utils/src/mocks.ts
@@ -1,0 +1,51 @@
+import { vi } from 'vitest';
+import type { ILNClient, Invoice, ReputationScore, LPPortfolio, ContractStats } from '../../../sdk/src/types';
+import type { GovernanceProposal } from '../../../sdk/src/governance-types';
+import { createInvoice, createReputationScore, createGovernanceProposal, createLPStats, createContractStats } from './factories';
+
+/** A mock ILNClient backed by factory-generated data. All methods are vitest spies. */
+export function createMockILNClient(overrides: Partial<ILNClient> = {}): ILNClient {
+  const invoice = createInvoice();
+  const invoices = [createInvoice(), createInvoice()];
+
+  return {
+    getInvoice: vi.fn().mockResolvedValue(invoice),
+    getInvoicesByIssuer: vi.fn().mockResolvedValue(invoices),
+    getInvoicesByStatus: vi.fn().mockResolvedValue(invoices),
+    getReputationScore: vi.fn().mockResolvedValue(createReputationScore()),
+    getLPPortfolio: vi.fn().mockResolvedValue(createLPStats()),
+    getContractStats: vi.fn().mockResolvedValue(createContractStats()),
+    getProposal: vi.fn().mockResolvedValue(createGovernanceProposal()),
+    getTokenBalances: vi.fn().mockResolvedValue([]),
+    submitInvoice: vi.fn().mockResolvedValue(invoice.id),
+    fundInvoice: vi.fn().mockResolvedValue(undefined),
+    markPaid: vi.fn().mockResolvedValue(undefined),
+    createProposal: vi.fn().mockResolvedValue(undefined),
+    vote: vi.fn().mockResolvedValue(undefined),
+    connectWallet: vi.fn().mockResolvedValue('GDRMKYQMTNZ3XPRF7K7L3PFBJQI2S2Y2E3KJQF3KHKY3XT3LZXG3G5X2'),
+    ...overrides,
+  } as unknown as ILNClient;
+}
+
+/** Returns a fixed invoice for snapshot / deterministic tests. */
+export const MOCK_INVOICE: Partial<Invoice> = {
+  id: 1n as any,
+  freelancer: 'GFREE00000000000000000000000000000000000000000000000000',
+  payer: 'GPAYER0000000000000000000000000000000000000000000000000',
+  amount: 100_000_000n as any,
+  dueDate: 1_800_000_000 as any,
+  discountRate: 300,
+  status: 'Pending' as any,
+  funder: null as any,
+  fundedAt: null as any,
+};
+
+export const MOCK_LP_STATS = createLPStats({
+  address: 'GLPADDR00000000000000000000000000000000000000000000000',
+  invoiceCount: 10,
+});
+
+export const MOCK_CONTRACT_STATS = createContractStats({
+  totalInvoices: 500,
+  defaultRate: 0.02,
+});

--- a/packages/test-utils/src/sdk-test-utils.test.ts
+++ b/packages/test-utils/src/sdk-test-utils.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createMockILNClient,
+  MOCK_INVOICE,
+  MOCK_LP_STATS,
+  MOCK_CONTRACT_STATS,
+} from './mocks';
+import {
+  assertValidInvoice,
+  assertInvoiceStatus,
+  assertAmountClose,
+  assertRejects,
+  assertSortedByAmountDesc,
+} from './assertions';
+import { createInvoice } from './factories';
+
+describe('createMockILNClient', () => {
+  it('returns a client with all expected methods', () => {
+    const client = createMockILNClient();
+    expect(typeof client.getInvoice).toBe('function');
+    expect(typeof client.submitInvoice).toBe('function');
+    expect(typeof client.fundInvoice).toBe('function');
+    expect(typeof client.markPaid).toBe('function');
+    expect(typeof client.connectWallet).toBe('function');
+  });
+
+  it('getInvoice resolves to an invoice-like object', async () => {
+    const client = createMockILNClient();
+    const invoice = await (client.getInvoice as any)(1);
+    expect(invoice).toBeTruthy();
+  });
+
+  it('respects overrides', async () => {
+    const client = createMockILNClient({
+      connectWallet: vi.fn().mockResolvedValue('GOVERRIDE'),
+    });
+    const addr = await client.connectWallet();
+    expect(addr).toBe('GOVERRIDE');
+  });
+});
+
+describe('MOCK_* constants', () => {
+  it('MOCK_INVOICE has expected fields', () => {
+    expect(MOCK_INVOICE.status).toBe('Pending');
+    expect(typeof MOCK_INVOICE.discountRate).toBe('number');
+  });
+
+  it('MOCK_LP_STATS has address and invoiceCount', () => {
+    expect(MOCK_LP_STATS.invoiceCount).toBe(10);
+    expect(typeof MOCK_LP_STATS.address).toBe('string');
+  });
+
+  it('MOCK_CONTRACT_STATS has totalInvoices', () => {
+    expect(MOCK_CONTRACT_STATS.totalInvoices).toBe(500);
+    expect(MOCK_CONTRACT_STATS.defaultRate).toBe(0.02);
+  });
+});
+
+describe('assertValidInvoice', () => {
+  it('passes for a valid factory invoice', () => {
+    const invoice = createInvoice();
+    expect(() => assertValidInvoice(invoice)).not.toThrow();
+  });
+
+  it('fails for a missing field', () => {
+    expect(() => assertValidInvoice({ id: 1n, freelancer: 'G...' })).toThrow();
+  });
+});
+
+describe('assertInvoiceStatus', () => {
+  it('passes when status matches', () => {
+    const inv = createInvoice({ status: 'Funded' });
+    expect(() => assertInvoiceStatus(inv as any, 'Funded')).not.toThrow();
+  });
+
+  it('fails when status differs', () => {
+    const inv = createInvoice({ status: 'Pending' });
+    expect(() => assertInvoiceStatus(inv as any, 'Funded')).toThrow();
+  });
+});
+
+describe('assertAmountClose', () => {
+  it('passes when values are equal', () => {
+    expect(() => assertAmountClose(100n, 100n)).not.toThrow();
+  });
+
+  it('fails when difference exceeds tolerance', () => {
+    expect(() => assertAmountClose(100n, 200n, 1n)).toThrow();
+  });
+});
+
+describe('assertRejects', () => {
+  it('passes when function rejects', async () => {
+    await assertRejects(() => Promise.reject(new Error('boom')));
+  });
+
+  it('passes with matching message pattern', async () => {
+    await assertRejects(() => Promise.reject(new Error('boom')), 'boom');
+  });
+
+  it('fails when function does not reject', async () => {
+    await expect(assertRejects(() => Promise.resolve())).rejects.toThrow();
+  });
+});
+
+describe('assertSortedByAmountDesc', () => {
+  it('passes for correctly sorted invoices', () => {
+    const invs = [300, 200, 100].map((a) => createInvoice({ amount: BigInt(a) }));
+    expect(() => assertSortedByAmountDesc(invs as any)).not.toThrow();
+  });
+
+  it('fails for incorrectly sorted invoices', () => {
+    const invs = [100, 200, 300].map((a) => createInvoice({ amount: BigInt(a) }));
+    expect(() => assertSortedByAmountDesc(invs as any)).toThrow();
+  });
+});

--- a/packages/test-utils/src/setup.ts
+++ b/packages/test-utils/src/setup.ts
@@ -1,0 +1,46 @@
+import { vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Call this at the top of a test file (or in a global setup) to apply
+ * standard ILN test environment defaults.
+ *
+ * - Resets all vitest mocks between tests
+ * - Provides deterministic Date.now() seeding when a seed is passed
+ */
+export function setupILNTestEnvironment(options: {
+  /** Freeze Date.now() to this unix-ms value for the test suite. */
+  frozenTime?: number;
+  /** Additional env vars to set before each test. */
+  env?: Record<string, string>;
+} = {}): void {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    if (options.frozenTime !== undefined) {
+      vi.setSystemTime(options.frozenTime);
+    }
+
+    if (options.env) {
+      for (const [key, val] of Object.entries(options.env)) {
+        process.env[key] = val;
+      }
+    }
+  });
+
+  afterEach(() => {
+    if (options.frozenTime !== undefined) {
+      vi.useRealTimers();
+    }
+  });
+}
+
+/**
+ * Minimal environment variables required to boot the notifications service
+ * without a real Stellar node. Safe to call in a beforeEach.
+ */
+export function setNotificationsTestEnv(): void {
+  process.env.NOTIFICATIONS_RPC_URL = 'http://localhost:8000';
+  process.env.NOTIFICATIONS_CONTRACT_ID = 'GTESTCONTRACT';
+  process.env.NOTIFICATIONS_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+  process.env.RESEND_API_KEY = 'test-api-key';
+}

--- a/scripts/profile.ts
+++ b/scripts/profile.ts
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+/**
+ * ILN Performance Profiler
+ *
+ * Measures execution time and memory usage for SDK and CLI operations,
+ * detects bottlenecks against configurable thresholds, and generates
+ * Markdown + JSON reports.
+ *
+ * Usage:
+ *   npx ts-node --esm scripts/profile.ts [options]
+ *
+ * Options:
+ *   --iterations <n>         Number of iterations per operation (default: 50)
+ *   --warmup <n>             Warmup iterations discarded from stats (default: 5)
+ *   --slow-threshold <ms>    Flag operation as slow above this p95 (default: 100)
+ *   --report <path>          Markdown report output (default: profile-report.md)
+ *   --json <path>            JSON report output (default: profile-results.json)
+ *   -h, --help               Show help
+ */
+
+import { writeFileSync } from "fs";
+import { resolve } from "path";
+import { parseArgs } from "util";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface OperationSample {
+  durationMs: number;
+  heapUsedBytes: number;
+  externalBytes: number;
+}
+
+interface OperationStats {
+  name: string;
+  category: "sdk" | "cli" | "utility";
+  samples: number;
+  minMs: number;
+  maxMs: number;
+  avgMs: number;
+  p50Ms: number;
+  p90Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  avgHeapMb: number;
+  peakHeapMb: number;
+  isBottleneck: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+function bytesToMb(b: number): number {
+  return Math.round((b / 1024 / 1024) * 100) / 100;
+}
+
+function formatMs(ms: number): string {
+  return `${ms.toFixed(3)} ms`;
+}
+
+// ── Profiler core ─────────────────────────────────────────────────────────────
+
+async function profileOperation(
+  name: string,
+  category: "sdk" | "cli" | "utility",
+  fn: () => Promise<void> | void,
+  iterations: number,
+  warmup: number,
+  slowThresholdMs: number
+): Promise<OperationStats> {
+  const all: OperationSample[] = [];
+
+  for (let i = 0; i < warmup + iterations; i++) {
+    if (global.gc) global.gc();
+
+    const memBefore = process.memoryUsage();
+    const start = performance.now();
+
+    await fn();
+
+    const durationMs = performance.now() - start;
+    const memAfter = process.memoryUsage();
+
+    if (i >= warmup) {
+      all.push({
+        durationMs,
+        heapUsedBytes: Math.max(0, memAfter.heapUsed - memBefore.heapUsed),
+        externalBytes: Math.max(0, memAfter.external - memBefore.external),
+      });
+    }
+  }
+
+  const durations = all.map((s) => s.durationMs).sort((a, b) => a - b);
+  const heaps = all.map((s) => s.heapUsedBytes);
+  const avgMs = durations.reduce((a, b) => a + b, 0) / durations.length;
+  const p95Ms = percentile(durations, 95);
+
+  return {
+    name,
+    category,
+    samples: all.length,
+    minMs: durations[0],
+    maxMs: durations[durations.length - 1],
+    avgMs,
+    p50Ms: percentile(durations, 50),
+    p90Ms: percentile(durations, 90),
+    p95Ms,
+    p99Ms: percentile(durations, 99),
+    avgHeapMb: bytesToMb(heaps.reduce((a, b) => a + b, 0) / heaps.length),
+    peakHeapMb: bytesToMb(Math.max(...heaps)),
+    isBottleneck: p95Ms > slowThresholdMs,
+  };
+}
+
+// ── Operation definitions ────────────────────────────────────────────────────
+
+function buildOperations(): { name: string; category: "sdk" | "cli" | "utility"; fn: () => void }[] {
+  return [
+    {
+      name: "JSON.parse large invoice payload",
+      category: "sdk",
+      fn: () => {
+        const payload = JSON.stringify(
+          Array.from({ length: 100 }, (_, i) => ({
+            id: i,
+            freelancer: `G${"A".repeat(55)}`,
+            payer: `G${"B".repeat(55)}`,
+            amount: Math.floor(Math.random() * 1_000_000_000).toString(),
+            dueDate: Date.now() + 86400000,
+            discountRate: 300,
+            status: "Pending",
+            funder: null,
+            fundedAt: null,
+          }))
+        );
+        JSON.parse(payload);
+      },
+    },
+    {
+      name: "Address truncation (100 addresses)",
+      category: "sdk",
+      fn: () => {
+        const addrs = Array.from({ length: 100 }, () => `G${"X".repeat(55)}`);
+        addrs.forEach((a) => `${a.slice(0, 6)}...${a.slice(-6)}`);
+      },
+    },
+    {
+      name: "Amount formatting (1000 values)",
+      category: "sdk",
+      fn: () => {
+        const fmt = new Intl.NumberFormat("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 7 });
+        for (let i = 0; i < 1000; i++) {
+          fmt.format(Math.random() * 1_000_000_000 / 1e7);
+        }
+      },
+    },
+    {
+      name: "Map lookup (10k invoice index)",
+      category: "utility",
+      fn: () => {
+        const map = new Map<number, string>();
+        for (let i = 0; i < 10_000; i++) map.set(i, `invoice-${i}`);
+        for (let i = 0; i < 10_000; i++) map.get(Math.floor(Math.random() * 10_000));
+      },
+    },
+    {
+      name: "Date formatting (500 timestamps)",
+      category: "utility",
+      fn: () => {
+        const fmt = new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "numeric" });
+        for (let i = 0; i < 500; i++) {
+          fmt.format(new Date(Date.now() - Math.random() * 1e10));
+        }
+      },
+    },
+    {
+      name: "String template interpolation (5000x)",
+      category: "cli",
+      fn: () => {
+        for (let i = 0; i < 5000; i++) {
+          const _s = `Invoice #${i}: amount=${(i * 100_000_000 / 1e7).toFixed(2)} XLM, status=Pending`;
+        }
+      },
+    },
+    {
+      name: "BigInt arithmetic (1000 calculations)",
+      category: "sdk",
+      fn: () => {
+        for (let i = 0; i < 1000; i++) {
+          const amount = BigInt(Math.floor(Math.random() * 1_000_000_000));
+          const discountRate = BigInt(300);
+          const bps = BigInt(10_000);
+          const _yield = (amount * discountRate) / bps;
+        }
+      },
+    },
+    {
+      name: "Array sort (500 invoices by amount)",
+      category: "sdk",
+      fn: () => {
+        const invoices = Array.from({ length: 500 }, (_, i) => ({
+          id: i,
+          amount: Math.floor(Math.random() * 1_000_000_000),
+        }));
+        invoices.sort((a, b) => b.amount - a.amount);
+      },
+    },
+  ];
+}
+
+// ── Report generation ────────────────────────────────────────────────────────
+
+function buildMarkdownReport(stats: OperationStats[], config: {
+  iterations: number;
+  warmup: number;
+  slowThresholdMs: number;
+}): string {
+  const bottlenecks = stats.filter((s) => s.isBottleneck);
+  const statusLine = bottlenecks.length === 0
+    ? `> [!NOTE]\n> All operations completed within the ${config.slowThresholdMs} ms p95 threshold.`
+    : `> [!WARNING]\n> **${bottlenecks.length} bottleneck(s) detected** (p95 > ${config.slowThresholdMs} ms):\n${bottlenecks.map((b) => `> - \`${b.name}\` — p95: ${formatMs(b.p95Ms)}`).join("\n")}`;
+
+  const categoryOrder = ["sdk", "cli", "utility"] as const;
+  const rows = categoryOrder.flatMap((cat) =>
+    stats
+      .filter((s) => s.category === cat)
+      .map((s) => {
+        const flag = s.isBottleneck ? " ⚠️" : "";
+        return `| ${s.name}${flag} | \`${cat}\` | ${s.samples} | ${formatMs(s.avgMs)} | ${formatMs(s.p50Ms)} | ${formatMs(s.p95Ms)} | ${formatMs(s.p99Ms)} | ${s.avgHeapMb} MB | ${s.peakHeapMb} MB |`;
+      })
+  );
+
+  return `# ILN Performance Profile Report
+
+Generated: ${new Date().toISOString()}
+
+## Configuration
+
+| Parameter | Value |
+|---|---|
+| Iterations per operation | ${config.iterations} |
+| Warmup iterations (discarded) | ${config.warmup} |
+| Slow-operation threshold (p95) | ${config.slowThresholdMs} ms |
+
+---
+
+${statusLine}
+
+---
+
+## Results
+
+| Operation | Category | Samples | Avg | p50 | p95 | p99 | Avg Heap | Peak Heap |
+|---|---|---|---|---|---|---|---|---|
+${rows.join("\n")}
+
+---
+
+## Summary
+
+- Total operations profiled: **${stats.length}**
+- Bottlenecks detected: **${bottlenecks.length}**
+- Fastest operation: **${stats.reduce((a, b) => (a.avgMs < b.avgMs ? a : b)).name}** (${formatMs(stats.reduce((a, b) => (a.avgMs < b.avgMs ? a : b)).avgMs)} avg)
+- Slowest operation: **${stats.reduce((a, b) => (a.avgMs > b.avgMs ? a : b)).name}** (${formatMs(stats.reduce((a, b) => (a.avgMs > b.avgMs ? a : b)).avgMs)} avg)
+
+---
+*Generated by the ILN performance profiling suite.*
+`;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const colors = {
+  reset: "\x1b[0m",
+  bright: "\x1b[1m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  red: "\x1b[31m",
+  cyan: "\x1b[36m",
+};
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs({
+      options: {
+        iterations: { type: "string", default: "50" },
+        warmup: { type: "string", default: "5" },
+        "slow-threshold": { type: "string", default: "100" },
+        report: { type: "string", default: "profile-report.md" },
+        json: { type: "string", default: "profile-results.json" },
+        help: { type: "boolean", short: "h" },
+      },
+    });
+  } catch (err: any) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (args.values.help) {
+    console.log("Usage: npx ts-node --esm scripts/profile.ts [--iterations N] [--warmup N] [--slow-threshold MS] [--report FILE] [--json FILE]");
+    process.exit(0);
+  }
+
+  const iterations = parseInt(args.values["iterations"] ?? "50", 10);
+  const warmup = parseInt(args.values["warmup"] ?? "5", 10);
+  const slowThresholdMs = parseFloat(args.values["slow-threshold"] ?? "100");
+  const reportPath = args.values["report"] ?? "profile-report.md";
+  const jsonPath = args.values["json"] ?? "profile-results.json";
+
+  console.log(`\n${colors.bright}${colors.cyan}=== ILN PERFORMANCE PROFILER ===${colors.reset}`);
+  console.log(`Iterations:       ${iterations} (+ ${warmup} warmup)`);
+  console.log(`Slow threshold:   ${slowThresholdMs} ms (p95)\n`);
+
+  const operations = buildOperations();
+  const allStats: OperationStats[] = [];
+
+  for (const op of operations) {
+    process.stdout.write(`  Profiling: ${op.name}... `);
+    const stats = await profileOperation(op.name, op.category, op.fn, iterations, warmup, slowThresholdMs);
+    allStats.push(stats);
+    const flag = stats.isBottleneck ? `${colors.yellow}⚠ SLOW${colors.reset}` : `${colors.green}OK${colors.reset}`;
+    console.log(`${flag} (avg: ${formatMs(stats.avgMs)}, p95: ${formatMs(stats.p95Ms)})`);
+  }
+
+  const bottlenecks = allStats.filter((s) => s.isBottleneck);
+  console.log(`\n${colors.bright}${colors.cyan}=== PROFILE SUMMARY ===${colors.reset}`);
+  console.log(`Operations:    ${allStats.length}`);
+  console.log(`Bottlenecks:   ${bottlenecks.length > 0 ? `${colors.yellow}${bottlenecks.length}${colors.reset}` : `${colors.green}0${colors.reset}`}`);
+
+  if (bottlenecks.length > 0) {
+    console.log(`\n${colors.yellow}Bottlenecks (p95 > ${slowThresholdMs} ms):${colors.reset}`);
+    for (const b of bottlenecks) {
+      console.log(`  ⚠  ${b.name}: p95=${formatMs(b.p95Ms)}`);
+    }
+  }
+
+  const markdown = buildMarkdownReport(allStats, { iterations, warmup, slowThresholdMs });
+  writeFileSync(resolve(process.cwd(), reportPath), markdown, "utf-8");
+  console.log(`\nMarkdown report: ${colors.bright}${reportPath}${colors.reset}`);
+
+  const json = {
+    generatedAt: new Date().toISOString(),
+    config: { iterations, warmup, slowThresholdMs },
+    bottleneckCount: bottlenecks.length,
+    operations: allStats,
+  };
+  writeFileSync(resolve(process.cwd(), jsonPath), JSON.stringify(json, null, 2), "utf-8");
+  console.log(`JSON report:     ${colors.bright}${jsonPath}${colors.reset}\n`);
+
+  process.exit(bottlenecks.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(`Profiler failed: ${err.message || err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changed

### #583 — Enhance SDK React Components
Added five typed React components to `packages/react/src/components/`:
- **`InvoiceCard`** — displays invoice ID, status badge, issuer/payer addresses, amount, and due date in a themed card
- **`StatusBadge`** — color-coded pill for `Pending | Funded | Paid | Defaulted` statuses
- **`AddressDisplay`** — truncates Stellar addresses with a copy-to-clipboard button
- **`AmountDisplay`** — converts stroops to human-readable XLM/token amounts via `Intl.NumberFormat`
- **`ThemeProvider`** — injects CSS custom properties (`--iln-color-primary`, etc.) and exposes `useILNTheme()` hook
- All components are exported from `packages/react/src/index.ts`; 9 unit tests added

### #584 — Add Scripts Performance Profiling
Added `scripts/profile.ts`:
- Profiles 8 representative SDK/CLI operations (JSON parsing, address truncation, amount formatting, BigInt arithmetic, etc.)
- Configurable iterations, warmup rounds, and slow-operation threshold (p95)
- Tracks execution time (min/avg/p50/p90/p95/p99/max) and heap memory per operation
- Detects bottlenecks and generates Markdown + JSON reports
- Exits non-zero when any operation exceeds the threshold (CI-friendly)

### #585 — Build SDK Testing Utilities
Extended `packages/test-utils/src/`:
- **`mocks.ts`** — `createMockILNClient()` backed by vitest spies and factory data; static `MOCK_INVOICE`, `MOCK_LP_STATS`, `MOCK_CONTRACT_STATS` constants
- **`assertions.ts`** — `assertValidInvoice`, `assertInvoiceStatus`, `assertAmountClose`, `assertRejects`, `assertSortedByAmountDesc` typed helpers
- **`setup.ts`** — `setupILNTestEnvironment()` with mock reset, frozen time, and env injection; `setNotificationsTestEnv()` for bootstrapping the notification service in tests
- 8 new tests in `sdk-test-utils.test.ts`

### #586 — Add Notifications Rate Limiting
Added `notifications/src/rate-limiter.ts`:
- Sliding-window `RateLimiter` class with independent per-user and per-channel buckets
- Configurable via `RATE_LIMIT_PER_USER`, `RATE_LIMIT_PER_CHANNEL`, `RATE_LIMIT_WINDOW_MS` env vars (defaults: 60/200/60000)
- Integrated into `notifications/src/api.ts` on `POST /subscribe` and `POST /test-webhook`
- Sets `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers on every guarded request
- Returns `429 Too Many Requests` with `{ error, retryAfter }` on limit breach
- 8 unit tests covering per-user, per-channel, independent tracking, reset, and API-level 429 responses

## How to test

- **#583**: `yarn react:test` — all component tests should pass
- **#584**: `npx ts-node --esm scripts/profile.ts --iterations 20` — runs and prints a report
- **#585**: `yarn workspace @iln/test-utils test` — factories + new utility tests should pass
- **#586**: `cd notifications && vitest run src/__tests__/rate-limiter.test.ts`

Closes #583
Closes #584
Closes #585
Closes #586