### PR TITLE
Fix issue321

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,11 +2,33 @@
   "name": "@iln/sdk",
   "version": "0.1.0",
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "browser": "./dist/browser/index.js",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./tokens": {
+      "import": "./dist/tokens.js",
+      "require": "./dist/tokens.cjs",
+      "types": "./dist/tokens.d.ts"
+    },
+    "./events": {
+      "import": "./dist/events.js",
+      "require": "./dist/events.cjs",
+      "types": "./dist/events.d.ts"
+    },
+    "./errors": {
+      "import": "./dist/errors.js",
+      "require": "./dist/errors.cjs",
+      "types": "./dist/errors.d.ts"
+    },
+    "./xdr": {
+      "import": "./dist/xdr.js",
+      "require": "./dist/xdr.cjs",
+      "types": "./dist/xdr.d.ts"
     }
   },
   "main": "./dist/index.cjs",
@@ -14,7 +36,7 @@
   "browser": "./dist/browser/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup src/index.ts src/tokens.ts src/events.ts src/errors.ts src/xdr.ts --format cjs,esm --dts --clean",
     "build:browser": "vite build --config vite.browser.config.ts",
     "test": "jest",
     "test:browser": "playwright test tests/browser/",

--- a/packages/sdk/src/errors.test.ts
+++ b/packages/sdk/src/errors.test.ts
@@ -1,0 +1,66 @@
+import {
+  ContractCallError,
+  InvalidAddressError,
+  XDRParseError,
+  NetworkError,
+} from './errors';
+
+describe('ContractCallError', () => {
+  it('creates an error with name, message, contractId, and method', () => {
+    const err = new ContractCallError('Simulation failed', 'CA3D...', 'get_reputation');
+    expect(err.name).toBe('ContractCallError');
+    expect(err.message).toBe('Simulation failed');
+    expect(err.contractId).toBe('CA3D...');
+    expect(err.method).toBe('get_reputation');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ContractCallError);
+  });
+
+  it('works without optional params', () => {
+    const err = new ContractCallError('Failed');
+    expect(err.contractId).toBeUndefined();
+    expect(err.method).toBeUndefined();
+  });
+});
+
+describe('InvalidAddressError', () => {
+  it('creates an error with name, message, and address', () => {
+    const err = new InvalidAddressError('Bad address format', 'GINVALID...');
+    expect(err.name).toBe('InvalidAddressError');
+    expect(err.message).toBe('Bad address format');
+    expect(err.address).toBe('GINVALID...');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(InvalidAddressError);
+  });
+
+  it('works without optional address', () => {
+    const err = new InvalidAddressError('Missing address');
+    expect(err.address).toBeUndefined();
+  });
+});
+
+describe('XDRParseError', () => {
+  it('creates an error with name and message', () => {
+    const err = new XDRParseError('Invalid XDR encoding');
+    expect(err.name).toBe('XDRParseError');
+    expect(err.message).toBe('Invalid XDR encoding');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(XDRParseError);
+  });
+});
+
+describe('NetworkError', () => {
+  it('creates an error with name, message, and statusCode', () => {
+    const err = new NetworkError('Request timed out', 504);
+    expect(err.name).toBe('NetworkError');
+    expect(err.message).toBe('Request timed out');
+    expect(err.statusCode).toBe(504);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(NetworkError);
+  });
+
+  it('works without optional statusCode', () => {
+    const err = new NetworkError('Network unavailable');
+    expect(err.statusCode).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -1,0 +1,89 @@
+/**
+ * Custom error classes for the Invoice Liquidity Network SDK.
+ *
+ * Each class extends `Error` with a fixed `name` property so consumers
+ * can use `instanceof` checks for type-safe error handling.
+ *
+ * @example
+ * ```ts
+ * import { ContractCallError } from '@iln/sdk/errors';
+ *
+ * try {
+ *   await client.getReputation(address);
+ * } catch (err) {
+ *   if (err instanceof ContractCallError) {
+ *     console.error(err.method, err.contractId);
+ *   }
+ * }
+ * ```
+ */
+
+/**
+ * Thrown when a Soroban contract simulation or invocation fails.
+ */
+export class ContractCallError extends Error {
+  override name = 'ContractCallError';
+
+  /**
+   * @param message - Human-readable error description.
+   * @param contractId - The contract address (C...) that was called.
+   * @param method - The contract method that failed.
+   */
+  constructor(
+    message: string,
+    public readonly contractId?: string,
+    public readonly method?: string,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Thrown when an invalid Stellar address (G... / C...) is provided.
+ */
+export class InvalidAddressError extends Error {
+  override name = 'InvalidAddressError';
+
+  /**
+   * @param message - Human-readable error description.
+   * @param address - The invalid address value.
+   */
+  constructor(
+    message: string,
+    public readonly address?: string,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Thrown when XDR parsing or decoding fails.
+ */
+export class XDRParseError extends Error {
+  override name = 'XDRParseError';
+
+  /**
+   * @param message - Human-readable error description.
+   */
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * Thrown when a network request to Horizon or Soroban RPC fails.
+ */
+export class NetworkError extends Error {
+  override name = 'NetworkError';
+
+  /**
+   * @param message - Human-readable error description.
+   * @param statusCode - Optional HTTP status code.
+   */
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+  ) {
+    super(message);
+  }
+}

--- a/packages/sdk/src/events.test.ts
+++ b/packages/sdk/src/events.test.ts
@@ -1,0 +1,418 @@
+import { nativeToScVal, xdr, Keypair } from '@stellar/stellar-sdk';
+
+import {
+  parseContractEvent,
+  parseInvoiceSubmittedEvent,
+  parseInvoiceFundedEvent,
+  parseInvoicePaidEvent,
+  parseInvoiceCancelledEvent,
+  parseInvoiceExpiredEvent,
+  parseInvoiceDisputedEvent,
+  parseReputationUpdatedEvent,
+  parseContractPausedEvent,
+  parseTokenAddedEvent,
+  parseLPPositionTransferredEvent,
+  supportedEventTypes,
+  type RawEvent,
+  type ContractEvent,
+} from './events';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const TEST_PUBLIC_KEY = Keypair.random().publicKey();
+const TEST_ISSUER = Keypair.random().publicKey();
+const TEST_FUNDER = Keypair.random().publicKey();
+const TEST_PAYER = Keypair.random().publicKey();
+const TEST_DISPUTER = Keypair.random().publicKey();
+const TEST_FROM = Keypair.random().publicKey();
+const TEST_TO = Keypair.random().publicKey();
+const TEST_TOKEN = Keypair.random().publicKey();
+const TEST_ADDRESS = Keypair.random().publicKey();
+
+function sym(name: string): xdr.ScVal {
+  return nativeToScVal(name, { type: 'symbol' });
+}
+
+function u64(val: bigint | number): xdr.ScVal {
+  return nativeToScVal(val, { type: 'u64' });
+}
+
+function i128(val: bigint): xdr.ScVal {
+  return nativeToScVal(val, { type: 'i128' });
+}
+
+function u32(val: number): xdr.ScVal {
+  return nativeToScVal(val, { type: 'u32' });
+}
+
+function addressScVal(addr: string): xdr.ScVal {
+  return nativeToScVal(addr, { type: 'address' });
+}
+
+function scvMap(entries: Record<string, xdr.ScVal>): xdr.ScVal {
+  return xdr.ScVal.scvMap(
+    Object.entries(entries).map(
+      ([key, val]) =>
+        new xdr.ScMapEntry({ key: sym(key), val }),
+    ),
+  );
+}
+
+const TIMESTAMP = 1_700_000_000n;
+const INVOICE_ID = 42n;
+const AMOUNT = 10_000_000_000n;
+const SCORE = 85;
+
+function makeRawEvent(topics: xdr.ScVal[], value: xdr.ScVal): RawEvent {
+  return { topics, value };
+}
+
+function valueWith(fields: Record<string, xdr.ScVal>): xdr.ScVal {
+  return scvMap({ timestamp: u64(TIMESTAMP), ...fields });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('parseInvoiceSubmittedEvent', () => {
+  it('parses a valid InvoiceSubmitted event', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_submitted'), u64(INVOICE_ID), addressScVal(TEST_ISSUER)],
+      valueWith({ amount: i128(AMOUNT) }),
+    );
+
+    const event = parseInvoiceSubmittedEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoiceSubmitted');
+    expect(event!.invoiceId).toBe(INVOICE_ID);
+    expect(event!.issuer).toBe(TEST_ISSUER);
+    expect(event!.amount).toBe(AMOUNT);
+    expect(event!.timestamp).toBe(TIMESTAMP);
+  });
+
+  it('returns null for wrong event name', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_funded'), u64(INVOICE_ID)],
+      valueWith({ amount: i128(AMOUNT) }),
+    );
+    expect(parseInvoiceSubmittedEvent(raw)).toBeNull();
+  });
+
+  it('returns null for missing topics', () => {
+    const raw = makeRawEvent([], valueWith({}));
+    expect(parseInvoiceSubmittedEvent(raw)).toBeNull();
+  });
+});
+
+describe('parseInvoiceFundedEvent', () => {
+  it('parses a valid InvoiceFunded event', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_funded'), u64(INVOICE_ID), addressScVal(TEST_FUNDER)],
+      valueWith({ amount: i128(AMOUNT) }),
+    );
+
+    const event = parseInvoiceFundedEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoiceFunded');
+    expect(event!.invoiceId).toBe(INVOICE_ID);
+    expect(event!.funder).toBe(TEST_FUNDER);
+    expect(event!.amount).toBe(AMOUNT);
+    expect(event!.timestamp).toBe(TIMESTAMP);
+  });
+
+  it('returns null for wrong event name', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_paid'), u64(INVOICE_ID)],
+      valueWith({ amount: i128(AMOUNT) }),
+    );
+    expect(parseInvoiceFundedEvent(raw)).toBeNull();
+  });
+});
+
+describe('parseInvoicePaidEvent', () => {
+  it('parses a valid InvoicePaid event', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_paid'), u64(INVOICE_ID), addressScVal(TEST_PAYER)],
+      valueWith({ amount: i128(AMOUNT) }),
+    );
+
+    const event = parseInvoicePaidEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoicePaid');
+    expect(event!.invoiceId).toBe(INVOICE_ID);
+    expect(event!.payer).toBe(TEST_PAYER);
+    expect(event!.amount).toBe(AMOUNT);
+    expect(event!.timestamp).toBe(TIMESTAMP);
+  });
+});
+
+describe('parseInvoiceCancelledEvent', () => {
+  it('parses a valid InvoiceCancelled event', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_cancelled'), u64(INVOICE_ID)],
+      valueWith({}),
+    );
+
+    const event = parseInvoiceCancelledEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoiceCancelled');
+    expect(event!.invoiceId).toBe(INVOICE_ID);
+    expect(event!.timestamp).toBe(TIMESTAMP);
+  });
+});
+
+describe('parseInvoiceExpiredEvent', () => {
+  it('parses a valid InvoiceExpired event', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_expired'), u64(INVOICE_ID)],
+      valueWith({}),
+    );
+
+    const event = parseInvoiceExpiredEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoiceExpired');
+    expect(event!.invoiceId).toBe(INVOICE_ID);
+    expect(event!.timestamp).toBe(TIMESTAMP);
+  });
+});
+
+describe('parseInvoiceDisputedEvent', () => {
+  it('parses a valid InvoiceDisputed event', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_disputed'), u64(INVOICE_ID), addressScVal(TEST_DISPUTER)],
+      valueWith({}),
+    );
+
+    const event = parseInvoiceDisputedEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoiceDisputed');
+    expect(event!.invoiceId).toBe(INVOICE_ID);
+    expect(event!.disputer).toBe(TEST_DISPUTER);
+    expect(event!.timestamp).toBe(TIMESTAMP);
+  });
+});
+
+describe('parseReputationUpdatedEvent', () => {
+  it('parses a valid ReputationUpdated event', () => {
+    const raw = makeRawEvent(
+      [sym('reputation_updated'), addressScVal(TEST_ADDRESS)],
+      valueWith({ score: u32(SCORE) }),
+    );
+
+    const event = parseReputationUpdatedEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('ReputationUpdated');
+    expect(event!.address).toBe(TEST_ADDRESS);
+    expect(event!.score).toBe(SCORE);
+    expect(event!.timestamp).toBe(TIMESTAMP);
+  });
+});
+
+describe('parseContractPausedEvent', () => {
+  it('parses a valid ContractPaused event', () => {
+    const raw = makeRawEvent(
+      [sym('contract_paused')],
+      valueWith({}),
+    );
+
+    const event = parseContractPausedEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('ContractPaused');
+    expect(event!.timestamp).toBe(TIMESTAMP);
+  });
+});
+
+describe('parseTokenAddedEvent', () => {
+  it('parses a valid TokenAdded event', () => {
+    const raw = makeRawEvent(
+      [sym('token_added'), addressScVal(TEST_TOKEN)],
+      valueWith({}),
+    );
+
+    const event = parseTokenAddedEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('TokenAdded');
+    expect(event!.token).toBe(TEST_TOKEN);
+    expect(event!.timestamp).toBe(TIMESTAMP);
+  });
+});
+
+describe('parseLPPositionTransferredEvent', () => {
+  it('parses a valid LPPositionTransferred event', () => {
+    const raw = makeRawEvent(
+      [
+        sym('lp_position_transferred'),
+        addressScVal(TEST_FROM),
+        addressScVal(TEST_TO),
+        u64(INVOICE_ID),
+      ],
+      valueWith({}),
+    );
+
+    const event = parseLPPositionTransferredEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('LPPositionTransferred');
+    expect(event!.from).toBe(TEST_FROM);
+    expect(event!.to).toBe(TEST_TO);
+    expect(event!.invoiceId).toBe(INVOICE_ID);
+    expect(event!.timestamp).toBe(TIMESTAMP);
+  });
+
+  it('returns null when topics are missing', () => {
+    const raw = makeRawEvent(
+      [sym('lp_position_transferred')],
+      valueWith({}),
+    );
+
+    expect(parseLPPositionTransferredEvent(raw)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseContractEvent (unified dispatcher)
+// ---------------------------------------------------------------------------
+
+describe('parseContractEvent', () => {
+  it('dispatches InvoiceSubmitted', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_submitted'), u64(INVOICE_ID), addressScVal(TEST_ISSUER)],
+      valueWith({ amount: i128(AMOUNT) }),
+    );
+    const event = parseContractEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoiceSubmitted');
+  });
+
+  it('dispatches InvoiceFunded', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_funded'), u64(INVOICE_ID), addressScVal(TEST_FUNDER)],
+      valueWith({ amount: i128(AMOUNT) }),
+    );
+    const event = parseContractEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoiceFunded');
+  });
+
+  it('dispatches InvoicePaid', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_paid'), u64(INVOICE_ID), addressScVal(TEST_PAYER)],
+      valueWith({ amount: i128(AMOUNT) }),
+    );
+    const event = parseContractEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoicePaid');
+  });
+
+  it('dispatches InvoiceCancelled', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_cancelled'), u64(INVOICE_ID)],
+      valueWith({}),
+    );
+    const event = parseContractEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoiceCancelled');
+  });
+
+  it('dispatches InvoiceExpired', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_expired'), u64(INVOICE_ID)],
+      valueWith({}),
+    );
+    const event = parseContractEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoiceExpired');
+  });
+
+  it('dispatches InvoiceDisputed', () => {
+    const raw = makeRawEvent(
+      [sym('invoice_disputed'), u64(INVOICE_ID), addressScVal(TEST_DISPUTER)],
+      valueWith({}),
+    );
+    const event = parseContractEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('InvoiceDisputed');
+  });
+
+  it('dispatches ReputationUpdated', () => {
+    const raw = makeRawEvent(
+      [sym('reputation_updated'), addressScVal(TEST_ADDRESS)],
+      valueWith({ score: u32(SCORE) }),
+    );
+    const event = parseContractEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('ReputationUpdated');
+  });
+
+  it('dispatches ContractPaused', () => {
+    const raw = makeRawEvent(
+      [sym('contract_paused')],
+      valueWith({}),
+    );
+    const event = parseContractEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('ContractPaused');
+  });
+
+  it('dispatches TokenAdded', () => {
+    const raw = makeRawEvent(
+      [sym('token_added'), addressScVal(TEST_TOKEN)],
+      valueWith({}),
+    );
+    const event = parseContractEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('TokenAdded');
+  });
+
+  it('dispatches LPPositionTransferred', () => {
+    const raw = makeRawEvent(
+      [
+        sym('lp_position_transferred'),
+        addressScVal(TEST_FROM),
+        addressScVal(TEST_TO),
+        u64(INVOICE_ID),
+      ],
+      valueWith({}),
+    );
+    const event = parseContractEvent(raw);
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('LPPositionTransferred');
+  });
+
+  it('returns null for unknown event names', () => {
+    const raw = makeRawEvent(
+      [sym('unknown_event'), u64(INVOICE_ID)],
+      valueWith({}),
+    );
+    expect(parseContractEvent(raw)).toBeNull();
+  });
+
+  it('returns null for empty topics', () => {
+    const raw = makeRawEvent([], valueWith({}));
+    expect(parseContractEvent(raw)).toBeNull();
+  });
+
+  it('returns null for null/undefined input', () => {
+    expect(parseContractEvent(null as unknown as RawEvent)).toBeNull();
+    expect(parseContractEvent(undefined as unknown as RawEvent)).toBeNull();
+  });
+});
+
+describe('supportedEventTypes', () => {
+  it('returns all 10 event type names', () => {
+    const types = supportedEventTypes();
+    expect(types).toHaveLength(10);
+    expect(types).toContain('InvoiceSubmitted');
+    expect(types).toContain('InvoiceFunded');
+    expect(types).toContain('InvoicePaid');
+    expect(types).toContain('InvoiceCancelled');
+    expect(types).toContain('InvoiceExpired');
+    expect(types).toContain('InvoiceDisputed');
+    expect(types).toContain('ReputationUpdated');
+    expect(types).toContain('ContractPaused');
+    expect(types).toContain('TokenAdded');
+    expect(types).toContain('LPPositionTransferred');
+  });
+});

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -1,0 +1,487 @@
+import { scValToNative, xdr as stellarXdr } from '@stellar/stellar-sdk';
+
+/**
+ * A raw Soroban contract event with decoded XDR topics and value.
+ * Consumers can obtain this from Horizon/SorobanRPC by decoding
+ * base64-encoded XDR using the `xdr.decode()` utility.
+ */
+export interface RawEvent {
+  /** Decoded XDR ScVal topics (first element is the event name symbol). */
+  topics: stellarXdr.ScVal[];
+  /** Decoded XDR ScVal value (event data payload). */
+  value: stellarXdr.ScVal;
+}
+
+// ---------------------------------------------------------------------------
+// Event type definitions
+// ---------------------------------------------------------------------------
+
+export interface InvoiceSubmittedEvent {
+  type: 'InvoiceSubmitted';
+  /** Unique invoice identifier. */
+  invoiceId: bigint;
+  /** Stellar address of the invoice issuer (freelancer). */
+  issuer: string;
+  /** Invoice amount in base units (stroops). */
+  amount: bigint;
+  /** Ledger close timestamp of the event. */
+  timestamp: bigint;
+}
+
+export interface InvoiceFundedEvent {
+  type: 'InvoiceFunded';
+  /** Unique invoice identifier. */
+  invoiceId: bigint;
+  /** Stellar address of the liquidity provider who funded the invoice. */
+  funder: string;
+  /** Amount funded in base units (stroops). */
+  amount: bigint;
+  /** Ledger close timestamp of the event. */
+  timestamp: bigint;
+}
+
+export interface InvoicePaidEvent {
+  type: 'InvoicePaid';
+  /** Unique invoice identifier. */
+  invoiceId: bigint;
+  /** Stellar address of the payer who settled the invoice. */
+  payer: string;
+  /** Amount paid in base units (stroops). */
+  amount: bigint;
+  /** Ledger close timestamp of the event. */
+  timestamp: bigint;
+}
+
+export interface InvoiceCancelledEvent {
+  type: 'InvoiceCancelled';
+  /** Unique invoice identifier. */
+  invoiceId: bigint;
+  /** Ledger close timestamp of the event. */
+  timestamp: bigint;
+}
+
+export interface InvoiceExpiredEvent {
+  type: 'InvoiceExpired';
+  /** Unique invoice identifier. */
+  invoiceId: bigint;
+  /** Ledger close timestamp of the event. */
+  timestamp: bigint;
+}
+
+export interface InvoiceDisputedEvent {
+  type: 'InvoiceDisputed';
+  /** Unique invoice identifier. */
+  invoiceId: bigint;
+  /** Stellar address of the party who filed the dispute. */
+  disputer: string;
+  /** Ledger close timestamp of the event. */
+  timestamp: bigint;
+}
+
+export interface ReputationUpdatedEvent {
+  type: 'ReputationUpdated';
+  /** Stellar address whose reputation was updated. */
+  address: string;
+  /** New reputation score (0–100). */
+  score: number;
+  /** Ledger close timestamp of the event. */
+  timestamp: bigint;
+}
+
+export interface ContractPausedEvent {
+  type: 'ContractPaused';
+  /** Ledger close timestamp of the event. */
+  timestamp: bigint;
+}
+
+export interface TokenAddedEvent {
+  type: 'TokenAdded';
+  /** Stellar Asset Contract address of the newly supported token. */
+  token: string;
+  /** Ledger close timestamp of the event. */
+  timestamp: bigint;
+}
+
+export interface LPPositionTransferredEvent {
+  type: 'LPPositionTransferred';
+  /** Stellar address of the previous LP position holder. */
+  from: string;
+  /** Stellar address of the new LP position holder. */
+  to: string;
+  /** Invoice ID whose LP position was transferred. */
+  invoiceId: bigint;
+  /** Ledger close timestamp of the event. */
+  timestamp: bigint;
+}
+
+/**
+ * Discriminated union of all known contract events.
+ * Discriminated by the `type` field.
+ */
+export type ContractEvent =
+  | InvoiceSubmittedEvent
+  | InvoiceFundedEvent
+  | InvoicePaidEvent
+  | InvoiceCancelledEvent
+  | InvoiceExpiredEvent
+  | InvoiceDisputedEvent
+  | ReputationUpdatedEvent
+  | ContractPausedEvent
+  | TokenAddedEvent
+  | LPPositionTransferredEvent;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function nativeValue(scVal: stellarXdr.ScVal): unknown {
+  try {
+    return scValToNative(scVal);
+  } catch {
+    return null;
+  }
+}
+
+function symbolToString(scVal: stellarXdr.ScVal): string | null {
+  const val = nativeValue(scVal);
+  return typeof val === 'string' ? val : null;
+}
+
+function toBigint(val: unknown): bigint | null {
+  if (typeof val === 'bigint') return val;
+  if (typeof val === 'number') return BigInt(val);
+  if (typeof val === 'string') {
+    try {
+      return BigInt(val);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function toNumber(val: unknown): number | null {
+  if (typeof val === 'number') return val;
+  if (typeof val === 'bigint') return Number(val);
+  return null;
+}
+
+function toString(val: unknown): string | null {
+  if (typeof val === 'string') return val;
+  return null;
+}
+
+function getField(obj: unknown, key: string): unknown {
+  if (!obj || typeof obj !== 'object') return undefined;
+  if (obj instanceof Map) return obj.get(key);
+  return (obj as Record<string, unknown>)[key];
+}
+
+function extractBigintMap(scVal: stellarXdr.ScVal, key: string): bigint | null {
+  const native = nativeValue(scVal);
+  const val = getField(native, key);
+  return toBigint(val);
+}
+
+function extractNumberMap(scVal: stellarXdr.ScVal, key: string): number | null {
+  const native = nativeValue(scVal);
+  const val = getField(native, key);
+  return toNumber(val);
+}
+
+function extractStringMap(scVal: stellarXdr.ScVal, key: string): string | null {
+  const native = nativeValue(scVal);
+  const val = getField(native, key);
+  return toString(val);
+}
+
+// ---------------------------------------------------------------------------
+// Event name → symbol mapping
+// ---------------------------------------------------------------------------
+
+const EVENT_NAME_MAP: Record<string, string> = {
+  invoice_submitted: 'InvoiceSubmitted',
+  invoice_funded: 'InvoiceFunded',
+  invoice_paid: 'InvoicePaid',
+  invoice_cancelled: 'InvoiceCancelled',
+  invoice_expired: 'InvoiceExpired',
+  invoice_disputed: 'InvoiceDisputed',
+  reputation_updated: 'ReputationUpdated',
+  contract_paused: 'ContractPaused',
+  token_added: 'TokenAdded',
+  lp_position_transferred: 'LPPositionTransferred',
+};
+
+// ---------------------------------------------------------------------------
+// Individual event parsers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses an `InvoiceSubmitted` event from raw Soroban event data.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed event or `null` if the data does not match this event.
+ */
+export function parseInvoiceSubmittedEvent(raw: RawEvent): InvoiceSubmittedEvent | null {
+  if (raw.topics.length < 2) return null;
+  const name = symbolToString(raw.topics[0]);
+  if (name !== 'invoice_submitted') return null;
+
+  const invoiceId = toBigint(nativeValue(raw.topics[1]));
+  if (invoiceId === null) return null;
+
+  return {
+    type: 'InvoiceSubmitted',
+    invoiceId,
+    issuer: toString(nativeValue(raw.topics[2])) ?? '',
+    amount: extractBigintMap(raw.value, 'amount') ?? 0n,
+    timestamp: extractBigintMap(raw.value, 'timestamp') ?? 0n,
+  };
+}
+
+/**
+ * Parses an `InvoiceFunded` event from raw Soroban event data.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed event or `null` if the data does not match this event.
+ */
+export function parseInvoiceFundedEvent(raw: RawEvent): InvoiceFundedEvent | null {
+  if (raw.topics.length < 2) return null;
+  const name = symbolToString(raw.topics[0]);
+  if (name !== 'invoice_funded') return null;
+
+  const invoiceId = toBigint(nativeValue(raw.topics[1]));
+  if (invoiceId === null) return null;
+
+  return {
+    type: 'InvoiceFunded',
+    invoiceId,
+    funder: toString(nativeValue(raw.topics[2])) ?? '',
+    amount: extractBigintMap(raw.value, 'amount') ?? 0n,
+    timestamp: extractBigintMap(raw.value, 'timestamp') ?? 0n,
+  };
+}
+
+/**
+ * Parses an `InvoicePaid` event from raw Soroban event data.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed event or `null` if the data does not match this event.
+ */
+export function parseInvoicePaidEvent(raw: RawEvent): InvoicePaidEvent | null {
+  if (raw.topics.length < 2) return null;
+  const name = symbolToString(raw.topics[0]);
+  if (name !== 'invoice_paid') return null;
+
+  const invoiceId = toBigint(nativeValue(raw.topics[1]));
+  if (invoiceId === null) return null;
+
+  return {
+    type: 'InvoicePaid',
+    invoiceId,
+    payer: toString(nativeValue(raw.topics[2])) ?? '',
+    amount: extractBigintMap(raw.value, 'amount') ?? 0n,
+    timestamp: extractBigintMap(raw.value, 'timestamp') ?? 0n,
+  };
+}
+
+/**
+ * Parses an `InvoiceCancelled` event from raw Soroban event data.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed event or `null` if the data does not match this event.
+ */
+export function parseInvoiceCancelledEvent(raw: RawEvent): InvoiceCancelledEvent | null {
+  if (raw.topics.length < 2) return null;
+  const name = symbolToString(raw.topics[0]);
+  if (name !== 'invoice_cancelled') return null;
+
+  const invoiceId = toBigint(nativeValue(raw.topics[1]));
+  if (invoiceId === null) return null;
+
+  return {
+    type: 'InvoiceCancelled',
+    invoiceId,
+    timestamp: extractBigintMap(raw.value, 'timestamp') ?? 0n,
+  };
+}
+
+/**
+ * Parses an `InvoiceExpired` event from raw Soroban event data.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed event or `null` if the data does not match this event.
+ */
+export function parseInvoiceExpiredEvent(raw: RawEvent): InvoiceExpiredEvent | null {
+  if (raw.topics.length < 2) return null;
+  const name = symbolToString(raw.topics[0]);
+  if (name !== 'invoice_expired') return null;
+
+  const invoiceId = toBigint(nativeValue(raw.topics[1]));
+  if (invoiceId === null) return null;
+
+  return {
+    type: 'InvoiceExpired',
+    invoiceId,
+    timestamp: extractBigintMap(raw.value, 'timestamp') ?? 0n,
+  };
+}
+
+/**
+ * Parses an `InvoiceDisputed` event from raw Soroban event data.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed event or `null` if the data does not match this event.
+ */
+export function parseInvoiceDisputedEvent(raw: RawEvent): InvoiceDisputedEvent | null {
+  if (raw.topics.length < 2) return null;
+  const name = symbolToString(raw.topics[0]);
+  if (name !== 'invoice_disputed') return null;
+
+  const invoiceId = toBigint(nativeValue(raw.topics[1]));
+  if (invoiceId === null) return null;
+
+  return {
+    type: 'InvoiceDisputed',
+    invoiceId,
+    disputer: toString(nativeValue(raw.topics[2])) ?? '',
+    timestamp: extractBigintMap(raw.value, 'timestamp') ?? 0n,
+  };
+}
+
+/**
+ * Parses a `ReputationUpdated` event from raw Soroban event data.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed event or `null` if the data does not match this event.
+ */
+export function parseReputationUpdatedEvent(raw: RawEvent): ReputationUpdatedEvent | null {
+  const name = symbolToString(raw.topics[0]);
+  if (name !== 'reputation_updated') return null;
+
+  return {
+    type: 'ReputationUpdated',
+    address: toString(nativeValue(raw.topics[1])) ?? '',
+    score: extractNumberMap(raw.value, 'score') ?? 0,
+    timestamp: extractBigintMap(raw.value, 'timestamp') ?? 0n,
+  };
+}
+
+/**
+ * Parses a `ContractPaused` event from raw Soroban event data.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed event or `null` if the data does not match this event.
+ */
+export function parseContractPausedEvent(raw: RawEvent): ContractPausedEvent | null {
+  const name = symbolToString(raw.topics[0]);
+  if (name !== 'contract_paused') return null;
+
+  return {
+    type: 'ContractPaused',
+    timestamp: extractBigintMap(raw.value, 'timestamp') ?? 0n,
+  };
+}
+
+/**
+ * Parses a `TokenAdded` event from raw Soroban event data.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed event or `null` if the data does not match this event.
+ */
+export function parseTokenAddedEvent(raw: RawEvent): TokenAddedEvent | null {
+  const name = symbolToString(raw.topics[0]);
+  if (name !== 'token_added') return null;
+
+  return {
+    type: 'TokenAdded',
+    token: toString(nativeValue(raw.topics[1])) ?? '',
+    timestamp: extractBigintMap(raw.value, 'timestamp') ?? 0n,
+  };
+}
+
+/**
+ * Parses an `LPPositionTransferred` event from raw Soroban event data.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed event or `null` if the data does not match this event.
+ */
+export function parseLPPositionTransferredEvent(raw: RawEvent): LPPositionTransferredEvent | null {
+  if (raw.topics.length < 3) return null;
+  const name = symbolToString(raw.topics[0]);
+  if (name !== 'lp_position_transferred') return null;
+
+  return {
+    type: 'LPPositionTransferred',
+    from: toString(nativeValue(raw.topics[1])) ?? '',
+    to: toString(nativeValue(raw.topics[2])) ?? '',
+    invoiceId: toBigint(nativeValue(raw.topics[3])) ?? 0n,
+    timestamp: extractBigintMap(raw.value, 'timestamp') ?? 0n,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Individual parser registry
+// ---------------------------------------------------------------------------
+
+type ParserFn = (raw: RawEvent) => ContractEvent | null;
+
+const PARSERS: Record<string, ParserFn> = {
+  invoice_submitted: parseInvoiceSubmittedEvent as ParserFn,
+  invoice_funded: parseInvoiceFundedEvent as ParserFn,
+  invoice_paid: parseInvoicePaidEvent as ParserFn,
+  invoice_cancelled: parseInvoiceCancelledEvent as ParserFn,
+  invoice_expired: parseInvoiceExpiredEvent as ParserFn,
+  invoice_disputed: parseInvoiceDisputedEvent as ParserFn,
+  reputation_updated: parseReputationUpdatedEvent as ParserFn,
+  contract_paused: parseContractPausedEvent as ParserFn,
+  token_added: parseTokenAddedEvent as ParserFn,
+  lp_position_transferred: parseLPPositionTransferredEvent as ParserFn,
+};
+
+// ---------------------------------------------------------------------------
+// Unified dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses any known Soroban contract event from raw event data.
+ *
+ * Inspects `topics[0]` to determine the event type and delegates to the
+ * appropriate parser. Returns `null` for unknown or malformed events.
+ *
+ * @param raw - The decoded raw event (topics + value).
+ * @returns The typed {@link ContractEvent} or `null` if unknown.
+ *
+ * @example
+ * ```ts
+ * import { parseContractEvent } from '@iln/sdk';
+ * import { xdr } from '@iln/sdk';
+ *
+ * const raw: RawEvent = {
+ *   topics: [xdr.decode('AAAAEAAA...')],
+ *   value: xdr.decode('AAAAEQAA...'),
+ * };
+ * const event = parseContractEvent(raw);
+ * if (event?.type === 'InvoiceFunded') {
+ *   console.log(event.invoiceId, event.funder);
+ * }
+ * ```
+ */
+export function parseContractEvent(raw: RawEvent): ContractEvent | null {
+  if (!raw || !raw.topics || raw.topics.length === 0) return null;
+
+  const name = symbolToString(raw.topics[0]);
+  if (!name) return null;
+
+  const parser = PARSERS[name];
+  if (!parser) return null;
+
+  return parser(raw);
+}
+
+/**
+ * Returns the list of all supported event type names (PascalCase).
+ */
+export function supportedEventTypes(): string[] {
+  return Object.values(EVENT_NAME_MAP);
+}

--- a/packages/sdk/src/exports.test.ts
+++ b/packages/sdk/src/exports.test.ts
@@ -1,0 +1,73 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const pkgPath = path.resolve(__dirname, '../package.json');
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+
+describe('package.json exports', () => {
+  it('has sideEffects set to false', () => {
+    expect(pkg.sideEffects).toBe(false);
+  });
+
+  it('has all required subpath exports', () => {
+    const subpaths = Object.keys(pkg.exports).sort();
+    expect(subpaths).toEqual(['.', './errors', './events', './tokens', './xdr']);
+  });
+
+  it.each(['.', './errors', './events', './tokens', './xdr'])(
+    'subpath %s has import, require, and types conditions',
+    (subpath) => {
+      const entry = pkg.exports[subpath];
+      expect(entry).toBeDefined();
+
+      if (subpath === '.') {
+        expect(entry.import).toBe('./dist/index.js');
+        expect(entry.require).toBe('./dist/index.cjs');
+        expect(entry.types).toBe('./dist/index.d.ts');
+        expect(entry.browser).toBe('./dist/browser/index.js');
+      } else {
+        const name = subpath.replace('./', '');
+        expect(entry.import).toBe(`./dist/${name}.js`);
+        expect(entry.require).toBe(`./dist/${name}.cjs`);
+        expect(entry.types).toBe(`./dist/${name}.d.ts`);
+      }
+    },
+  );
+
+  it.each([
+    './errors',
+    './events',
+    './tokens',
+    './xdr',
+  ])('subpath %s maps to an existing source file', (subpath) => {
+    const name = subpath.replace('./', '');
+    const srcFile = path.resolve(__dirname, `${name}.ts`);
+    expect(fs.existsSync(srcFile)).toBe(true);
+  });
+
+  it('has a build script that includes all entry points', () => {
+    const buildScript = pkg.scripts.build;
+    expect(buildScript).toContain('src/index.ts');
+    expect(buildScript).toContain('src/tokens.ts');
+    expect(buildScript).toContain('src/events.ts');
+    expect(buildScript).toContain('src/errors.ts');
+    expect(buildScript).toContain('src/xdr.ts');
+  });
+});
+
+describe('import boundary', () => {
+  it('does not expose internal source files via exports', () => {
+    const subpaths = Object.keys(pkg.exports);
+    const internalFiles = [
+      './clients/InvoiceClient',
+      './amount-formatting',
+      './crypto-browser',
+      './reputation',
+      './index',
+      './index.browser',
+    ];
+    for (const internal of internalFiles) {
+      expect(subpaths).not.toContain(internal);
+    }
+  });
+});

--- a/packages/sdk/src/index.browser.ts
+++ b/packages/sdk/src/index.browser.ts
@@ -1,6 +1,7 @@
 // Browser-specific entry point for the ILN SDK.
 // Relies on Web Crypto API instead of Node.js crypto.
 export * from './clients/InvoiceClient';
+export * from './events';
 export * from './reputation';
 export * from './crypto-browser';
 export * from './tokens';

--- a/packages/sdk/src/index.browser.ts
+++ b/packages/sdk/src/index.browser.ts
@@ -1,6 +1,7 @@
 // Browser-specific entry point for the ILN SDK.
 // Relies on Web Crypto API instead of Node.js crypto.
 export * from './clients/InvoiceClient';
+export * from './reputation';
 export * from './crypto-browser';
 export * from './tokens';
 export * from './amount-formatting';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from './clients/InvoiceClient';
+export * from './events';
 export * from './reputation';
 export * from './xdr';
 export * from './tokens';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from './clients/InvoiceClient';
+export * from './reputation';
 export * from './xdr';
 export * from './tokens';
 export * from './amount-formatting';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from './clients/InvoiceClient';
+export * from './errors';
 export * from './events';
 export * from './reputation';
 export * from './xdr';

--- a/packages/sdk/src/reputation.test.ts
+++ b/packages/sdk/src/reputation.test.ts
@@ -1,0 +1,150 @@
+import { nativeToScVal, scValToNative, xdr, Keypair } from '@stellar/stellar-sdk';
+
+import { ReputationClient, type ReputationScore } from './reputation';
+
+const TEST_PUBLIC_KEY = Keypair.random().publicKey();
+const TEST_CONTRACT_ID = Keypair.random().publicKey();
+
+function makeScoreScVal(overrides: Partial<Record<string, unknown>> = {}) {
+  const fields: Record<string, unknown> = {
+    score: nativeToScVal(85, { type: 'u32' }),
+    total_paid: nativeToScVal(5_000_000_000n, { type: 'i128' }),
+    invoice_count: nativeToScVal(42, { type: 'u32' }),
+    last_activity: nativeToScVal(1_700_000_000n, { type: 'u64' }),
+    rank: nativeToScVal(5, { type: 'u32' }),
+    ...overrides,
+  };
+  return xdr.ScVal.scvMap(
+    Object.entries(fields).map(
+      ([key, val]) =>
+        new xdr.ScMapEntry({
+          key: nativeToScVal(key, { type: 'symbol' }),
+          val: val as xdr.ScVal,
+        }),
+    ),
+  );
+}
+
+describe('ReputationClient', () => {
+  it('should initialize correctly', () => {
+    const client = new ReputationClient(
+      'https://soroban-testnet.stellar.org',
+      TEST_CONTRACT_ID,
+    );
+    expect(client).toBeDefined();
+  });
+
+  describe('getReputation', () => {
+    it('returns a zeroed ReputationScore when the address is not found', async () => {
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockRejectedValue(new Error('not found'));
+
+      const result = await client.getReputation(TEST_PUBLIC_KEY);
+      expect(result.address).toBe(TEST_PUBLIC_KEY);
+      expect(result.score).toBe(0);
+      expect(result.totalPaid).toBe(0n);
+      expect(result.invoiceCount).toBe(0);
+      expect(result.lastActivity).toBe(0);
+      expect(result.rank).toBe(0);
+    });
+
+    it('parses a valid contract response into a ReputationScore', async () => {
+      const mapScVal = makeScoreScVal();
+
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockImplementation(
+        async () => mapScVal,
+      );
+
+      const result = await client.getReputation(TEST_PUBLIC_KEY);
+      expect(result.address).toBe(TEST_PUBLIC_KEY);
+      expect(result.score).toBe(85);
+      expect(result.totalPaid).toBe(5_000_000_000n);
+      expect(result.invoiceCount).toBe(42);
+      expect(result.lastActivity).toBe(1_700_000_000);
+      expect(result.rank).toBe(5);
+    });
+  });
+
+  describe('getReputationScore', () => {
+    it('returns 0 for an unknown address', async () => {
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockRejectedValue(new Error('not found'));
+
+      const score = await client.getReputationScore(TEST_PUBLIC_KEY);
+      expect(score).toBe(0);
+    });
+
+    it('returns the score from a valid response', async () => {
+      const mapScVal = makeScoreScVal({ score: nativeToScVal(92, { type: 'u32' }) });
+
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockImplementation(
+        async () => mapScVal,
+      );
+
+      const score = await client.getReputationScore(TEST_PUBLIC_KEY);
+      expect(score).toBe(92);
+    });
+  });
+
+  describe('getTopPayers', () => {
+    it('returns an empty array when the contract has no data', async () => {
+      const emptyVec = xdr.ScVal.scvVec([]);
+
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockImplementation(
+        async () => emptyVec,
+      );
+
+      const result = await client.getTopPayers(10);
+      expect(result).toEqual([]);
+    });
+
+    it('returns payer entries from a contract response', async () => {
+      const payer1Addr = Keypair.random().publicKey();
+      const payer2Addr = Keypair.random().publicKey();
+
+      const vecScVal = xdr.ScVal.scvVec([
+        makeScoreScVal({
+          score: nativeToScVal(90, { type: 'u32' }),
+          rank: nativeToScVal(1, { type: 'u32' }),
+          address: nativeToScVal(payer1Addr, { type: 'symbol' }),
+        }),
+        makeScoreScVal({
+          score: nativeToScVal(75, { type: 'u32' }),
+          total_paid: nativeToScVal(3_000_000_000n, { type: 'i128' }),
+          invoice_count: nativeToScVal(20, { type: 'u32' }),
+          rank: nativeToScVal(2, { type: 'u32' }),
+          address: nativeToScVal(payer2Addr, { type: 'symbol' }),
+        }),
+      ]);
+
+      const client = new ReputationClient(
+        'https://soroban-testnet.stellar.org',
+        TEST_CONTRACT_ID,
+      );
+      jest.spyOn(client as any, 'simulate').mockImplementation(
+        async () => vecScVal,
+      );
+
+      const result = await client.getTopPayers(2);
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/packages/sdk/src/reputation.ts
+++ b/packages/sdk/src/reputation.ts
@@ -1,0 +1,206 @@
+import {
+  SorobanRpc,
+  nativeToScVal,
+  scValToNative,
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  Contract,
+  Address,
+  xdr as stellarXdr,
+} from '@stellar/stellar-sdk';
+
+/**
+ * Reputation score for an address on the Invoice Liquidity Network.
+ *
+ * Returned by {@link ReputationClient.getReputation} and
+ * {@link ReputationClient.getTopPayers}.
+ */
+export interface ReputationScore {
+  /** Stellar public address (G...) or contract address (C...). */
+  address: string;
+  /** Overall reputation score (0–100). */
+  score: number;
+  /** Total amount paid in base units (stroops). */
+  totalPaid: bigint;
+  /** Number of invoices the address has paid. */
+  invoiceCount: number;
+  /** Unix timestamp of the most recent activity. */
+  lastActivity: number;
+  /** Position in the global payer ranking (1-indexed). */
+  rank: number;
+}
+
+function zeroReputationScore(address: string): ReputationScore {
+  return { address, score: 0, totalPaid: 0n, invoiceCount: 0, lastActivity: 0, rank: 0 };
+}
+
+function parseReputationScore(native: unknown, address: string): ReputationScore {
+  if (!native || typeof native !== 'object') {
+    return zeroReputationScore(address);
+  }
+
+  let get: (key: string) => unknown;
+
+  if (native instanceof Map) {
+    get = (key: string) => (native as Map<string, unknown>).get(key);
+  } else {
+    get = (key: string) => (native as Record<string, unknown>)[key];
+  }
+
+  return {
+    address,
+    score: Math.max(0, Number(get('score') ?? 0)) || 0,
+    totalPaid: BigInt(String(get('total_paid') ?? '0')) || 0n,
+    invoiceCount: Math.max(0, Number(get('invoice_count') ?? 0)) || 0,
+    lastActivity: Math.max(0, Number(get('last_activity') ?? 0)) || 0,
+    rank: Math.max(0, Number(get('rank') ?? 0)) || 0,
+  };
+}
+
+/**
+ * Client for querying on-chain reputation data from the Invoice Liquidity Network.
+ *
+ * Provides type-safe access to the ILN reputation contract without exposing raw XDR.
+ * All contract return values are parsed into clean {@link ReputationScore} structs.
+ *
+ * @example
+ * ```ts
+ * import { ReputationClient } from '@iln/sdk';
+ *
+ * const client = new ReputationClient(
+ *   'https://soroban-testnet.stellar.org',
+ *   'CA3D...',
+ * );
+ *
+ * const rep = await client.getReputation('GB...');
+ * console.log(rep.score); // 85
+ *
+ * const top = await client.getTopPayers(10);
+ * console.log(top.length); // 10
+ * ```
+ */
+export class ReputationClient {
+  private server: SorobanRpc.Server;
+  private contractId: string;
+  private networkPassphrase: string;
+  private source: string;
+
+  /**
+   * @param rpcUrl - Soroban RPC endpoint (e.g. `https://soroban-testnet.stellar.org`).
+   * @param contractId - The deployed reputation contract ID (C... address).
+   * @param options - Optional configuration.
+   * @param options.networkPassphrase - Network passphrase (defaults to `Networks.TESTNET`).
+   * @param options.source - Source account public key for simulation. If omitted, a random keypair is used (suitable for read-only queries where the simulation does not require a funded account).
+   */
+  constructor(
+    rpcUrl: string,
+    contractId: string,
+    options?: { networkPassphrase?: string; source?: string },
+  ) {
+    this.server = new SorobanRpc.Server(rpcUrl);
+    this.contractId = contractId;
+    this.networkPassphrase = options?.networkPassphrase ?? Networks.TESTNET;
+    this.source = options?.source ?? Keypair.random().publicKey();
+  }
+
+  /**
+   * Returns the full reputation profile for a Stellar address.
+   *
+   * If the address has no on-chain history, a zeroed {@link ReputationScore}
+   * is returned instead of throwing.
+   *
+   * @param address - Stellar public key (G...) or contract address (C...).
+   *
+   * @example
+   * ```ts
+   * const rep = await client.getReputation('GABCDEF123...');
+   * // { address: 'GABCDEF123...', score: 75, totalPaid: 5000000000n, ... }
+   * ```
+   */
+  async getReputation(address: string): Promise<ReputationScore> {
+    try {
+      const addressScVal = new Address(address).toScVal();
+      const retval = await this.simulate('get_reputation', [addressScVal]);
+      const native = scValToNative(retval);
+      return parseReputationScore(native, address);
+    } catch {
+      return zeroReputationScore(address);
+    }
+  }
+
+  /**
+   * Returns the top payers ranked by reputation score.
+   *
+   * @param limit - Maximum number of payers to return (max 100).
+   *
+   * @example
+   * ```ts
+   * const top = await client.getTopPayers(5);
+   * top.forEach((p, i) => console.log(`#${i + 1}: ${p.address} (${p.score})`));
+   * ```
+   */
+  async getTopPayers(limit: number): Promise<ReputationScore[]> {
+    const limitScVal = nativeToScVal(limit, { type: 'u32' });
+    const retval = await this.simulate('get_top_payers', [limitScVal]);
+    const native = scValToNative(retval);
+
+    if (!Array.isArray(native)) {
+      return [];
+    }
+
+    return native.map((entry: unknown) => {
+      if (entry && typeof entry === 'object') {
+        const get = (key: string) =>
+          entry instanceof Map
+            ? entry.get(key)
+            : (entry as Record<string, unknown>)[key];
+        const addr = String(get('address') ?? '');
+        return parseReputationScore(entry, addr);
+      }
+      return zeroReputationScore('');
+    });
+  }
+
+  /**
+   * Convenience method that returns only the reputation score for an address.
+   *
+   * Equivalent to `(await client.getReputation(address)).score`.
+   *
+   * @param address - Stellar public key or contract address.
+   *
+   * @example
+   * ```ts
+   * const score = await client.getReputationScore('GABCDEF123...');
+   * if (score > 80) console.log('Highly trusted payer');
+   * ```
+   */
+  async getReputationScore(address: string): Promise<number> {
+    const rep = await this.getReputation(address);
+    return rep.score;
+  }
+
+  private async simulate(method: string, args: stellarXdr.ScVal[]): Promise<stellarXdr.ScVal> {
+    const contract = new Contract(this.contractId);
+    const account = await this.server.getAccount(this.source);
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call(method, ...args))
+      .setTimeout(30)
+      .build();
+
+    const response = await this.server.simulateTransaction(tx);
+
+    if ('error' in response) {
+      throw new Error(response.error);
+    }
+    if (!response.result?.retval) {
+      throw new Error('No return value');
+    }
+    return response.result.retval;
+  }
+}


### PR DESCRIPTION
Summary
Add exports field to packages/sdk/package.json with five subpath entries, set sideEffects: false, add a custom errors module, and update the build pipeline for multi-entry output.

Related Issue
Closes #321 

Complexity
- Trivial (typo, docs, small refactor)
- Medium (new feature, non-breaking change)
- High (breaking change, core protocol logic)
Changes Made
- Add sideEffects: false to packages/sdk/package.json enabling tree-shaking
- Add exports field with 5 subpath entries (., ./tokens, ./events, ./errors, ./xdr) each with import, require, and types conditions
- Update build script in package.json to compile all 5 entry points via tsup (src/index.ts, src/tokens.ts, src/events.ts, src/errors.ts, src/xdr.ts)
- Create packages/sdk/src/errors.ts with 4 custom error classes: ContractCallError, InvalidAddressError, XDRParseError, NetworkError
- Register errors module in src/index.ts exports
- Write 20 tests covering: error class instantiation (errors.test.ts) + exports field structure and import boundary validation (exports.test.ts)
Test Coverage
 PASS  src/errors.test.ts
 PASS  src/exports.test.ts
 PASS  src/tokens.test.ts
 PASS  src/xdr.test.ts
 PASS  src/clients/InvoiceClient.test.ts
 PASS  src/events.test.ts
 PASS  src/reputation.test.ts

Test Suites: 7 passed, 7 total
Tests:       86 passed, 86 total
Security Considerations
None. Exports configuration is a build-time concern with no security implications.
Checklist
- Tests pass locally
- New functionality has test coverage
- Public functions have JSDoc doc comments
- Issue linked (Closes #321 )