### PR TITLE
added notification retry mechanism

### DIFF
--- a/notifications/src/delivery.ts
+++ b/notifications/src/delivery.ts
@@ -3,7 +3,7 @@ import { Resend } from "resend";
 import Twilio from "twilio";
 import { CONFIG } from "./config";
 import { createWebhookDeliveryLog, updateWebhookDeliveryLog } from "./db";
-import type { NotificationPayload, Subscription } from "./types";
+import type { NotificationPayload, Subscription, NotificationTrigger, Invoice } from "./types";
 
 const resend = new Resend(CONFIG.resendApiKey);
 
@@ -20,19 +20,115 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export interface DeadLetterEntry {
+  channel: "email" | "sms" | "webhook";
+  destination: string;
+  subscriptionId: string;
+  trigger: NotificationTrigger;
+  invoice: Invoice;
+  subject: string;
+  message: string;
+  lastError: string;
+  attempts: number;
+  timestamp: number;
+}
+
+export interface RetryMetrics {
+  totalRetries: number;
+  activeRetries: number;
+  deadLetterCount: number;
+  deadLetterEntries: DeadLetterEntry[];
+}
+
+const deadLetterQueue: DeadLetterEntry[] = [];
+let totalRetries = 0;
+let activeRetries = 0;
+
+export function getRetryMetrics(): RetryMetrics {
+  return {
+    totalRetries,
+    activeRetries,
+    deadLetterCount: deadLetterQueue.length,
+    deadLetterEntries: [...deadLetterQueue],
+  };
+}
+
+export function clearDeadLetterQueue(): void {
+  deadLetterQueue.length = 0;
+}
+
+async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  options: {
+    label: string;
+    maxRetries?: number;
+    baseDelayMs?: number;
+    onRetry?: (attempt: number, error: string) => void;
+    onDeadLetter?: (lastError: string) => void;
+  },
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? CONFIG.maxWebhookRetry;
+  const baseDelayMs = options.baseDelayMs ?? CONFIG.webhookBackoffBaseMs;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await fn();
+      if (attempt > 1) {
+        totalRetries++;
+      }
+      return result;
+    } catch (error: any) {
+      const errorMessage = error?.message ?? String(error);
+      if (attempt < maxRetries) {
+        activeRetries++;
+        totalRetries++;
+        options.onRetry?.(attempt, errorMessage);
+        const backoff = baseDelayMs * 2 ** (attempt - 1);
+        await delay(backoff);
+      } else {
+        options.onDeadLetter?.(errorMessage);
+        throw error;
+      }
+    }
+  }
+
+  throw new Error(`Retry exhausted for ${options.label}`);
+}
+
 export async function sendEmail(
   subscription: Subscription,
   payload: NotificationPayload,
 ): Promise<void> {
-  await resend.emails.send({
-    from: CONFIG.resendFromEmail,
-    to: subscription.destination,
-    subject: payload.subject,
-    html: `<p>${payload.message}</p>
+  await retryWithBackoff(
+    async () => {
+      await resend.emails.send({
+        from: CONFIG.resendFromEmail,
+        to: subscription.destination,
+        subject: payload.subject,
+        html: `<p>${payload.message}</p>
       <p><strong>Invoice #${payload.invoice.id}</strong></p>
       <p>Status: ${payload.invoice.status}</p>
       <p>Due date: ${new Date(payload.invoice.due_date * 1000).toISOString()}</p>`,
-  });
+      });
+    },
+    {
+      label: `email to ${subscription.destination}`,
+      onDeadLetter: (lastError) => {
+        deadLetterQueue.push({
+          channel: "email",
+          destination: subscription.destination,
+          subscriptionId: subscription.id,
+          trigger: payload.trigger,
+          invoice: payload.invoice,
+          subject: payload.subject,
+          message: payload.message,
+          lastError,
+          attempts: CONFIG.maxWebhookRetry,
+          timestamp: Date.now(),
+        });
+      },
+    },
+  );
 }
 
 function getWebhookSignature(secret: string, body: string): string {
@@ -123,10 +219,23 @@ export async function sendWebhook(
       attempts: attempt,
       error: errorMessage,
     });
-    throw new Error(
-      `Webhook failed after ${attempt} attempts: ${response?.status || errorMessage}`,
-    );
+    deadLetterQueue.push({
+      channel: "webhook",
+      destination: subscription.destination,
+      subscriptionId: subscription.id,
+      trigger: payload.trigger,
+      invoice: payload.invoice,
+      subject: payload.subject,
+      message: payload.message,
+      lastError: errorMessage ?? "Unknown error",
+      attempts: attempt,
+      timestamp: Date.now(),
+    });
+    return;
   }
+
+  totalRetries++;
+  activeRetries++;
 
   await updateWebhookDeliveryLog(id, {
     attempts: attempt,
@@ -141,7 +250,7 @@ export async function sendWebhook(
 
 export async function sendSms(
   subscription: Subscription,
-  payload: NotificationPayload
+  payload: NotificationPayload,
 ): Promise<void> {
   const client = getTwilioClient();
   if (!client) {
@@ -156,11 +265,32 @@ export async function sendSms(
     `Due date: ${new Date(payload.invoice.due_date * 1000).toISOString()}`,
   ].join("\n");
 
-  await client.messages.create({
-    to: subscription.destination,
-    from: CONFIG.twilioFromNumber,
-    body: message,
-  });
+  await retryWithBackoff(
+    async () => {
+      await client.messages.create({
+        to: subscription.destination,
+        from: CONFIG.twilioFromNumber,
+        body: message,
+      });
+    },
+    {
+      label: `sms to ${subscription.destination}`,
+      onDeadLetter: (lastError) => {
+        deadLetterQueue.push({
+          channel: "sms",
+          destination: subscription.destination,
+          subscriptionId: subscription.id,
+          trigger: payload.trigger,
+          invoice: payload.invoice,
+          subject: payload.subject,
+          message: payload.message,
+          lastError,
+          attempts: CONFIG.maxWebhookRetry,
+          timestamp: Date.now(),
+        });
+      },
+    },
+  );
 }
 
 export async function deliverNotification(


### PR DESCRIPTION
## Summary
<!-- Brief description of what this PR does -->
Add retry mechanism with exponential backoff, dead letter queue, and retry monitoring to the notification service delivery layer.

## Related Issue
Closes #596 

## Complexity
<!-- Check one -->
- [ ] Trivial (typo, docs, small refactor)
- [ x ] Medium (new feature, non-breaking change)
- [ ] High (breaking change, core protocol logic)

## Changes Made
<!-- Bulleted list of key changes -->
- Added retryWithBackoff<T>() generic helper with exponential backoff (baseDelayMs * 2^(attempt-1)), configurable max retries, and onRetry/onDeadLetter callbacks
- Wrapped sendEmail and sendSms with retryWithBackoff so all channels retry on failure
- Updated sendWebhook to push to the dead letter queue instead of throwing when retries exhaust
- Added DeadLetterEntry interface and in-memory dead letter queue to capture exhausted retries with full context
- Added getRetryMetrics() and clearDeadLetterQueue() for retry monitoring

## Test Coverage
<!-- Paste relevant test output showing coverage -->
```
cargo test
```

<details>
<summary>Test output</summary>

```
<!-- paste here -->
```
</details>

## Security Considerations
<!-- Any security implications? Contract upgrade impact? Access control changes? -->
None — retry logic operates on existing delivery channels with no new access control or contract interaction.

## Checklist
- [ ] Tests pass locally (`cargo test`)
- [ ] New functionality has test coverage
- [ ] `cargo fmt` applied
- [ ] `cargo clippy` warnings resolved
- [ ] Public functions have doc comments
- [ ] Breaking changes documented in PR description
- [ x ] Issue linked (Closes #596 )
