### PR TITLE
docs: add ecosystem readiness documentation

### DIFF
--- a/.github/workflows/mainnet-checklist-status.yml
+++ b/.github/workflows/mainnet-checklist-status.yml
@@ -1,0 +1,83 @@
+name: Mainnet Checklist Status
+
+on:
+  issues:
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  update-checklist:
+    name: Update checklist statuses
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Mark rows linked to closed issues as done
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'docs/mainnet-launch-checklist.md';
+            let content = fs.readFileSync(path, 'utf8');
+            const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/`;
+            const issueNumbers = [...content.matchAll(new RegExp(`${repoUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+)`, 'g'))]
+              .map((match) => Number(match[1]));
+            const uniqueIssueNumbers = [...new Set(issueNumbers)];
+            const closedIssues = new Set();
+
+            for (const issue_number of uniqueIssueNumbers) {
+              const { data } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+              });
+
+              if (data.state === 'closed') {
+                closedIssues.add(issue_number);
+              }
+            }
+
+            const updated = content
+              .split('\n')
+              .map((line) => {
+                if (!line.startsWith('|') || !line.includes(repoUrl)) {
+                  return line;
+                }
+
+                const issueMatch = line.match(new RegExp(`${repoUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+)`));
+                if (!issueMatch || !closedIssues.has(Number(issueMatch[1]))) {
+                  return line;
+                }
+
+                const cells = line.split('|');
+                if (cells.length < 6) {
+                  return line;
+                }
+
+                cells[4] = ' Done ';
+                return cells.join('|');
+              })
+              .join('\n');
+
+            if (updated !== content) {
+              fs.writeFileSync(path, updated);
+            }
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: docs: update mainnet checklist statuses
+          title: docs: update mainnet checklist statuses
+          body: |
+            Automated update from the Mainnet Checklist Status workflow.
+
+            Rows linked to closed issues were marked as `Done`.
+          branch: automation/mainnet-checklist-status
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ npm run test:e2e              # Run E2E integration tests
 | [`docs/notifications.md`](./docs/notifications.md) | Notification system |
 | [`docs/api-collection.md`](./docs/api-collection.md) | Horizon and Soroban RPC API collection examples |
 | [`docs/local-development.md`](./docs/local-development.md) | Local dev setup |
+| [`docs/mainnet-launch-checklist.md`](./docs/mainnet-launch-checklist.md) | Mainnet readiness checklist with owners, statuses, and sign-off |
+| [`docs/glossary.md`](./docs/glossary.md) | Protocol terminology for Stellar, invoice factoring, DeFi, and security terms |
 | [`docs/tutorials/first-invoice.md`](./docs/tutorials/first-invoice.md) | Hands-on invoice submission tutorial |
 | [`docs/ci-cd.md`](./docs/ci-cd.md) | CI/CD and deployment environments |
 | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | How to contribute |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,37 +1,84 @@
 # Security Policy
 
+This policy covers the full Invoice Liquidity Network (ILN) ecosystem: Soroban contracts, SDKs and CLI tooling, indexer APIs, notification delivery, documentation, and deployment automation in this repository and linked ILN repositories.
+
 ## Supported Versions
-We currently support security updates for the latest major version of the Invoice Liquidity Network (ILN) protocol and its components.
+
+Security fixes are provided for the latest major version of each maintained ILN component. Pre-mainnet deployments are treated as test environments and must not be used with real funds unless the release notes explicitly say otherwise.
+
+| Component | Supported surface | Notes |
+| --- | --- | --- |
+| Soroban contracts | Latest deployed testnet contracts and release candidates | Includes invoice, reputation, governance, upgrade, and token integration logic. |
+| SDK and CLI | Latest published npm major version | Includes transaction construction, XDR handling, signing flows, and browser or Node.js integrations. |
+| Indexer | Latest main branch deployment target | Includes ingestion, SQLite or API storage, REST and GraphQL endpoints, and rate limiting. |
+| Notifications | Latest main branch deployment target | Includes webhook, email, SMS, digest, and WebSocket delivery paths. |
+| Documentation and CI/CD | Latest main branch | Includes setup guidance, examples, workflows, and release automation. |
 
 ## Reporting a Vulnerability
-If you discover a security vulnerability within ILN, please report it privately. **Do not disclose the vulnerability publicly until a fix has been issued.**
 
-You can report vulnerabilities by:
-- Opening a **GitHub Security Advisory** in this repository.
-- Emailing our security team at security@invoiceliquidity.network.
+Please report suspected vulnerabilities privately. Do not open a public issue, discussion, or pull request with exploit details before the maintainers have investigated and shipped any necessary fix.
 
-### What to Include in Your Report
-- A detailed description of the vulnerability.
-- Step-by-step reproduction instructions.
-- Estimated impact (e.g., how it affects users, transactions, or the protocol).
-- Any potential mitigations you suggest.
+Use either reporting channel:
 
-## Response Timeline
-- **Acknowledgment:** Within 48 hours.
-- **Resolution/Fix:** Within 14 days for Critical severity bugs.
+- Email: `security@invoiceliquidity.network`
+- GitHub: open a private GitHub Security Advisory for the affected ILN repository
+
+Include as much of the following as you can:
+
+- Affected component, version, branch, commit, contract ID, or deployment environment
+- Impact summary, including whether funds, signatures, private data, or service availability are affected
+- Step-by-step reproduction instructions or proof-of-concept code
+- Transaction hashes, logs, screenshots, webhook payloads, API requests, or XDR samples
+- Any known limitations, prerequisites, or suggested mitigations
+- Your preferred contact details and disclosure timeline constraints
+
+## Vulnerability Classes
+
+The examples below are in scope when they affect ILN confidentiality, integrity, availability, signer safety, protocol accounting, or user funds.
+
+| Component | In-scope vulnerability classes |
+| --- | --- |
+| Soroban contracts | Reentrancy or callback ordering issues, storage collision or key namespace confusion, authorization bypass, incorrect invoice lifecycle transition, asset escrow accounting bug, unsafe upgrade path, missing circuit breaker, quorum or timelock bypass, precision or basis point calculation error. |
+| SDK and CLI | XDR encoding or decoding bugs, signing bypass, signing the wrong network passphrase, transaction simulation mismatch, unsafe secret handling, address validation bypass, replay-prone transaction construction, browser bundle crypto regression. |
+| Indexer | SQL injection, API abuse, broken rate limiting, event ingestion poisoning, ledger replay inconsistency, data exposure through REST or GraphQL filters, denial of service through expensive queries, backup or archive leakage. |
+| Notifications | HMAC verification bypass, SSRF through webhook URLs, webhook secret leakage, template injection, notification preference bypass, replayable delivery callbacks, email or SMS abuse, unsafe redirect or URL rendering. |
+| CI/CD and docs | Release provenance tampering, workflow secret exposure, malicious generated docs, dependency confusion, inaccurate security-critical setup instructions. |
 
 ## Severity Classification
-- **Critical:** Allows draining of funds from smart contracts, bypassing authentication, or total system compromise.
-- **High:** Significant data breach, unauthorized state manipulation with limited financial impact.
-- **Medium:** Denial of service (DoS), localized data leaks.
-- **Low:** UI spoofing, minor bugs with no direct financial or data impact.
 
-## Reward Process
-Valid, critical vulnerabilities reported privately that result in a patch may be eligible for a bug bounty reward, determined on a case-by-case basis.
+| Severity | Typical impact | Initial target |
+| --- | --- | --- |
+| Critical | Direct theft or permanent lock of user funds; arbitrary contract state mutation; signing bypass that can authorize transactions; exposed production signing secret; unauthenticated administrative action. | Acknowledge within 48 hours, mitigation or fix target within 7 days, coordinated release as soon as safely possible. |
+| High | Limited fund loss or temporary lock; privilege escalation; persistent data exposure; exploitable SQL injection; HMAC bypass for trusted webhooks; reliable service-wide denial of service. | Acknowledge within 48 hours, fix target within 14 days. |
+| Medium | Localized data exposure; bounded denial of service; incorrect indexer state without fund impact; SDK validation bug requiring user interaction; replay or webhook issue with limited blast radius. | Acknowledge within 48 hours, fix target within 30 days. |
+| Low | Defense-in-depth weakness, misleading security documentation, low-impact information disclosure, non-sensitive spoofing, hardening issue without a practical exploit path. | Acknowledge within 5 business days, address in normal maintenance. |
 
-## Responsible Disclosure Hall of Fame
-We maintain a public hall of fame for security researchers who responsibly disclose vulnerabilities to ILN.
+Severity may be adjusted after triage based on exploitability, affected deployments, user interaction requirements, available mitigations, and whether real funds or signing authority are at risk.
 
-- See the full list in `HALL_OF_FAME.md`
-- Maintainers should add entries after a fix is merged and a disclosure is publicly announced
-- Entries should include researcher handle/name, date, severity, brief description, and CVE/advisory link if applicable
+## Response Process
+
+1. The security team acknowledges the report and assigns a primary maintainer.
+2. Maintainers reproduce the issue, classify severity, and identify affected components.
+3. A private fix branch, patch, configuration change, or operational mitigation is prepared.
+4. The fix is reviewed by maintainers with relevant component ownership.
+5. A release, advisory, or disclosure note is published after affected users have a reasonable update path.
+
+If the report affects multiple ILN repositories, maintainers coordinate the fix privately across those repositories before public disclosure.
+
+## Safe Harbour
+
+ILN supports good-faith security research. We will not pursue legal action or recommend legal action for research that:
+
+- Avoids privacy violations, destruction of data, degradation of service, and interruption of other users
+- Uses the minimum access needed to verify the vulnerability
+- Does not move, drain, or permanently lock funds
+- Does not disclose details publicly before maintainers have completed coordinated remediation
+- Reports findings promptly through the private channels above
+
+Safe harbour does not cover extortion, social engineering, phishing, physical attacks, malware, spam, or attempts to access unrelated third-party systems.
+
+## Bug Bounty and Recognition
+
+ILN does not guarantee bounty payment unless a separate bounty program says otherwise. Valid reports may be eligible for discretionary recognition or reward based on severity, quality of report, and impact.
+
+Researchers who want public credit may be listed in [`HALL_OF_FAME.md`](./HALL_OF_FAME.md) after the issue is fixed and disclosure is approved.

--- a/docs/_meta.json
+++ b/docs/_meta.json
@@ -4,6 +4,7 @@
   "troubleshooting": "Troubleshooting",
   "analytics": "Analytics",
   "local-development": "Local Development",
+  "mainnet-launch-checklist": "Mainnet Launch Checklist",
   "notifications": "Notifications",
   "sdk-api-reference": "SDK API Reference",
   "sdk-migration-guide": "SDK Migration Guide",
@@ -13,5 +14,6 @@
   "cross-repo-sync": "Cross-Repo Sync",
   "branch-protection": "Branch Protection",
   "project-board": "Project Board",
+  "security": "Security",
   "security-guide": "Security Guide"
 }

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,143 +1,123 @@
-# ILN Glossary of Terms
+# Glossary
 
-A reference guide to domain-specific terms used throughout the Invoice Liquidity Network protocol and documentation. Terms are listed in alphabetical order.
-
----
+Protocol terminology used across ILN docs, SDKs, contracts, indexer, and notifications. Terms are sorted alphabetically.
 
 ## Basis Points (bps)
 
-A unit of measurement equal to one-hundredth of one percent (0.01%). Used to express discount rates and yield with precision.
+A unit equal to one-hundredth of one percent, so 100 bps equals 1%. ILN uses bps for discount rates, fees, and yield calculations because integer math is safer in contracts and SDKs.
 
-**ILN usage:** A freelancer submitting an invoice with a 300 bps discount rate is offering a 3% discount on the invoice face value to attract liquidity providers.
+See: [Protocol Economics](protocol-economics.md)
 
----
+## Circuit Breaker
+
+A safety control that pauses or limits sensitive protocol actions during an incident. In ILN, circuit breakers are relevant to contract funding, settlement, upgrades, indexing, and notification delivery.
+
+See: [Security](security.md)
 
 ## Discount Rate
 
-The percentage deducted from an invoice's face value that a liquidity provider receives as compensation for funding the invoice early.
+The percentage discount a submitter accepts in exchange for receiving liquidity before the payer settles the invoice. A 300 bps discount means the liquidity provider funds 97% of face value and earns the 3% spread at settlement.
 
-**ILN usage:** When a freelancer calls `submit_invoice()`, they set a discount rate (in basis points) that determines how much of the invoice value they receive upfront versus what the LP earns at settlement.
-
----
-
-## Due Date
-
-The date by which a payer is expected to settle an invoice in full.
-
-**ILN usage:** The due date is passed as a parameter in `submit_invoice()` and determines the timeframe within which the payer must call `mark_paid()` to release funds to the LP.
-
----
+See: [Protocol Economics](protocol-economics.md)
 
 ## Effective Yield
 
-The annualised return earned by a liquidity provider on a funded invoice, accounting for the discount rate and the time between funding and settlement.
+The annualized return implied by the discount rate and time to settlement. ILN examples commonly calculate this as `(discount_bps / 10000) * (365 / days_to_settlement)`.
 
-**ILN usage:** An LP funding a 30-day invoice at 300 bps discount earns an effective yield of approximately 36% APR, calculated as `(bps / 10000) * (365 / days_to_due_date)`.
+See: [LP Funding Tutorial](tutorials/lp-funding.md)
 
----
+## HMAC
 
-## Freelancer
+Hash-based Message Authentication Code, a signature-like digest used to verify that a webhook payload came from the expected sender and was not modified. ILN notification receivers should reject webhook requests with missing or invalid HMAC values.
 
-A service provider, creator, or SME that submits an outstanding invoice to the ILN protocol to receive immediate liquidity at a discount rather than waiting for the payer to settle.
-
-**ILN usage:** The freelancer calls `submit_invoice()` with the invoice details, receives USDC immediately after an LP funds it, and is responsible for ensuring the payer settles on time.
-
----
-
-## Funded State
-
-The lifecycle state of an invoice after a liquidity provider has called `fund_invoice()` and the freelancer has received their discounted payment.
-
-**ILN usage:** An invoice in the Funded State is awaiting settlement by the payer; the LP's capital is locked in the contract until `mark_paid()` is called.
-
----
+See: [Notifications](notifications.md)
 
 ## Horizon
 
-The Stellar network's REST API server that provides access to ledger data, account balances, transaction history, and fee estimates.
+Stellar's REST API service for account data, transactions, ledgers, assets, and network metadata. ILN tooling may use Horizon alongside Soroban RPC for account and network state.
 
-**ILN usage:** The ILN indexer queries Horizon to track contract events and invoice state changes, and the SDK uses Horizon endpoints to fetch account sequence numbers before submitting transactions.
+See: [Stellar Primer](stellar-primer.md)
 
----
+## Invoice Factoring
 
-## LP (Liquidity Provider)
+A financing model where an invoice holder sells or discounts an unpaid invoice to receive cash before the payer settles. ILN implements a DeFi version where liquidity providers fund invoices on-chain and receive settlement value later.
 
-A participant who funds invoices on the ILN protocol by sending stablecoins to the contract in exchange for the right to receive the full invoice amount when the payer settles.
+See: [Protocol Overview](protocol-overview.md)
 
-**ILN usage:** An LP calls `fund_invoice()` with a valid invoice ID, sends the discounted amount to the contract, and earns the spread between the funded amount and the face value when the payer calls `mark_paid()`.
+## Ledger
 
----
+An ordered batch of Stellar transactions accepted by network consensus. ILN indexers track ledger ranges to reconstruct invoice events and settlement state.
 
-## Mark Paid
+See: [Indexer Data Model](indexer-data-model.md)
 
-The action taken by a payer to confirm that an invoice has been settled off-chain, triggering the release of the full invoice amount from the contract to the LP.
+## Liquidity Provider (LP)
 
-**ILN usage:** The payer calls `mark_paid()` on the ILN contract once they have transferred funds off-chain; this releases the full invoice face value held in escrow to the liquidity provider.
+A participant who funds invoices by providing liquidity at the discounted amount. The LP expects to receive the invoice face value at settlement and earns the difference as yield.
 
----
+See: [LP Funding Tutorial](tutorials/lp-funding.md)
 
 ## Payer
 
-The client or organisation that owes payment on an outstanding invoice and is responsible for calling `mark_paid()` to settle the invoice on-chain.
+The customer or counterparty responsible for settling the invoice. ILN uses payer identity and behavior as part of invoice authorization, settlement, and reputation flows.
 
-**ILN usage:** The payer's wallet address is recorded in the invoice at submission time; only that address is authorised to call `mark_paid()` for a given invoice.
+See: [Submit Your First Invoice](tutorials/first-invoice.md)
 
----
+## Quorum
 
-## Pending State
+The minimum approval threshold required for a governance or administrative decision. ILN uses quorum concepts for maintainer sign-off, governance changes, and mainnet readiness decisions.
 
-The lifecycle state of an invoice after it has been submitted by a freelancer but before any liquidity provider has funded it.
-
-**ILN usage:** An invoice in the Pending State is visible to LPs browsing the protocol; it remains in this state until `fund_invoice()` is called or it expires unfunded.
-
----
+See: [Governance Guide](governance-guide.md)
 
 ## Reputation Score
 
-An on-chain metric assigned to freelancers and payers that reflects their track record of successful invoice settlements on the ILN protocol.
+A score that represents observed reliability for submitters, payers, or related protocol actors. ILN reputation can help liquidity providers assess invoice risk and discount expectations.
 
-**ILN usage:** A payer with a high Reputation Score signals reliability to LPs, potentially attracting funding at lower discount rates; the score is updated by the ILN-Smart-Contract after each `mark_paid()` call.
+See: [Reputation Contract](contracts/reputation-contract.md)
 
----
+## Settlement
 
-## SAC (Stellar Asset Contract)
+The point where the payer's obligation is marked as paid and the protocol releases or accounts for final value owed to the liquidity provider. Settlement changes invoice state and is a core event for indexer and notification consumers.
 
-A Soroban smart contract that wraps a native Stellar asset, making it accessible to other Soroban contracts via the standard token interface.
-
-**ILN usage:** USDC on the ILN protocol is represented as a SAC, allowing the ILN contract to call `transfer()` directly on the token contract to move funds between freelancers, LPs, and the escrow.
-
----
+See: [Invoice Contract](contracts/invoice-contract.md)
 
 ## Soroban
 
-Stellar's smart contract platform that allows developers to write and deploy WebAssembly (WASM) contracts on the Stellar ledger.
+Stellar's smart contract platform, where contracts are compiled to WebAssembly and run with Stellar ledger integration. ILN contract logic for invoices, reputation, and governance is designed for Soroban.
 
-**ILN usage:** All ILN core logic — invoice submission, funding, settlement, and governance — is implemented as Soroban smart contracts deployed to the Stellar network.
+See: [Stellar Primer](stellar-primer.md)
 
----
+## Stellar Asset Contract (SAC)
 
-## Stroop
+A Soroban contract interface that represents Stellar assets for smart contract use. ILN uses SAC-compatible assets such as USDC-style stablecoins for funding and settlement flows.
 
-The smallest unit of XLM (Stellar's native currency), equal to one ten-millionth of one XLM (0.0000001 XLM). Used for precise fee and balance calculations.
-
-**ILN usage:** Transaction fees on the ILN protocol are denominated in stroops; the SDK exposes fee estimates in stroops via the Horizon `fee_estimate` endpoint before submitting contract invocations.
-
----
+See: [Multi-Token Support](tokens/multi-token-support.md)
 
 ## Submitter
 
-The wallet address that signs and broadcasts a transaction to the Stellar network on behalf of a freelancer or payer. May be the same as the freelancer or an automated relay.
+The account or service that submits an invoice transaction to the network. The submitter may be the invoice owner directly or an authorized integration using the SDK or CLI.
 
-**ILN usage:** In the ILN CLI, the submitter is configured via the `--source` flag; in the SDK, it is the wallet passed to the `submitInvoice()` call, which must hold enough XLM to cover the transaction fee.
+See: [SDK Quickstart](sdk-quickstart.md)
 
----
+## Timelock
+
+A delay between approval and execution of a sensitive action, such as an upgrade or parameter change. Timelocks give users and maintainers time to inspect pending governance changes before they take effect.
+
+See: [Governance Guide](governance-guide.md)
 
 ## Trustline
 
-An explicit opt-in relationship between a Stellar account and a non-native asset that allows the account to hold and transact that asset.
+A Stellar account's explicit opt-in to hold a non-native asset. Users must have the correct trustline before receiving or transacting certain Stellar assets outside pure Soroban contract custody.
 
-**ILN usage:** Before an LP can receive USDC through the ILN protocol, their Stellar account must have an established trustline for the USDC SAC; the ILN frontend prompts LPs to create this trustline during onboarding.
+See: [Stellar Primer](stellar-primer.md)
 
----
+## XDR
 
-*For terms not listed here, refer to the [Stellar Developers Portal](https://developers.stellar.org) or open an issue in the [ILN repository](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network).*
+External Data Representation, the binary serialization format used by Stellar for transactions, operations, ledger entries, and contract data. ILN SDK and CLI code must encode and decode XDR exactly to avoid signing or submission bugs.
+
+See: [`sdk/src/xdr.ts`](../sdk/src/xdr.ts)
+
+## Yield
+
+The return earned by a liquidity provider for funding an invoice. In ILN, yield usually comes from the discount between the funded amount and the invoice face value paid at settlement.
+
+See: [Protocol Economics](protocol-economics.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,11 +11,14 @@
 ## Development & Operations
 
 - [Local Development](local-development.md)
+- [Mainnet Launch Checklist](mainnet-launch-checklist.md)
 - [Multi-Token Support](tokens/multi-token-support.md)
 - [Mutation Testing](mutation-testing.md)
 - [Notifications](notifications.md)
 - [CI/CD](ci-cd.md)
 - [PR Submission Form](pr-16-submission-form.md)
+- [Security](security.md)
+- [Glossary](glossary.md)
 
 ## Support
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,53 +1,271 @@
-# Local Development Environment
-This guide explains how to quickly set up a local [Soroban](glossary.md#soroban) testing environment for the Invoice Liquidity Network project. The Hardhat-style test environment allows you to develop, build, and test locally in under 5 minutes.
+# Local Development
+
+This guide sets up the local ILN stack: Stellar Quickstart, contract deployment helpers, account seeding, SDK, CLI, indexer, and notifications.
+
 ## Prerequisites
 
-- **Docker** and **Docker Compose**: Required to run the local Stellar node and initialization services.
-- Ensure ports `8000` and `11626` are available.
-- *(Optional)* A compiled `.wasm` contract file located at `backend/target/wasm32-unknown-unknown/release/invoice_liquidity.wasm` or similar. If not found, a dummy contract ID will be generated for testing.
+| Tool | Required version | Why it is needed |
+| --- | --- | --- |
+| Node.js | `>=20` for the root workspace; `>=18` for older package folders | Runs TypeScript services, tests, docs, SDK, CLI, indexer, and notifications. |
+| pnpm | `>=9` | Primary monorepo package manager for root scripts and workspace packages. |
+| npm | Bundled with Node.js | Some legacy package folders still use `package-lock.json` and `npm` scripts directly. |
+| Docker Desktop or Docker Engine | Current stable | Runs the local Stellar node, deployer, and account seeder. |
+| Docker Compose | Compose v2, available as `docker compose` | Starts the local stack from `docker-compose.yml`. |
+| Rust | Stable toolchain | Builds and tests Soroban smart contracts. |
+| Stellar CLI | Current stable | Builds, deploys, and invokes Soroban contracts locally and on testnet. |
+| Git | Current stable | Clones this repo and initializes submodules. |
 
-## Start the Environment
-
-To start the complete environment (Stellar node, contract deployment, and account seeding), run:
+Check the basics:
 
 ```bash
-docker compose up
+node --version
+pnpm --version
+docker --version
+docker compose version
+rustc --version
+cargo --version
+stellar --version
 ```
 
-For detached mode, use:
+## Clone With Submodules
 
 ```bash
-docker compose up -d
+git clone --recurse-submodules https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network.git
+cd Invoice-Liquidity-Network
 ```
 
-The stack will:
-1. Start a local Stellar Quickstart node.
-2. Wait for the node to become healthy.
-3. Deploy the smart contract (via the `contract-deployer` service).
-4. Create and fund test accounts and mock assets (via the `account-seeder` service).
+If the repository was already cloned without submodules:
 
-## Output Directory Contents
+```bash
+git submodule update --init --recursive
+```
 
-Once the `account-seeder` service completes, it writes essential information to the git-ignored `.docker-output/` directory:
+## Install Dependencies
 
-- `.docker-output/accounts.json`: Contains the public and secret keys for the `freelancer`, `payer`, and `funder` test accounts, along with the deployed `usdc` and `eurc` asset IDs, and the `contractId`.
-- `.docker-output/contract-id.txt`: The raw deployed contract ID.
-- `.docker-output/usdc-id.txt` / `.docker-output/eurc-id.txt`: The raw IDs of the mock tokens.
+Install the root workspace first:
 
-These files are formatted for easy consumption by the frontend and CLI tools.
+```bash
+pnpm install
+```
 
-## Tearing Down
+Some top-level services also keep their own lockfiles. Install them when you plan to run those services directly:
 
-To stop the environment and completely clear the local chain state and volumes, run:
+```bash
+npm ci --prefix sdk
+npm ci --prefix cli
+npm ci --prefix indexer
+npm ci --prefix notifications
+```
+
+## Environment Variables
+
+Copy only the examples for the services you run:
+
+```bash
+cp indexer/.env.example indexer/.env
+cp notifications/.env.example notifications/.env
+cp docs/.env.example docs/.env.local
+```
+
+### Indexer Variables
+
+| Variable | Description |
+| --- | --- |
+| `CONTRACT_ID` | Soroban contract ID whose events the indexer reads. Use `.docker-output/contract-id.txt` after local deployment. |
+| `NETWORK_PASSPHRASE` | Stellar network passphrase. Local standalone defaults to `Standalone Network ; February 2017`; testnet uses `Test SDF Network ; September 2015`. |
+| `RPC_URL` | Soroban RPC endpoint. Local Docker uses `http://localhost:8000/soroban/rpc` or the endpoint exposed by the Quickstart image in your version. |
+| `DB_PATH` | SQLite database path for indexed data. |
+| `POLL_INTERVAL_MS` | Polling interval for new ledgers and contract events. |
+| `PORT` | REST API port, usually `3001`. |
+| `START_LEDGER` | First ledger to index. `0` lets the service choose a recent starting point. |
+| `RATE_LIMIT_WINDOW_MS` | Rate limit window length in milliseconds. |
+| `RATE_LIMIT_MAX` | Maximum requests per IP per window. |
+| `RATE_LIMIT_WHITELIST` | Comma-separated IPs exempt from public API rate limiting. |
+| `BACKUP_ENABLED` | Enables automated indexer backups when set to `true`. |
+| `BACKUP_INTERVAL_MS` | Backup cadence in milliseconds. |
+| `BACKUP_DIR` | Local backup output directory. |
+| `BACKUP_MAX_LOCAL` | Number of local backups to retain. |
+| `BACKUP_CLOUD_PROVIDER` | Optional cloud backup provider: `s3`, `gcs`, or `azure`. |
+| `BACKUP_CLOUD_BUCKET` | Cloud bucket name when cloud backups are enabled. |
+| `BACKUP_CLOUD_PREFIX` | Optional folder or key prefix for cloud backups. |
+| `BACKUP_CLOUD_REGION` | Region for the cloud backup bucket. |
+
+### Notifications Variables
+
+| Variable | Description |
+| --- | --- |
+| `NOTIFICATIONS_DB_PATH` | SQLite database path for notification state and preferences. |
+| `NOTIFICATIONS_RPC_URL` | Stellar or Soroban RPC endpoint used to poll invoice events. |
+| `NOTIFICATIONS_CONTRACT_ID` | Contract ID to monitor. Use `.docker-output/contract-id.txt` locally. |
+| `NOTIFICATIONS_NETWORK_PASSPHRASE` | Stellar network passphrase for the monitored network. |
+| `RESEND_API_KEY` | Resend API key for email delivery. Use a test key or leave unset when only running non-delivery tests. |
+| `RESEND_FROM_EMAIL` | Sender address used for email notifications. |
+| `NOTIFICATIONS_POLL_INTERVAL_MS` | Polling interval for event checks. |
+| `NOTIFICATIONS_START_LEDGER` | First ledger to poll. `0` means start from the service default. |
+| `DUE_WARNING_HOURS` | Number of hours before due date to send warnings. |
+| `PORT` | HTTP port for notification APIs, usually `4001`. |
+
+### Docs Variables
+
+| Variable | Description |
+| --- | --- |
+| `NEXT_PUBLIC_ALGOLIA_APP_ID` | Algolia DocSearch application ID. Optional for local docs browsing. |
+| `NEXT_PUBLIC_ALGOLIA_API_KEY` | Public search API key for DocSearch. Optional locally. |
+| `NEXT_PUBLIC_ALGOLIA_INDEX_NAME` | Algolia index name for the docs site. Optional locally. |
+
+## Start the Docker Stack
+
+Make sure ports `8000` and `11626` are free, then start the full stack:
+
+```bash
+docker compose up --build
+```
+
+For detached mode:
+
+```bash
+docker compose up --build -d
+```
+
+The stack starts:
+
+| Service | Purpose | Health check |
+| --- | --- | --- |
+| `stellar-node` | Local Stellar Quickstart node with Soroban RPC enabled. | `curl -s http://localhost:8000/friendbot` returns a JSON response. |
+| `contract-deployer` | Deploys the local contract or writes a dummy ID when no compiled WASM exists. | `docker compose ps contract-deployer` shows `exited (0)`. |
+| `account-seeder` | Creates funded test accounts, mock assets, and `.docker-output/*` files. | `docker compose ps account-seeder` shows `exited (0)`. |
+
+Verify the output:
+
+```bash
+docker compose ps
+ls .docker-output
+cat .docker-output/contract-id.txt
+```
+
+Expected files:
+
+| File | Contents |
+| --- | --- |
+| `.docker-output/accounts.json` | Test account public keys, secret keys, mock asset IDs, and contract ID. |
+| `.docker-output/contract-id.txt` | Local contract ID or dummy ID. |
+| `.docker-output/usdc-id.txt` | Mock USDC asset ID. |
+| `.docker-output/eurc-id.txt` | Mock EURC asset ID. |
+
+Stop and reset the local ledger:
 
 ```bash
 docker compose down -v
 ```
 
-> **Note:** The `-v` flag ensures that the local persistent chain data (`stellar-data` volume) is removed, giving you a completely fresh slate on your next start.
+## Run Services Individually
 
-## Common Troubleshooting
+### SDK
 
-- **Containers failing to start:** Ensure Docker is running and ports `8000` and `11626` are not occupied by other services.
-- **Contract deployed with dummy ID:** If you see `dummy-contract-id-for-local-dev` in `.docker-output/contract-id.txt`, it means the compiled `.wasm` file wasn't found. Ensure you've built the contract locally first using `make build` or standard Rust cargo commands inside the contract workspace.
-- **Node healthcheck failing:** In rare cases, the quickstart node takes longer to initialize. The seeder and deployer will patiently wait or retry via Docker Compose dependency checks.
+```bash
+npm run build --prefix sdk
+npm run test --prefix sdk
+npm run test:e2e-local --prefix sdk
+```
+
+### CLI
+
+```bash
+npm run build --prefix cli
+npm run test --prefix cli
+npm run check --prefix cli
+```
+
+After building, run the local binary:
+
+```bash
+node cli/dist/bin.js --help
+```
+
+### Indexer
+
+```bash
+cp indexer/.env.example indexer/.env
+npm run dev --prefix indexer
+```
+
+In another terminal:
+
+```bash
+curl http://localhost:3001/health
+```
+
+If the service does not expose `/health` in your branch, confirm it started by checking the console logs and the SQLite file configured by `DB_PATH`.
+
+### Notifications
+
+```bash
+cp notifications/.env.example notifications/.env
+npm run dev --prefix notifications
+```
+
+In another terminal:
+
+```bash
+curl http://localhost:4001/health
+```
+
+If delivery credentials are not configured, keep to local tests and non-delivery API checks.
+
+### Docs
+
+```bash
+pnpm docs:dev
+```
+
+## Run Tests
+
+| Area | Command |
+| --- | --- |
+| Entire pnpm workspace | `pnpm test` |
+| Root coverage task | `pnpm test:coverage` |
+| SDK | `npm run test --prefix sdk` |
+| SDK coverage | `npm run test:coverage --prefix sdk` |
+| SDK local node e2e | `npm run test:e2e-local --prefix sdk` |
+| CLI | `npm run test --prefix cli` |
+| CLI type check | `npm run check --prefix cli` |
+| Indexer | `npm run test --prefix indexer` |
+| Indexer coverage | `npm run test:coverage --prefix indexer` |
+| Notifications | `npm run test --prefix notifications` |
+| Notifications coverage | `npm run test:coverage --prefix notifications` |
+| Load test indexer | `pnpm test:load:indexer` |
+| Load test notifications | `pnpm test:load:notifications` |
+| License scan | `pnpm licence:check` |
+| Secret scan | `pnpm gitleaks:scan` |
+
+## Common Errors and Fixes
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `docker compose` is not found | Docker Compose v2 is not installed or Docker Desktop is not running. | Install Docker Desktop or the Compose v2 plugin, then rerun `docker compose version`. |
+| Port `8000` or `11626` is already allocated | Another Stellar Quickstart, local API, or previous compose stack is running. | Run `docker compose down -v`, stop the conflicting process, or change port mappings locally. |
+| `stellar-node` health check never passes | Docker VM is still starting, network access is blocked, or the image changed endpoints. | Check `docker compose logs stellar-node`; retry after Docker is fully ready. |
+| `dummy-contract-id-for-local-dev` appears | No compiled WASM was found by the deployer. | Build the contract in the smart contract workspace, then rerun `docker compose up --build contract-deployer account-seeder`. |
+| `pnpm install` fails with an engine warning | Node.js is older than the root `>=20` requirement. | Install Node.js 20 or newer with `nvm`, Volta, fnm, or your OS package manager. |
+| `npm ci --prefix <service>` fails after dependency changes | Lockfile is out of date for that service. | Run the package maintainer-approved install command and commit lockfile changes in the same PR. |
+| Rust cannot build a WASM target | The Soroban target is missing. | Install the target requested by the contract workspace or CI, commonly `rustup target add wasm32v1-none`. |
+| Stellar CLI command is not found | Stellar CLI is not installed or not on `PATH`. | Install it from the Stellar developer tools instructions and restart the shell. |
+| macOS Docker file sharing errors | The repository path is not shared with Docker Desktop. | Add the parent directory in Docker Desktop settings under file sharing. |
+| Ubuntu permission denied on Docker socket | The user is not in the `docker` group. | Use `sudo docker ...` temporarily or add the user to the `docker` group and restart the session. |
+| Windows WSL cannot reach localhost service | Docker Desktop WSL integration or port forwarding is disabled. | Enable integration for the distro and run commands from the same WSL distribution that owns the checkout. |
+| Windows checkout shows script line ending errors | Git converted shell scripts to CRLF. | Run `git config core.autocrlf input`, then re-checkout the affected scripts. |
+
+## Fresh-Machine Verification Checklist
+
+Use this checklist before marking local setup docs as verified on a new OS image:
+
+| Step | macOS | Ubuntu | Windows WSL |
+| --- | --- | --- | --- |
+| Install prerequisites and confirm versions | Pending | Pending | Pending |
+| Clone with submodules | Pending | Pending | Pending |
+| Install dependencies | Pending | Pending | Pending |
+| Start Docker stack | Pending | Pending | Pending |
+| Verify `.docker-output/*` | Pending | Pending | Pending |
+| Run SDK, CLI, indexer, and notifications tests | Pending | Pending | Pending |
+| Start indexer and notifications individually | Pending | Pending | Pending |
+| Record OS-specific troubleshooting notes | Pending | Pending | Pending |

--- a/docs/mainnet-launch-checklist.md
+++ b/docs/mainnet-launch-checklist.md
@@ -1,0 +1,74 @@
+# Mainnet Launch Checklist
+
+This checklist tracks the requirements that must be complete before ILN mainnet deployment. Each item has an owner, status, and link to the issue, PR, or document that proves completion.
+
+Status values:
+
+- `Not started`
+- `In progress`
+- `Blocked`
+- `Done`
+
+## Security
+
+| Item | Description | Owner | Status | Link |
+| --- | --- | --- | --- | --- |
+| External security audit | Complete an external audit of Soroban contracts, upgrade controls, SDK signing paths, indexer APIs, and notification webhooks. | Security lead | Not started | [Create audit tracking issue](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/issues/new) |
+| Coverage thresholds met | Confirm contract, SDK, CLI, indexer, and notifications coverage thresholds pass in CI before release branch freeze. | QA lead | In progress | [Coverage workflow](../.github/workflows/coverage.yml) |
+| Fuzz tests run | Run fuzz or property-based tests for invoice lifecycle, XDR encoding, amount math, and settlement state transitions. | Protocol lead | In progress | [`sdk/src/xdr.test.ts`](../sdk/src/xdr.test.ts) |
+| Unified security policy | Publish ecosystem-wide reporting, severity, safe-harbour, and response timeline policy. | Security lead | In progress | [#299](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/issues/299) |
+
+## Contracts
+
+| Item | Description | Owner | Status | Link |
+| --- | --- | --- | --- | --- |
+| Upgrade path tested | Prove contract upgrade flow works on a local network and testnet without storage collision or authorization regressions. | Protocol lead | In progress | [`packages/upgrade-tests`](../packages/upgrade-tests) |
+| Multi-sig admin configured | Configure production admin keys with multi-sig, quorum, timelock, and emergency response procedures. | Governance lead | Not started | [Governance guide](governance-guide.md) |
+| Circuit breaker tested | Exercise pause and recovery paths for funding, settlement, indexing, and notification delivery. | Security lead | Not started | [Security policy](security.md) |
+| Mainnet deployment dry run | Run deployment automation against a non-production target and record contract IDs, asset IDs, and rollback notes. | Release lead | Not started | [Deployment guide](../DEPLOYMENT_GUIDE.md) |
+
+## Infrastructure
+
+| Item | Description | Owner | Status | Link |
+| --- | --- | --- | --- | --- |
+| Indexer deployed | Deploy the indexer with rate limiting, backups, replay procedure, and public API health checks. | Infrastructure lead | In progress | [Indexer deployment](indexer/deployment.md) |
+| Monitoring configured | Configure alerts for RPC health, indexer lag, notification failures, webhook delivery errors, and CI release failures. | Infrastructure lead | In progress | [Upptime workflow](../.github/workflows/upptime.yml) |
+| Backups verified | Restore indexer backup artifacts in a clean environment and document recovery time. | Infrastructure lead | Not started | [Infrastructure deployment](deployment/infrastructure.md) |
+| Release provenance verified | Verify npm package provenance and GitHub release artifacts before mainnet announcement. | Release lead | In progress | [Security provenance](security.md#package-provenance) |
+
+## Documentation
+
+| Item | Description | Owner | Status | Link |
+| --- | --- | --- | --- | --- |
+| Local development guide complete | Provide contributor setup for prerequisites, submodules, env vars, Docker Compose, service commands, tests, and OS troubleshooting. | Docs lead | In progress | [#300](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/issues/300) |
+| Glossary complete | Define protocol terminology for DeFi, invoice factoring, Stellar, governance, security, and notifications. | Docs lead | In progress | [#301](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/issues/301) |
+| API and SDK guides complete | Confirm SDK, CLI, indexer, and notification API docs match current package behavior. | SDK lead | In progress | [SDK API reference](sdk-api-reference.md) |
+| Mainnet checklist maintained | Keep this checklist linked from the root README and update statuses as referenced issues close. | Release lead | In progress | [#298](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/issues/298) |
+
+## Community
+
+| Item | Description | Owner | Status | Link |
+| --- | --- | --- | --- | --- |
+| CONTRIBUTING current | Confirm contribution workflow, branch expectations, tests, and security reporting guidance are current. | Maintainers | In progress | [`CONTRIBUTING.md`](../CONTRIBUTING.md) |
+| SECURITY current | Confirm root security policy and docs security page are aligned. | Security lead | In progress | [`SECURITY.md`](../SECURITY.md) |
+| CHANGELOG current | Confirm release notes describe mainnet readiness changes and any breaking changes. | Release lead | In progress | [`CHANGELOG.md`](../CHANGELOG.md) |
+| Community announcement prepared | Prepare launch announcement, support channels, incident contact, and maintainer availability plan. | Community lead | Not started | [Create launch comms issue](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/issues/new) |
+
+## Automatic Status Updates
+
+The [`Mainnet Checklist Status`](../.github/workflows/mainnet-checklist-status.yml) workflow scans links in this file when an issue is closed or when maintainers run it manually. If a row links to a closed issue in this repository, the workflow changes that row's status to `Done` and opens a pull request with the generated update.
+
+Rows linked to documents, workflows, external repositories, or new-issue templates still require manual maintainer review.
+
+## Maintainer Sign-off
+
+Mainnet launch requires sign-off from the core maintainers below after every checklist item is `Done` or has an explicitly accepted launch exception.
+
+| Role | Maintainer | Signature | Date |
+| --- | --- | --- | --- |
+| Protocol lead | TBD |  |  |
+| Security lead | TBD |  |  |
+| Infrastructure lead | TBD |  |  |
+| SDK lead | TBD |  |  |
+| Release lead | TBD |  |  |
+| Community lead | TBD |  |  |

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,55 +1,87 @@
 # Security
 
-## Package Provenance (SLSA Level 3)
+This page is the documentation copy of the ILN security policy. The repository root [`SECURITY.md`](../SECURITY.md) remains the canonical policy for GitHub security reporting.
 
-All ILN npm packages (`@invoice-liquidity/sdk`, `@invoice-liquidity/cli`) are published with [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) provenance attestations. This proves each release was built by the `Release` GitHub Actions workflow from this repository — not from a developer's local machine.
+## Reporting a Vulnerability
 
-### How it works
+Report suspected vulnerabilities privately through one of these channels:
 
-1. The `Release` workflow calls `npm publish --provenance`, which generates a signed attestation linking the package tarball to the exact commit and workflow run that produced it.
-2. The attestation is stored in the [GitHub Artifact Attestations](https://github.com/Invoice-Liquidity-Network/Invoice-Liquidity-Network/attestations) ledger and referenced in the `_attestations` field on the npm package page.
+- Email `security@invoiceliquidity.network`
+- Open a private GitHub Security Advisory for the affected ILN repository
 
-### Verifying provenance
+Do not open a public issue, discussion, or pull request with exploit details before maintainers have investigated and shipped any necessary fix.
 
-#### Via npm (quickest)
+Include the affected component, version or commit, contract ID or environment, impact summary, reproduction steps, proof-of-concept code, transaction hashes, logs, webhook payloads, API requests, XDR samples, and any suggested mitigations.
+
+## Supported Components
+
+| Component | Supported surface | Notes |
+| --- | --- | --- |
+| Soroban contracts | Latest deployed testnet contracts and release candidates | Invoice, reputation, governance, upgrade, and token integration logic. |
+| SDK and CLI | Latest published npm major version | Transaction construction, XDR handling, signing flows, and browser or Node.js integrations. |
+| Indexer | Latest main branch deployment target | Ingestion, SQLite or API storage, REST and GraphQL endpoints, backups, and rate limiting. |
+| Notifications | Latest main branch deployment target | Webhook, email, SMS, digest, and WebSocket delivery paths. |
+| Documentation and CI/CD | Latest main branch | Setup guidance, examples, workflows, and release automation. |
+
+## Vulnerability Classes
+
+| Component | In-scope vulnerability classes |
+| --- | --- |
+| Soroban contracts | Reentrancy or callback ordering issues, storage collision or key namespace confusion, authorization bypass, incorrect invoice lifecycle transition, asset escrow accounting bug, unsafe upgrade path, missing circuit breaker, quorum or timelock bypass, precision or basis point calculation error. |
+| SDK and CLI | XDR encoding or decoding bugs, signing bypass, signing the wrong network passphrase, transaction simulation mismatch, unsafe secret handling, address validation bypass, replay-prone transaction construction, browser bundle crypto regression. |
+| Indexer | SQL injection, API abuse, broken rate limiting, event ingestion poisoning, ledger replay inconsistency, data exposure through REST or GraphQL filters, denial of service through expensive queries, backup or archive leakage. |
+| Notifications | HMAC verification bypass, SSRF through webhook URLs, webhook secret leakage, template injection, notification preference bypass, replayable delivery callbacks, email or SMS abuse, unsafe redirect or URL rendering. |
+| CI/CD and docs | Release provenance tampering, workflow secret exposure, malicious generated docs, dependency confusion, inaccurate security-critical setup instructions. |
+
+## Severity and Response Timeline
+
+| Severity | Typical impact | Response commitment |
+| --- | --- | --- |
+| Critical | Direct theft or permanent lock of user funds; arbitrary contract state mutation; signing bypass that can authorize transactions; exposed production signing secret; unauthenticated administrative action. | Acknowledge within 48 hours, mitigation or fix target within 7 days, coordinated release as soon as safely possible. |
+| High | Limited fund loss or temporary lock; privilege escalation; persistent data exposure; exploitable SQL injection; HMAC bypass for trusted webhooks; reliable service-wide denial of service. | Acknowledge within 48 hours, fix target within 14 days. |
+| Medium | Localized data exposure; bounded denial of service; incorrect indexer state without fund impact; SDK validation bug requiring user interaction; replay or webhook issue with limited blast radius. | Acknowledge within 48 hours, fix target within 30 days. |
+| Low | Defense-in-depth weakness, misleading security documentation, low-impact information disclosure, non-sensitive spoofing, hardening issue without a practical exploit path. | Acknowledge within 5 business days, address in normal maintenance. |
+
+Severity may be adjusted after triage based on exploitability, affected deployments, user interaction requirements, available mitigations, and whether real funds or signing authority are at risk.
+
+## Response Process
+
+1. The security team acknowledges the report and assigns a primary maintainer.
+2. Maintainers reproduce the issue, classify severity, and identify affected components.
+3. A private fix branch, patch, configuration change, or operational mitigation is prepared.
+4. The fix is reviewed by maintainers with relevant component ownership.
+5. A release, advisory, or disclosure note is published after affected users have a reasonable update path.
+
+If the report affects multiple ILN repositories, maintainers coordinate the fix privately across those repositories before public disclosure.
+
+## Safe Harbour
+
+ILN supports good-faith security research. We will not pursue legal action or recommend legal action for research that avoids privacy violations, destruction of data, degradation of service, and interruption of other users; uses the minimum access needed to verify the vulnerability; does not move, drain, or permanently lock funds; does not disclose details publicly before coordinated remediation; and reports findings promptly through private channels.
+
+Safe harbour does not cover extortion, social engineering, phishing, physical attacks, malware, spam, or attempts to access unrelated third-party systems.
+
+## Package Provenance
+
+All ILN npm packages, including `@invoice-liquidity/sdk`, `@invoice-liquidity/cli`, and `@iln/sdk`, should be published from GitHub Actions with provenance attestations rather than from a developer workstation.
+
+### Verify With npm
 
 ```bash
-npm audit signatures @invoice-liquidity/sdk
+npm audit signatures @iln/sdk
 ```
 
-Expected output:
+Expected result: npm reports a verified registry signature and a verified attestation for packages published with provenance.
 
-```
-audited 1 package in Xs
-1 package has a verified registry signature
-1 package has a verified attestation
-```
-
-#### Via GitHub CLI
+### Verify With GitHub CLI
 
 ```bash
-gh attestation verify \
-  $(npm pack @invoice-liquidity/sdk --dry-run 2>/dev/null | tail -1) \
+npm pack @iln/sdk
+gh attestation verify iln-sdk-*.tgz \
   --repo Invoice-Liquidity-Network/Invoice-Liquidity-Network
 ```
 
-Or for a tarball you've already downloaded:
+A successful verification prints the workflow run, commit SHA, and attestation metadata for the tarball.
 
-```bash
-# 1. Download the tarball
-npm pack @invoice-liquidity/sdk
+## Recognition
 
-# 2. Verify the attestation against the source repo
-gh attestation verify invoice-liquidity-sdk-*.tgz \
-  --repo Invoice-Liquidity-Network/Invoice-Liquidity-Network
-```
-
-A successful verification prints the attestation details, including the workflow run URL and the exact commit SHA used to build the package.
-
-#### Via the npm website
-
-Open the package page on npmjs.com (e.g. [npmjs.com/package/@invoice-liquidity/sdk](https://www.npmjs.com/package/@invoice-liquidity/sdk)) and look for the **Provenance** section, which links directly to the GitHub Actions run and the signed SLSA attestation bundle.
-
-### Reporting vulnerabilities
-
-Please see [SECURITY.md](../SECURITY.md) at the repository root for how to report security vulnerabilities privately.
+Researchers who want public credit may be listed in [`HALL_OF_FAME.md`](../HALL_OF_FAME.md) after the issue is fixed and disclosure is approved. ILN does not guarantee bounty payment unless a separate bounty program says otherwise.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,6 +2,8 @@
 
 Typed TypeScript SDK for the Invoice Liquidity Network — works in Node.js and modern browsers.
 
+New to ILN terminology? See the protocol [glossary](../../docs/glossary.md) for Stellar, invoice factoring, and security terms used by the SDK.
+
 ## Install
 
 ```bash

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -6,6 +6,8 @@
 
 Typed JavaScript and TypeScript SDK for the Invoice Liquidity Network Soroban contract on Stellar.
 
+New to ILN terminology? See the protocol [glossary](../docs/glossary.md) for Stellar, invoice factoring, and security terms used by the SDK.
+
 By participating in this project, you agree to abide by our [Code of Conduct](../CODE_OF_CONDUCT.md).
 
 ## Quick Start


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->

## Related Issue
Closes #

## Complexity
<!-- Check one -->
- [ ] Trivial (typo, docs, small refactor)
- [ ] Medium (new feature, non-breaking change)
- [ ] High (breaking change, core protocol logic)

## Changes Made
<!-- Bulleted list of key changes -->
- 
- 

## Test Coverage
<!-- Paste relevant test output showing coverage -->
```
cargo test
```

<details>
<summary>Test output</summary>

```
<!-- paste here -->
```
</details>

## Security Considerations
<!-- Any security implications? Contract upgrade impact? Access control changes? -->

## Checklist
- [ ] Tests pass locally (`cargo test`)
- [ ] New functionality has test coverage
- [ ] `cargo fmt` applied
- [ ] `cargo clippy` warnings resolved
- [ ] Public functions have doc comments
- [ ] Breaking changes documented in PR description
- [ ] Issue linked (Closes #)
Closes #298
Closes #299
Closes #300
Closes #301