### PR TITLE
feat: add Swagger/OpenAPI docs to indexer and offline tx queue to SDK

### DIFF
--- a/indexer/package.json
+++ b/indexer/package.json
@@ -21,12 +21,14 @@
     "express": "^4.19.2",
     "graphql": "^16.9.0",
     "graphql-yoga": "^5.10.4",
-    "ioredis": "^5.3.2"
+    "ioredis": "^5.3.2",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@iln/eslint-config": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^4.17.21",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/node": "^24.7.2",
     "@types/ws": "^8.5.10",
     "@types/supertest": "^6.0.2",

--- a/indexer/src/api.ts
+++ b/indexer/src/api.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response, Router, RequestHandler } from "express";
+import swaggerUi from "swagger-ui-express";
 import {
   getDb,
   getFreelancerStats,
@@ -11,6 +12,7 @@ import {
   getCursorUpdatedAt,
 } from "./db";
 import { cacheGet, cacheSet } from "./cache";
+import { openApiSpec } from "./openapi";
 import { createGraphQLHandler } from "./graphql";
 import { createApiRateLimiter } from "./rateLimit";
 import {
@@ -39,6 +41,12 @@ export function createApp(): express.Application {
   // ── GraphQL (queries, mutations, subscriptions via SSE + GraphiQL) ──────────
   const yoga = createGraphQLHandler();
   app.use(yoga.graphqlEndpoint, yoga);
+
+  // ── Swagger / OpenAPI docs ─────────────────────────────────────────────────
+  app.use("/docs", swaggerUi.serve, swaggerUi.setup(openApiSpec, {
+    customSiteTitle: "ILN Indexer API Docs",
+    swaggerOptions: { defaultModelsExpandDepth: -1 },
+  }));
 
   const startTime = Date.now();
   const backupManager = new BackupManager();

--- a/indexer/src/openapi.ts
+++ b/indexer/src/openapi.ts
@@ -1,0 +1,642 @@
+import type { OpenAPIV3 } from "openapi-types";
+
+// ─── Reusable schema fragments ────────────────────────────────────────────────
+
+const StellarAddress: OpenAPIV3.SchemaObject = {
+  type: "string",
+  pattern: "^G[A-Z2-7]{55}$",
+  example: "GABC1234EXAMPLESTELLARADDRESS000000000000000000000000000",
+};
+
+const InvoiceStatus: OpenAPIV3.SchemaObject = {
+  type: "string",
+  enum: ["Pending", "Funded", "Paid", "Defaulted"],
+};
+
+const Invoice: OpenAPIV3.SchemaObject = {
+  type: "object",
+  properties: {
+    id: { type: "integer", example: 1 },
+    freelancer: StellarAddress,
+    payer: StellarAddress,
+    amount: { type: "string", example: "1000000" },
+    due_date: { type: "integer", description: "Unix timestamp in seconds", example: 1893456000 },
+    discount_rate: { type: "integer", description: "Basis points (e.g. 500 = 5%)", example: 500 },
+    status: InvoiceStatus,
+    funder: { ...StellarAddress, nullable: true },
+    funded_at: { type: "integer", nullable: true, description: "Unix timestamp of funding" },
+    created_at: { type: "integer", description: "Millisecond timestamp when indexed" },
+    updated_at: { type: "integer", description: "Millisecond timestamp of last update" },
+  },
+  required: ["id", "freelancer", "payer", "amount", "due_date", "discount_rate", "status", "created_at", "updated_at"],
+};
+
+const ErrorResponse: OpenAPIV3.SchemaObject = {
+  type: "object",
+  properties: { error: { type: "string" } },
+  required: ["error"],
+};
+
+const errorResponses: OpenAPIV3.ResponsesObject = {
+  "400": {
+    description: "Bad request — invalid query parameter or path segment",
+    content: { "application/json": { schema: ErrorResponse } },
+  },
+  "404": {
+    description: "Resource not found",
+    content: { "application/json": { schema: ErrorResponse } },
+  },
+  "429": {
+    description: "Too many requests — rate limit exceeded",
+    content: { "application/json": { schema: ErrorResponse } },
+  },
+  "500": {
+    description: "Internal server error",
+    content: { "application/json": { schema: ErrorResponse } },
+  },
+};
+
+// ─── Full OpenAPI document ────────────────────────────────────────────────────
+
+export const openApiSpec: OpenAPIV3.Document = {
+  openapi: "3.0.3",
+  info: {
+    title: "Invoice Liquidity Network — Indexer API",
+    version: "1.0.0",
+    description:
+      "REST API for the ILN on-chain event indexer. " +
+      "Unversioned paths (`/invoices`, etc.) are deprecated; prefer `/v1/` equivalents. " +
+      "A GraphQL endpoint is also available at `/graphql`.",
+    contact: { name: "ILN Team" },
+    license: { name: "MIT" },
+  },
+  servers: [
+    { url: "/v1", description: "Current stable version" },
+    { url: "/", description: "Deprecated unversioned routes" },
+  ],
+  tags: [
+    { name: "System", description: "Health and observability" },
+    { name: "Invoices", description: "Invoice queries" },
+    { name: "Participants", description: "LP and freelancer statistics" },
+    { name: "Archive", description: "Archived data management" },
+    { name: "Backup", description: "Database backup management" },
+  ],
+  paths: {
+    // ── System ──────────────────────────────────────────────────────────────
+    "/health": {
+      get: {
+        tags: ["System"],
+        summary: "Health check",
+        description: "Returns service health, database status, last sync ledger time, and uptime.",
+        operationId: "getHealth",
+        responses: {
+          "200": {
+            description: "Service status",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    status: { type: "string", enum: ["ok", "degraded"] },
+                    db: { type: "string", enum: ["ok", "error"] },
+                    lastSync: { type: "string", format: "date-time", nullable: true },
+                    uptime: { type: "integer", description: "Milliseconds since process start" },
+                  },
+                  required: ["status", "db", "lastSync", "uptime"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/dashboard": {
+      get: {
+        tags: ["System"],
+        summary: "Dashboard metrics",
+        description: "Aggregate request count, error rates, and latency data for monitoring.",
+        operationId: "getDashboard",
+        responses: {
+          "200": {
+            description: "Dashboard metrics object",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+    "/stats": {
+      get: {
+        tags: ["Invoices"],
+        summary: "Protocol statistics",
+        description: "Returns aggregate stats: total invoices, total volume, total yield, and default rate.",
+        operationId: "getStats",
+        responses: {
+          "200": {
+            description: "Protocol statistics",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    totalInvoices: { type: "integer" },
+                    totalVolume: { type: "string", description: "Smallest token unit" },
+                    totalYield: { type: "string", description: "Smallest token unit" },
+                    defaultRate: { type: "number", minimum: 0, maximum: 1 },
+                  },
+                  required: ["totalInvoices", "totalVolume", "totalYield", "defaultRate"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+
+    // ── Invoices ────────────────────────────────────────────────────────────
+    "/invoices": {
+      get: {
+        tags: ["Invoices"],
+        summary: "List invoices",
+        description:
+          "Returns a paginated list of indexed invoices. All filters are optional and ANDed together. " +
+          "Use `cursor` from the previous response to fetch the next page.",
+        operationId: "listInvoices",
+        parameters: [
+          {
+            name: "status",
+            in: "query",
+            schema: InvoiceStatus,
+            description: "Filter by invoice status",
+          },
+          {
+            name: "freelancer",
+            in: "query",
+            schema: StellarAddress,
+            description: "Filter by freelancer Stellar address",
+          },
+          {
+            name: "payer",
+            in: "query",
+            schema: StellarAddress,
+            description: "Filter by payer Stellar address",
+          },
+          {
+            name: "funder",
+            in: "query",
+            schema: StellarAddress,
+            description: "Filter by funder Stellar address",
+          },
+          {
+            name: "limit",
+            in: "query",
+            schema: { type: "integer", minimum: 1, maximum: 100, default: 100 },
+            description: "Maximum number of results to return",
+          },
+          {
+            name: "cursor",
+            in: "query",
+            schema: { type: "string" },
+            description: "Opaque pagination cursor from a previous response",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Paginated invoice list",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    invoices: { type: "array", items: Invoice },
+                    hasMore: { type: "boolean" },
+                    nextCursor: { type: "string", nullable: true },
+                  },
+                  required: ["invoices", "hasMore"],
+                },
+              },
+            },
+          },
+          ...errorResponses,
+        },
+      },
+    },
+    "/invoice/{id}": {
+      get: {
+        tags: ["Invoices"],
+        summary: "Get invoice by ID",
+        description: "Fetch the current indexed state of a single invoice. Responses are cached for 30 seconds.",
+        operationId: "getInvoiceById",
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "integer", minimum: 1 },
+            description: "Invoice ID",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Invoice details",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { invoice: Invoice },
+                  required: ["invoice"],
+                },
+              },
+            },
+          },
+          ...errorResponses,
+        },
+      },
+    },
+    "/history/{address}": {
+      get: {
+        tags: ["Invoices"],
+        summary: "Invoice history for an address",
+        description: "Returns all invoices where the given address played the specified role.",
+        operationId: "getHistory",
+        parameters: [
+          {
+            name: "address",
+            in: "path",
+            required: true,
+            schema: StellarAddress,
+            description: "Stellar address",
+          },
+          {
+            name: "role",
+            in: "query",
+            schema: { type: "string", enum: ["freelancer", "payer", "funder"], default: "freelancer" },
+            description: "Role the address played in the invoice",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "List of matching invoices",
+            content: {
+              "application/json": {
+                schema: { type: "array", items: Invoice },
+              },
+            },
+          },
+          ...errorResponses,
+        },
+      },
+    },
+
+    // ── Participants ─────────────────────────────────────────────────────────
+    "/lps/top": {
+      get: {
+        tags: ["Participants"],
+        summary: "Top liquidity providers",
+        description: "Returns the top LPs ranked by yield earned, optionally filtered by time period.",
+        operationId: "getTopLPs",
+        parameters: [
+          {
+            name: "limit",
+            in: "query",
+            schema: { type: "integer", minimum: 1, maximum: 100, default: 10 },
+          },
+          {
+            name: "period",
+            in: "query",
+            schema: { type: "string", enum: ["all", "week", "month"], default: "all" },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Ranked LP list",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      address: StellarAddress,
+                      yield: { type: "string" },
+                      invoiceCount: { type: "integer" },
+                    },
+                    required: ["address", "yield", "invoiceCount"],
+                  },
+                },
+              },
+            },
+          },
+          ...errorResponses,
+        },
+      },
+    },
+    "/lps/{address}/stats": {
+      get: {
+        tags: ["Participants"],
+        summary: "LP statistics",
+        description: "Returns total deployed capital, earned yield, invoice count, and default rate for a liquidity provider.",
+        operationId: "getLPStats",
+        parameters: [
+          {
+            name: "address",
+            in: "path",
+            required: true,
+            schema: StellarAddress,
+          },
+        ],
+        responses: {
+          "200": {
+            description: "LP statistics",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    deployed: { type: "string" },
+                    yield: { type: "string" },
+                    invoiceCount: { type: "integer" },
+                    defaultRate: { type: "number" },
+                  },
+                  required: ["deployed", "yield", "invoiceCount", "defaultRate"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/freelancers/{address}/stats": {
+      get: {
+        tags: ["Participants"],
+        summary: "Freelancer statistics",
+        description: "Returns submitted count, funded count, total received, and average discount rate for a freelancer.",
+        operationId: "getFreelancerStats",
+        parameters: [
+          {
+            name: "address",
+            in: "path",
+            required: true,
+            schema: StellarAddress,
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Freelancer statistics",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    submitted: { type: "integer" },
+                    funded: { type: "integer" },
+                    totalReceived: { type: "string" },
+                    avgDiscount: { type: "number" },
+                  },
+                  required: ["submitted", "funded", "totalReceived", "avgDiscount"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+
+    // ── Archive ──────────────────────────────────────────────────────────────
+    "/archive/stats": {
+      get: {
+        tags: ["Archive"],
+        summary: "Archive statistics",
+        description: "Returns counts and byte sizes of archived invoices and events.",
+        operationId: "getArchiveStats",
+        responses: {
+          "200": {
+            description: "Archive statistics",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+        },
+      },
+    },
+    "/archive/invoices": {
+      get: {
+        tags: ["Archive"],
+        summary: "Query archived invoices",
+        description: "Returns invoices that have been moved to the archive table.",
+        operationId: "queryArchiveInvoices",
+        parameters: [
+          { name: "status", in: "query", schema: InvoiceStatus },
+          { name: "freelancer", in: "query", schema: StellarAddress },
+          { name: "payer", in: "query", schema: StellarAddress },
+          { name: "funder", in: "query", schema: StellarAddress },
+        ],
+        responses: {
+          "200": {
+            description: "Archived invoices",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { invoices: { type: "array", items: Invoice } },
+                  required: ["invoices"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/archive/events": {
+      get: {
+        tags: ["Archive"],
+        summary: "Query archived events",
+        description: "Returns contract events that have been archived.",
+        operationId: "queryArchiveEvents",
+        parameters: [
+          { name: "invoiceId", in: "query", schema: { type: "integer" } },
+        ],
+        responses: {
+          "200": {
+            description: "Archived events",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { events: { type: "array", items: { type: "object" } } },
+                  required: ["events"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/archive/restore/{id}": {
+      post: {
+        tags: ["Archive"],
+        summary: "Restore archived invoice",
+        description: "Moves an invoice and its events back from the archive table to the active tables.",
+        operationId: "restoreInvoice",
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "integer", minimum: 1 },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Invoice restored",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean" },
+                    message: { type: "string" },
+                  },
+                  required: ["success", "message"],
+                },
+              },
+            },
+          },
+          ...errorResponses,
+        },
+      },
+    },
+    "/archive/run": {
+      post: {
+        tags: ["Archive"],
+        summary: "Trigger archival run",
+        description: "Manually moves invoices older than the given threshold from active to archive tables.",
+        operationId: "runArchive",
+        requestBody: {
+          required: false,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  olderThanDays: { type: "integer", minimum: 1, default: 90 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Archival result",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+          ...errorResponses,
+        },
+      },
+    },
+
+    // ── Backup ───────────────────────────────────────────────────────────────
+    "/backup": {
+      get: {
+        tags: ["Backup"],
+        summary: "List backups",
+        description: "Returns metadata for all locally stored database backups.",
+        operationId: "listBackups",
+        responses: {
+          "200": {
+            description: "Backup list",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    backups: { type: "array", items: { type: "object" } },
+                    total: { type: "integer" },
+                  },
+                  required: ["backups", "total"],
+                },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        tags: ["Backup"],
+        summary: "Trigger manual backup",
+        description: "Creates a new database backup snapshot immediately.",
+        operationId: "createBackup",
+        responses: {
+          "200": {
+            description: "Backup result",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean" },
+                    backup: { type: "object" },
+                  },
+                  required: ["success"],
+                },
+              },
+            },
+          },
+          ...errorResponses,
+        },
+      },
+    },
+    "/backup/latest": {
+      get: {
+        tags: ["Backup"],
+        summary: "Latest backup",
+        description: "Returns the manifest of the most recent backup.",
+        operationId: "getLatestBackup",
+        responses: {
+          "200": {
+            description: "Latest backup manifest",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+          "404": { description: "No backups found" },
+        },
+      },
+    },
+    "/backup/restore": {
+      post: {
+        tags: ["Backup"],
+        summary: "Restore from backup",
+        description: "Restores the database from the given backup file path.",
+        operationId: "restoreBackup",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  backupPath: { type: "string", description: "Path to the backup file" },
+                  verify: { type: "boolean", default: true, description: "Verify backup integrity before restore" },
+                },
+                required: ["backupPath"],
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Restore result",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean" },
+                    message: { type: "string" },
+                  },
+                  required: ["success"],
+                },
+              },
+            },
+          },
+          ...errorResponses,
+        },
+      },
+    },
+  },
+};

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -54,6 +54,13 @@ import {
   ILNError,
 } from "./errors";
 import {
+  OfflineManager,
+  OfflineQueuedError,
+  type OfflineConfig,
+  type OfflineQueueItem,
+  type OfflineState,
+} from "./offline";
+import {
   resolveRequestTimeouts,
   TimeoutError,
   withTimeout,
@@ -115,6 +122,7 @@ export class ILNSdk {
   private readonly analyticsNetwork: string;
   private readonly cache: Cache<unknown>;
   private readonly cacheEnabled: boolean;
+  private offlineManager: OfflineManager | null = null;
 
   /**
    * Create a new ILN SDK client.
@@ -132,6 +140,11 @@ export class ILNSdk {
     const cacheConfig = config.cache ?? { ttl: 60000, storage: "memory", enabled: true };
     this.cache = new Cache(cacheConfig);
     this.cacheEnabled = cacheConfig.enabled ?? true;
+
+    if (config.offline !== undefined) {
+      this.offlineManager = new OfflineManager(config.offline);
+      this.offlineManager.onSubmit((item) => this.executeQueuedOperation(item));
+    }
   }
 
   private async wrapRpcCall<T>(promise: Promise<T>, operationName: string): Promise<T> {
@@ -698,7 +711,11 @@ export class ILNSdk {
    */
   async submitInvoice(params: SubmitInvoiceParams): Promise<bigint> {
     Validators.assertValid(Validators.validateInvoiceSubmission(params), "submitInvoice");
-    
+
+    if (this.offlineManager && !this.offlineManager.getIsOnline()) {
+      throw new OfflineQueuedError(this.offlineManager.enqueue("submitInvoice", params));
+    }
+
     const signerAddress = await this.requireSignerAddress();
 
     if (signerAddress !== params.freelancer) {
@@ -754,7 +771,11 @@ export class ILNSdk {
    */
   async fundInvoice(params: FundInvoiceParams): Promise<void> {
     Validators.assertValid(Validators.validateFunding(params), "fundInvoice");
-    
+
+    if (this.offlineManager && !this.offlineManager.getIsOnline()) {
+      throw new OfflineQueuedError(this.offlineManager.enqueue("fundInvoice", params));
+    }
+
     const signerAddress = await this.requireSignerAddress();
 
     if (signerAddress !== params.funder) {
@@ -805,7 +826,11 @@ export class ILNSdk {
    */
   async markPaid(params: MarkPaidParams): Promise<void> {
     Validators.assertValid(Validators.validatePayment(params), "markPaid");
-    
+
+    if (this.offlineManager && !this.offlineManager.getIsOnline()) {
+      throw new OfflineQueuedError(this.offlineManager.enqueue("markPaid", params));
+    }
+
     try {
       const payer = await this.requireSignerAddress();
       const transaction = await this.buildWriteTransaction(payer, "mark_paid", [
@@ -853,6 +878,10 @@ export class ILNSdk {
    * ```
    */
   async claimDefault(params: ClaimDefaultParams): Promise<void> {
+    if (this.offlineManager && !this.offlineManager.getIsOnline()) {
+      throw new OfflineQueuedError(this.offlineManager.enqueue("claimDefault", params));
+    }
+
     const signerAddress = await this.requireSignerAddress();
 
     if (signerAddress !== params.funder) {
@@ -1480,6 +1509,68 @@ export class ILNSdk {
     }
 
     return String(error);
+  }
+
+  // ── Offline queue public API ──────────────────────────────────────────────
+
+  /**
+   * Returns the current offline queue state, or null if the offline queue is
+   * not enabled for this SDK instance.
+   */
+  getOfflineState(): OfflineState | null {
+    return this.offlineManager?.getState() ?? null;
+  }
+
+  /**
+   * Returns the underlying OfflineManager, or null when the queue is disabled.
+   * Use this for advanced queue management (retry, remove, clear).
+   */
+  getOfflineManager(): OfflineManager | null {
+    return this.offlineManager;
+  }
+
+  /**
+   * Manually mark the SDK as online/offline.
+   * Useful for Node.js environments that don't have browser connectivity events.
+   * When set to `true`, the queue is flushed immediately.
+   */
+  setOnline(online: boolean): void {
+    this.offlineManager?.setOnline(online);
+  }
+
+  /**
+   * Flush all pending offline queue items immediately.
+   * No-op when the offline queue is not enabled.
+   */
+  async flushOfflineQueue(): Promise<void> {
+    if (this.offlineManager) {
+      await this.offlineManager.processQueue();
+    }
+  }
+
+  private async executeQueuedOperation(item: OfflineQueueItem): Promise<boolean> {
+    try {
+      const params = item.params as any;
+      switch (item.operation) {
+        case "submitInvoice":
+          await this.submitInvoice(params as SubmitInvoiceParams);
+          break;
+        case "fundInvoice":
+          await this.fundInvoice(params as FundInvoiceParams);
+          break;
+        case "markPaid":
+          await this.markPaid(params as MarkPaidParams);
+          break;
+        case "claimDefault":
+          await this.claimDefault(params as ClaimDefaultParams);
+          break;
+        default:
+          return false;
+      }
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/sdk/src/offline.ts
+++ b/sdk/src/offline.ts
@@ -52,6 +52,22 @@ export interface OfflineState {
 export type StateChangeCallback = (state: OfflineState) => void;
 export type SubmitCallback = (item: OfflineQueueItem) => Promise<boolean>;
 
+/**
+ * Thrown by SDK write methods when the offline queue is enabled and the
+ * client is currently offline. Catch this error to present a "queued" state
+ * to the user — the operation will be retried automatically when connectivity
+ * is restored.
+ */
+export class OfflineQueuedError extends Error {
+  public readonly item: OfflineQueueItem;
+
+  constructor(item: OfflineQueueItem) {
+    super(`Operation "${item.operation}" queued for submission when back online (id: ${item.id})`);
+    this.name = "OfflineQueuedError";
+    this.item = item;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Default Configuration
 // ---------------------------------------------------------------------------

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -184,6 +184,14 @@ export interface ILNSdkConfig {
     simulationMs?: number;
   };
   cache?: CacheConfig;
+  /**
+   * Enable the offline transaction queue.
+   * When provided, write methods (`submitInvoice`, `fundInvoice`, `markPaid`,
+   * `claimDefault`) will automatically queue operations while the client is
+   * offline and submit them when connectivity is restored.
+   * Set to `{}` to use all defaults.
+   */
+  offline?: import("./offline").OfflineConfig;
 }
 
 /**


### PR DESCRIPTION
Closes #579
Closes #580
Closes #581
Closes #582

## Summary

- **Indexer – OpenAPI/Swagger docs**: Added `swagger-ui-express` to the indexer and created a typed OpenAPI 3.0.3 spec (`indexer/src/openapi.ts`) covering all REST endpoints — invoices, stats, LPs, freelancers, history, archive, and backup. Swagger UI is served at `GET /docs`.
- **SDK – Offline transaction queue**: Integrated the existing `OfflineManager` into `ILNSdk` via an optional `offline` config field. When offline, write methods (`submitInvoice`, `fundInvoice`, `markPaid`, `claimDefault`) enqueue the operation and throw `OfflineQueuedError` instead of failing. The queue auto-flushes when connectivity is restored via browser `online` events.

## Changes

### Indexer
- `indexer/package.json` — added `swagger-ui-express` + `@types/swagger-ui-express`
- `indexer/src/openapi.ts` — new OpenAPI 3.0.3 document with schemas and path definitions for all REST endpoints
- `indexer/src/api.ts` — mounts Swagger UI at `GET /docs`

### SDK
- `sdk/src/offline.ts` — added `OfflineQueuedError` (catchable error carrying the queued item)
- `sdk/src/types.ts` — added `offline?: OfflineConfig` to `ILNSdkConfig`
- `sdk/src/client.ts` — creates `OfflineManager` when configured, wraps write methods with offline check, exposes `getOfflineState()`, `getOfflineManager()`, `setOnline()`, `flushOfflineQueue()`

## Test plan

- [ ] Start indexer, open `http://localhost:3001/docs` — Swagger UI renders with all endpoints
- [ ] Confirm `/v1/invoices` shows correct query params and response schema in the spec
- [ ] Create `ILNSdk` with `offline: {}`, call `sdk.setOnline(false)`, then `sdk.submitInvoice(...)` — expect `OfflineQueuedError`, `sdk.getOfflineState().queueSize === 1`
- [ ] Call `sdk.setOnline(true)` — queue flushes and item submits on-chain
- [ ] Confirm SDK without `offline` option behaves identically to before (no regression)

