### PR TITLE
Fix Issue 226

### DIFF
--- a/packages/sdk/src/index.browser.ts
+++ b/packages/sdk/src/index.browser.ts
@@ -1,6 +1,7 @@
 // Browser-specific entry point for the ILN SDK.
 // Relies on Web Crypto API instead of Node.js crypto.
 export * from './clients/InvoiceClient';
+export * from './reputation';
 export * from './crypto-browser';
 export * from './tokens';
 export * from './amount-formatting';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from './clients/InvoiceClient';
+export * from './reputation';
 export * from './xdr';
 export * from './tokens';
 export * from './amount-formatting';

--- a/packages/sdk/src/reputation.test.ts
+++ b/packages/sdk/src/reputation.test.ts
@@ -1,0 +1,150 @@
+import { nativeToScVal, scValToNative, xdr, Keypair } from '@stellar/stellar-sdk';
+
+import { ReputationClient, type ReputationScore } from './reputation';
+
+const TEST_PUBLIC_KEY = Keypair.random().publicKey();
+const TEST_CONTRACT_ID = Keypair.random().publicKey();
+
+function makeScoreScVal(overrides: Partial<Record<string, unknown>> = {}) {
+  const fields: Record<string, unknown> = {
+    score: nativeToScVal(85, { type: 'u32' }),
+    total_paid: nativeToScVal(5_000_000_000n, { type: 'i128' }),
+    invoice_count: nativeToScVal(42, { type: 'u32' }),
+    last_activity: nativeToScVal(1_700_000_000n, { type: 'u64' }),
+    rank: nativeToScVal(5, { type: 'u32' }),
+    ...overrides,
+  };
+  return xdr.ScVal.scvMap(
+    Object.entries(fields).map(
+      ([key, val]) =>
+        new xdr.ScMapEntry({
+          key: nativeToScVal(key, { type: 'symbol' }),
+          val: val as xdr.ScVal,
+        }),
+    ),
+  );
+}
+
+describe('ReputationClient', () => {
+  it('should initialize correctly', () => {
+    const client = new ReputationClient(
+      'https://soroban-testnet.stellar.org',
+      TEST_CONTRACT_ID,
+    );
+    expect(client).toBeDefined();
+  });
+
+  describe('getReputation', () => {
+    it('returns a zeroed ReputationScore when the address is not found', async () => {
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockRejectedValue(new Error('not found'));
+
+      const result = await client.getReputation(TEST_PUBLIC_KEY);
+      expect(result.address).toBe(TEST_PUBLIC_KEY);
+      expect(result.score).toBe(0);
+      expect(result.totalPaid).toBe(0n);
+      expect(result.invoiceCount).toBe(0);
+      expect(result.lastActivity).toBe(0);
+      expect(result.rank).toBe(0);
+    });
+
+    it('parses a valid contract response into a ReputationScore', async () => {
+      const mapScVal = makeScoreScVal();
+
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockImplementation(
+        async () => mapScVal,
+      );
+
+      const result = await client.getReputation(TEST_PUBLIC_KEY);
+      expect(result.address).toBe(TEST_PUBLIC_KEY);
+      expect(result.score).toBe(85);
+      expect(result.totalPaid).toBe(5_000_000_000n);
+      expect(result.invoiceCount).toBe(42);
+      expect(result.lastActivity).toBe(1_700_000_000);
+      expect(result.rank).toBe(5);
+    });
+  });
+
+  describe('getReputationScore', () => {
+    it('returns 0 for an unknown address', async () => {
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockRejectedValue(new Error('not found'));
+
+      const score = await client.getReputationScore(TEST_PUBLIC_KEY);
+      expect(score).toBe(0);
+    });
+
+    it('returns the score from a valid response', async () => {
+      const mapScVal = makeScoreScVal({ score: nativeToScVal(92, { type: 'u32' }) });
+
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockImplementation(
+        async () => mapScVal,
+      );
+
+      const score = await client.getReputationScore(TEST_PUBLIC_KEY);
+      expect(score).toBe(92);
+    });
+  });
+
+  describe('getTopPayers', () => {
+    it('returns an empty array when the contract has no data', async () => {
+      const emptyVec = xdr.ScVal.scvVec([]);
+
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockImplementation(
+        async () => emptyVec,
+      );
+
+      const result = await client.getTopPayers(10);
+      expect(result).toEqual([]);
+    });
+
+    it('returns payer entries from a contract response', async () => {
+      const payer1Addr = Keypair.random().publicKey();
+      const payer2Addr = Keypair.random().publicKey();
+
+      const vecScVal = xdr.ScVal.scvVec([
+        makeScoreScVal({
+          score: nativeToScVal(90, { type: 'u32' }),
+          rank: nativeToScVal(1, { type: 'u32' }),
+          address: nativeToScVal(payer1Addr, { type: 'symbol' }),
+        }),
+        makeScoreScVal({
+          score: nativeToScVal(75, { type: 'u32' }),
+          total_paid: nativeToScVal(3_000_000_000n, { type: 'i128' }),
+          invoice_count: nativeToScVal(20, { type: 'u32' }),
+          rank: nativeToScVal(2, { type: 'u32' }),
+          address: nativeToScVal(payer2Addr, { type: 'symbol' }),
+        }),
+      ]);
+
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockImplementation(
+        async () => vecScVal,
+      );
+
+      const result = await client.getTopPayers(2);
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/packages/sdk/src/reputation.ts
+++ b/packages/sdk/src/reputation.ts
@@ -1,0 +1,206 @@
+import {
+  SorobanRpc,
+  nativeToScVal,
+  scValToNative,
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  Contract,
+  Address,
+  xdr as stellarXdr,
+} from '@stellar/stellar-sdk';
+
+/**
+ * Reputation score for an address on the Invoice Liquidity Network.
+ *
+ * Returned by {@link ReputationClient.getReputation} and
+ * {@link ReputationClient.getTopPayers}.
+ */
+export interface ReputationScore {
+  /** Stellar public address (G...) or contract address (C...). */
+  address: string;
+  /** Overall reputation score (0–100). */
+  score: number;
+  /** Total amount paid in base units (stroops). */
+  totalPaid: bigint;
+  /** Number of invoices the address has paid. */
+  invoiceCount: number;
+  /** Unix timestamp of the most recent activity. */
+  lastActivity: number;
+  /** Position in the global payer ranking (1-indexed). */
+  rank: number;
+}
+
+function zeroReputationScore(address: string): ReputationScore {
+  return { address, score: 0, totalPaid: 0n, invoiceCount: 0, lastActivity: 0, rank: 0 };
+}
+
+function parseReputationScore(native: unknown, address: string): ReputationScore {
+  if (!native || typeof native !== 'object') {
+    return zeroReputationScore(address);
+  }
+
+  let get: (key: string) => unknown;
+
+  if (native instanceof Map) {
+    get = (key: string) => (native as Map<string, unknown>).get(key);
+  } else {
+    get = (key: string) => (native as Record<string, unknown>)[key];
+  }
+
+  return {
+    address,
+    score: Math.max(0, Number(get('score') ?? 0)) || 0,
+    totalPaid: BigInt(String(get('total_paid') ?? '0')) || 0n,
+    invoiceCount: Math.max(0, Number(get('invoice_count') ?? 0)) || 0,
+    lastActivity: Math.max(0, Number(get('last_activity') ?? 0)) || 0,
+    rank: Math.max(0, Number(get('rank') ?? 0)) || 0,
+  };
+}
+
+/**
+ * Client for querying on-chain reputation data from the Invoice Liquidity Network.
+ *
+ * Provides type-safe access to the ILN reputation contract without exposing raw XDR.
+ * All contract return values are parsed into clean {@link ReputationScore} structs.
+ *
+ * @example
+ * ```ts
+ * import { ReputationClient } from '@iln/sdk';
+ *
+ * const client = new ReputationClient(
+ *   'https://soroban-testnet.stellar.org',
+ *   'CA3D...',
+ * );
+ *
+ * const rep = await client.getReputation('GB...');
+ * console.log(rep.score); // 85
+ *
+ * const top = await client.getTopPayers(10);
+ * console.log(top.length); // 10
+ * ```
+ */
+export class ReputationClient {
+  private server: SorobanRpc.Server;
+  private contractId: string;
+  private networkPassphrase: string;
+  private source: string;
+
+  /**
+   * @param rpcUrl - Soroban RPC endpoint (e.g. `https://soroban-testnet.stellar.org`).
+   * @param contractId - The deployed reputation contract ID (C... address).
+   * @param options - Optional configuration.
+   * @param options.networkPassphrase - Network passphrase (defaults to `Networks.TESTNET`).
+   * @param options.source - Source account public key for simulation. If omitted, a random keypair is used (suitable for read-only queries where the simulation does not require a funded account).
+   */
+  constructor(
+    rpcUrl: string,
+    contractId: string,
+    options?: { networkPassphrase?: string; source?: string },
+  ) {
+    this.server = new SorobanRpc.Server(rpcUrl);
+    this.contractId = contractId;
+    this.networkPassphrase = options?.networkPassphrase ?? Networks.TESTNET;
+    this.source = options?.source ?? Keypair.random().publicKey();
+  }
+
+  /**
+   * Returns the full reputation profile for a Stellar address.
+   *
+   * If the address has no on-chain history, a zeroed {@link ReputationScore}
+   * is returned instead of throwing.
+   *
+   * @param address - Stellar public key (G...) or contract address (C...).
+   *
+   * @example
+   * ```ts
+   * const rep = await client.getReputation('GABCDEF123...');
+   * // { address: 'GABCDEF123...', score: 75, totalPaid: 5000000000n, ... }
+   * ```
+   */
+  async getReputation(address: string): Promise<ReputationScore> {
+    try {
+      const addressScVal = new Address(address).toScVal();
+      const retval = await this.simulate('get_reputation', [addressScVal]);
+      const native = scValToNative(retval);
+      return parseReputationScore(native, address);
+    } catch {
+      return zeroReputationScore(address);
+    }
+  }
+
+  /**
+   * Returns the top payers ranked by reputation score.
+   *
+   * @param limit - Maximum number of payers to return (max 100).
+   *
+   * @example
+   * ```ts
+   * const top = await client.getTopPayers(5);
+   * top.forEach((p, i) => console.log(`#${i + 1}: ${p.address} (${p.score})`));
+   * ```
+   */
+  async getTopPayers(limit: number): Promise<ReputationScore[]> {
+    const limitScVal = nativeToScVal(limit, { type: 'u32' });
+    const retval = await this.simulate('get_top_payers', [limitScVal]);
+    const native = scValToNative(retval);
+
+    if (!Array.isArray(native)) {
+      return [];
+    }
+
+    return native.map((entry: unknown) => {
+      if (entry && typeof entry === 'object') {
+        const get = (key: string) =>
+          entry instanceof Map
+            ? entry.get(key)
+            : (entry as Record<string, unknown>)[key];
+        const addr = String(get('address') ?? '');
+        return parseReputationScore(entry, addr);
+      }
+      return zeroReputationScore('');
+    });
+  }
+
+  /**
+   * Convenience method that returns only the reputation score for an address.
+   *
+   * Equivalent to `(await client.getReputation(address)).score`.
+   *
+   * @param address - Stellar public key or contract address.
+   *
+   * @example
+   * ```ts
+   * const score = await client.getReputationScore('GABCDEF123...');
+   * if (score > 80) console.log('Highly trusted payer');
+   * ```
+   */
+  async getReputationScore(address: string): Promise<number> {
+    const rep = await this.getReputation(address);
+    return rep.score;
+  }
+
+  private async simulate(method: string, args: stellarXdr.ScVal[]): Promise<stellarXdr.ScVal> {
+    const contract = new Contract(this.contractId);
+    const account = await this.server.getAccount(this.source);
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call(method, ...args))
+      .setTimeout(30)
+      .build();
+
+    const response = await this.server.simulateTransaction(tx);
+
+    if ('error' in response) {
+      throw new Error(response.error);
+    }
+    if (!response.result?.retval) {
+      throw new Error('No return value');
+    }
+    return response.result.retval;
+  }
+}


### PR DESCRIPTION
Summary
Add ReputationClient to the SDK — a type-safe client for querying on-chain reputation data from the ILN protocol via Soroban RPC.
Related Issue
Closes #226 

Complexity
- Medium (new feature, non-breaking change)
- 
Changes Made
- Add ReputationScore TypeScript interface with typed fields (address, score, totalPaid, invoiceCount, lastActivity, rank)
- Add ReputationClient class to packages/sdk/src/reputation.ts with three methods:
- getReputation(address) — returns full ReputationScore profile, zeroed struct for unknown addresses
- getTopPayers(limit) — returns ranked list of top payers
- getReputationScore(address) — convenience wrapper for just the score
- Implement Soroban contract simulation via TransactionBuilder + SorobanRpc.Server for read-only queries
- Handle XDR responses into clean TypeScript types (no raw XDR exposure)
- Gracefully handle address-not-found by returning zeroed ReputationScore (never throws)
- Add comprehensive JSDoc with usage examples
- Register ReputationClient in index.ts and index.browser.ts exports
- Add 7 unit tests covering: initialization, unknown-address zero struct, valid response parsing, and empty top-payers
Test Coverage
 PASS  src/reputation.test.ts
  ReputationClient
    ✓ should initialize correctly
    getReputation
      ✓ returns a zeroed ReputationScore when the address is not found
      ✓ parses a valid contract response into a ReputationScore
    getReputationScore
      ✓ returns 0 for an unknown address
      ✓ returns the score from a valid response
    getTopPayers
      ✓ returns an empty array when the contract has no data
      ✓ returns payer entries from a contract response

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Security Considerations
None. Reputation queries are read-only contract simulations — no state mutations, no access control implications.
Checklist
- Tests pass locally
- New functionality has test coverage
- Public functions have JSDoc doc comments
- Issue linked (Closes #) — add issue number if applicable