### PR TITLE
feat(sdk): add transaction history with filters, pagination and CSV export

### DIFF
--- a/packages/sdk/src/clients/InvoiceClient.test.ts
+++ b/packages/sdk/src/clients/InvoiceClient.test.ts
@@ -1,8 +1,307 @@
-﻿import { InvoiceClient } from './InvoiceClient';
+import {
+  InvoiceClient,
+  exportTransactionsToCsv,
+  TransactionRecord,
+} from './InvoiceClient';
 
-describe('InvoiceClient', () => {
-  it('should initialize correctly', () => {
-    const client = new InvoiceClient('https://horizon-testnet.stellar.org', 'CONTRACT_ID');
-    expect(client).toBeDefined();
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOp(overrides: Partial<Record<string, any>> = {}): any {
+  return {
+    id: 'op-1',
+    created_at: '2024-06-01T12:00:00Z',
+    type: 'payment',
+    source_account: 'GABC',
+    from: 'GABC',
+    to: 'GXYZ',
+    asset_type: 'credit_alphanum4',
+    asset_code: 'USDC',
+    amount: '100.0000000',
+    transaction_hash: 'hash-abc',
+    paging_token: 'token-1',
+    ...overrides,
+  };
+}
+
+function mockServer(records: any[]) {
+  const callFn = jest.fn().mockResolvedValue({ records });
+  const queryChain = {
+    forAccount: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    cursor: jest.fn().mockReturnThis(),
+    call: callFn,
+  };
+  return { queryChain, callFn };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('InvoiceClient.getTransactionHistory', () => {
+  let client: InvoiceClient;
+
+  beforeEach(() => {
+    client = new InvoiceClient('https://horizon-testnet.stellar.org', 'CONTRACT_ID');
+  });
+
+  it('returns normalised records from Horizon', async () => {
+    const { queryChain } = mockServer([makeOp()]);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC');
+
+    expect(page.records).toHaveLength(1);
+    expect(page.records[0]).toMatchObject({
+      id: 'op-1',
+      type: 'payment',
+      from: 'GABC',
+      to: 'GXYZ',
+      asset: 'USDC',
+      amount: '100.0000000',
+      transactionHash: 'hash-abc',
+    });
+    expect(page.count).toBe(1);
+  });
+
+  it('maps native XLM asset correctly', async () => {
+    const { queryChain } = mockServer([
+      makeOp({ asset_type: 'native', asset_code: undefined }),
+    ]);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC');
+    expect(page.records[0].asset).toBe('XLM');
+  });
+
+  // Filter by type
+  it('filters records by type', async () => {
+    const { queryChain } = mockServer([
+      makeOp({ id: 'op-1', type: 'payment' }),
+      makeOp({ id: 'op-2', type: 'create_account' }),
+    ]);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC', { type: 'payment' });
+    expect(page.records).toHaveLength(1);
+    expect(page.records[0].id).toBe('op-1');
+  });
+
+  it('returns all records when no type filter is given', async () => {
+    const { queryChain } = mockServer([
+      makeOp({ id: 'op-1', type: 'payment' }),
+      makeOp({ id: 'op-2', type: 'create_account' }),
+    ]);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC');
+    expect(page.records).toHaveLength(2);
+  });
+
+  // Filter by date range
+  it('filters records by startDate', async () => {
+    const { queryChain } = mockServer([
+      makeOp({ id: 'op-old', created_at: '2024-01-01T00:00:00Z' }),
+      makeOp({ id: 'op-new', created_at: '2024-06-01T00:00:00Z' }),
+    ]);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC', {
+      startDate: '2024-03-01T00:00:00Z',
+    });
+
+    expect(page.records).toHaveLength(1);
+    expect(page.records[0].id).toBe('op-new');
+  });
+
+  it('filters records by endDate', async () => {
+    const { queryChain } = mockServer([
+      makeOp({ id: 'op-old', created_at: '2024-01-01T00:00:00Z' }),
+      makeOp({ id: 'op-new', created_at: '2024-06-01T00:00:00Z' }),
+    ]);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC', {
+      endDate: '2024-03-01T00:00:00Z',
+    });
+
+    expect(page.records).toHaveLength(1);
+    expect(page.records[0].id).toBe('op-old');
+  });
+
+  it('filters records by both startDate and endDate', async () => {
+    const { queryChain } = mockServer([
+      makeOp({ id: 'op-a', created_at: '2024-01-01T00:00:00Z' }),
+      makeOp({ id: 'op-b', created_at: '2024-04-01T00:00:00Z' }),
+      makeOp({ id: 'op-c', created_at: '2024-08-01T00:00:00Z' }),
+    ]);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC', {
+      startDate: '2024-03-01T00:00:00Z',
+      endDate: '2024-06-01T00:00:00Z',
+    });
+
+    expect(page.records).toHaveLength(1);
+    expect(page.records[0].id).toBe('op-b');
+  });
+
+  it('accepts Date objects for startDate and endDate', async () => {
+    const { queryChain } = mockServer([
+      makeOp({ id: 'op-a', created_at: '2024-01-01T00:00:00Z' }),
+      makeOp({ id: 'op-b', created_at: '2024-06-01T00:00:00Z' }),
+    ]);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC', {
+      startDate: new Date('2024-03-01'),
+      endDate: new Date('2024-12-31'),
+    });
+
+    expect(page.records).toHaveLength(1);
+    expect(page.records[0].id).toBe('op-b');
+  });
+
+  // Pagination
+  it('respects the limit option', async () => {
+    const ops = Array.from({ length: 10 }, (_, i) =>
+      makeOp({ id: `op-${i}`, paging_token: `token-${i}` }),
+    );
+    const { queryChain } = mockServer(ops);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC', { limit: 3 });
+    expect(page.records).toHaveLength(3);
+    expect(page.count).toBe(3);
+  });
+
+  it('clamps limit to 200', async () => {
+    const { queryChain } = mockServer([makeOp()]);
+    (client as any).server = { payments: () => queryChain };
+
+    await client.getTransactionHistory('GABC', { limit: 9999 });
+    expect(queryChain.limit).toHaveBeenCalledWith(200);
+  });
+
+  it('returns nextCursor when more pages exist', async () => {
+    const ops = Array.from({ length: 5 }, (_, i) =>
+      makeOp({ id: `op-${i}`, paging_token: `token-${i}` }),
+    );
+    const { queryChain } = mockServer(ops);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC', { limit: 5 });
+    expect(page.nextCursor).toBe('token-4');
+  });
+
+  it('returns no nextCursor when records are fewer than limit', async () => {
+    const { queryChain } = mockServer([makeOp()]);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC', { limit: 20 });
+    expect(page.nextCursor).toBeUndefined();
+  });
+
+  it('passes cursor to Horizon when provided', async () => {
+    const { queryChain } = mockServer([]);
+    (client as any).server = { payments: () => queryChain };
+
+    await client.getTransactionHistory('GABC', { cursor: 'token-42' });
+    expect(queryChain.cursor).toHaveBeenCalledWith('token-42');
+  });
+
+  it('passes order to Horizon', async () => {
+    const { queryChain } = mockServer([]);
+    (client as any).server = { payments: () => queryChain };
+
+    await client.getTransactionHistory('GABC', { order: 'asc' });
+    expect(queryChain.order).toHaveBeenCalledWith('asc');
+  });
+
+  it('defaults to desc order', async () => {
+    const { queryChain } = mockServer([]);
+    (client as any).server = { payments: () => queryChain };
+
+    await client.getTransactionHistory('GABC');
+    expect(queryChain.order).toHaveBeenCalledWith('desc');
+  });
+
+  it('returns empty page when Horizon returns no records', async () => {
+    const { queryChain } = mockServer([]);
+    (client as any).server = { payments: () => queryChain };
+
+    const page = await client.getTransactionHistory('GABC');
+    expect(page.records).toHaveLength(0);
+    expect(page.nextCursor).toBeUndefined();
+    expect(page.count).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exportTransactionsToCsv
+// ---------------------------------------------------------------------------
+
+describe('exportTransactionsToCsv', () => {
+  const record: TransactionRecord = {
+    id: 'op-1',
+    createdAt: '2024-06-01T12:00:00Z',
+    type: 'payment',
+    from: 'GABC',
+    to: 'GXYZ',
+    asset: 'USDC',
+    amount: '100.0000000',
+    transactionHash: 'hash-abc',
+  };
+
+  it('produces a header row', () => {
+    const csv = exportTransactionsToCsv([record]);
+    const firstLine = csv.split('\n')[0];
+    expect(firstLine).toBe('id,createdAt,type,from,to,asset,amount,transactionHash');
+  });
+
+  it('produces one data row per record', () => {
+    const csv = exportTransactionsToCsv([record, { ...record, id: 'op-2' }]);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(3);
+  });
+
+  it('exports all fields in the correct order', () => {
+    const csv = exportTransactionsToCsv([record]);
+    const dataRow = csv.split('\n')[1];
+    expect(dataRow).toBe('op-1,2024-06-01T12:00:00Z,payment,GABC,GXYZ,USDC,100.0000000,hash-abc');
+  });
+
+  it('handles undefined optional fields as empty strings', () => {
+    const minimal: TransactionRecord = {
+      id: 'op-min',
+      createdAt: '2024-06-01T12:00:00Z',
+      type: 'create_account',
+      from: 'GABC',
+      transactionHash: 'hash-min',
+    };
+    const csv = exportTransactionsToCsv([minimal]);
+    const dataRow = csv.split('\n')[1];
+    expect(dataRow.split(',')).toHaveLength(8);
+  });
+
+  it('wraps values containing commas in double quotes', () => {
+    const r: TransactionRecord = { ...record, amount: '1,000.00' };
+    const csv = exportTransactionsToCsv([r]);
+    expect(csv).toContain('"1,000.00"');
+  });
+
+  it('escapes double quotes inside values per RFC 4180', () => {
+    const r: TransactionRecord = { ...record, asset: 'US"DC' };
+    const csv = exportTransactionsToCsv([r]);
+    expect(csv).toContain('"US""DC"');
+  });
+
+  it('returns only a header row for an empty array', () => {
+    const csv = exportTransactionsToCsv([]);
+    expect(csv).toBe('id,createdAt,type,from,to,asset,amount,transactionHash');
+    expect(csv.split('\n')).toHaveLength(1);
   });
 });

--- a/packages/sdk/src/clients/InvoiceClient.ts
+++ b/packages/sdk/src/clients/InvoiceClient.ts
@@ -1,10 +1,176 @@
-﻿import { Horizon } from '@stellar/stellar-sdk';
+import { Horizon } from '@stellar/stellar-sdk';
+
+/**
+ * Supported transaction types for filtering history.
+ * Maps to Horizon operation type strings.
+ */
+export type TransactionType =
+  | 'payment'
+  | 'create_account'
+  | 'change_trust'
+  | 'manage_sell_offer'
+  | 'manage_buy_offer'
+  | 'path_payment_strict_send'
+  | 'path_payment_strict_receive'
+  | 'invoke_host_function';
+
+/**
+ * A normalised transaction record returned by {@link InvoiceClient.getTransactionHistory}.
+ */
+export interface TransactionRecord {
+  /** Unique operation ID from Horizon. */
+  id: string;
+  /** ISO-8601 timestamp of when the operation was included in a ledger. */
+  createdAt: string;
+  /** Horizon operation type string (e.g. `"payment"`, `"invoke_host_function"`). */
+  type: TransactionType | string;
+  /** Source account that submitted the transaction. */
+  from: string;
+  /** Destination account (present for payment-like operations). */
+  to?: string;
+  /** Asset code (e.g. `"XLM"`, `"USDC"`). */
+  asset?: string;
+  /** Human-readable amount as a string to preserve decimal precision. */
+  amount?: string;
+  /** Hash of the parent transaction envelope. */
+  transactionHash: string;
+}
+
+/**
+ * Options for {@link InvoiceClient.getTransactionHistory}.
+ */
+export interface TransactionHistoryOptions {
+  /**
+   * Filter to a specific operation type.
+   * When omitted all types are returned.
+   */
+  type?: TransactionType | string;
+  /**
+   * Inclusive lower bound (ISO-8601 or `Date`).
+   * Operations with `created_at` before this value are excluded.
+   */
+  startDate?: string | Date;
+  /**
+   * Inclusive upper bound (ISO-8601 or `Date`).
+   * Operations with `created_at` after this value are excluded.
+   */
+  endDate?: string | Date;
+  /**
+   * Number of records per page (1–200, default 20).
+   * Horizon caps this at 200.
+   */
+  limit?: number;
+  /**
+   * Pagination cursor returned by a previous call as `nextCursor`.
+   * Pass this value to fetch the next page of results.
+   */
+  cursor?: string;
+  /**
+   * Sort order for results (default `"desc"` — newest first).
+   */
+  order?: 'asc' | 'desc';
+}
+
+/**
+ * Paginated response from {@link InvoiceClient.getTransactionHistory}.
+ */
+export interface TransactionHistoryPage {
+  /** The records on this page. */
+  records: TransactionRecord[];
+  /**
+   * Cursor to pass as `cursor` to fetch the next page.
+   * `undefined` when there are no more pages.
+   */
+  nextCursor?: string;
+  /** Total number of records returned on this page. */
+  count: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function toDate(value: string | Date): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+function normaliseOperation(op: any): TransactionRecord {
+  return {
+    id: op.id,
+    createdAt: op.created_at,
+    type: op.type,
+    from: op.source_account ?? op.from ?? '',
+    to: op.to,
+    asset:
+      op.asset_type === 'native'
+        ? 'XLM'
+        : op.asset_code ?? op.selling_asset_code ?? op.buying_asset_code,
+    amount: op.amount ?? op.starting_balance,
+    transactionHash: op.transaction_hash,
+  };
+}
+
+/**
+ * Converts an array of {@link TransactionRecord} objects to a CSV string.
+ *
+ * @param records - The records to serialise.
+ * @returns A UTF-8 CSV string with a header row.
+ */
+export function exportTransactionsToCsv(records: TransactionRecord[]): string {
+  const headers = [
+    'id',
+    'createdAt',
+    'type',
+    'from',
+    'to',
+    'asset',
+    'amount',
+    'transactionHash',
+  ] as const;
+
+  const escape = (value: string | undefined): string => {
+    if (value === undefined || value === '') return '';
+    // Wrap in quotes and escape any inner quotes per RFC 4180
+    const str = String(value);
+    if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+      return `"${str.replace(/"/g, '""')}"`;
+    }
+    return str;
+  };
+
+  const rows = records.map((r) =>
+    headers.map((h) => escape(r[h])).join(','),
+  );
+
+  return [headers.join(','), ...rows].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
 
 /**
  * Client for interacting with the Invoice Liquidity Network protocol on Stellar.
  *
- * Provides methods to create, fund, and settle invoices via the ILN smart contract.
- * Requires a Horizon server URL and the deployed contract ID.
+ * Provides methods to create, fund, and settle invoices via the ILN smart contract,
+ * and to query, filter, paginate, and export an account's transaction history.
+ *
+ * @example
+ * ```ts
+ * const client = new InvoiceClient(
+ *   'https://horizon-testnet.stellar.org',
+ *   'CA3D...',
+ * );
+ *
+ * // Fetch the last 10 payments
+ * const page = await client.getTransactionHistory('GB...', {
+ *   type: 'payment',
+ *   limit: 10,
+ * });
+ *
+ * // Export to CSV
+ * const csv = exportTransactionsToCsv(page.records);
+ * ```
  */
 export class InvoiceClient {
   private server: Horizon.Server;
@@ -21,38 +187,139 @@ export class InvoiceClient {
     this.contractId = contractId;
   }
 
+  // -------------------------------------------------------------------------
+  // Invoice lifecycle
+  // -------------------------------------------------------------------------
+
   /**
    * Submits a new invoice to the ILN smart contract for liquidity.
    *
-   * @param invoiceData - The invoice payload to submit on-chain. Should include payer address, amount, discount rate, due date, and token contract ID.
+   * @param invoiceData - The invoice payload to submit on-chain.
    * @returns A promise that resolves when the invoice has been submitted.
    */
-  public async submitInvoice(invoiceData: any) {
-    console.log("Submitting invoice...");
+  public async submitInvoice(invoiceData: any): Promise<void> {
+    console.log('Submitting invoice...');
   }
 
   /**
    * Funds a pending invoice as a liquidity provider.
    *
-   * The caller provides liquidity for the invoice at the agreed discount rate.
-   * The invoice must be in Pending status.
-   *
    * @param invoiceId - The unique identifier of the invoice to fund.
    * @returns A promise that resolves when the funding transaction is complete.
    */
-  public async fundInvoice(invoiceId: string) {
-    console.log("Funding invoice: " + invoiceId);
+  public async fundInvoice(invoiceId: string): Promise<void> {
+    console.log('Funding invoice: ' + invoiceId);
   }
 
   /**
    * Marks an invoice as paid, releasing the escrowed funds to the liquidity provider.
    *
-   * Typically called by the invoice payer or an authorized oracle once payment is confirmed.
-   *
    * @param invoiceId - The unique identifier of the invoice to mark as paid.
    * @returns A promise that resolves when the payment has been confirmed on-chain.
    */
-  public async markPaid(invoiceId: string) {
-    console.log("Marking invoice as paid: " + invoiceId);
+  public async markPaid(invoiceId: string): Promise<void> {
+    console.log('Marking invoice as paid: ' + invoiceId);
+  }
+
+  // -------------------------------------------------------------------------
+  // Transaction history
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fetches paginated transaction history for a Stellar account.
+   *
+   * Results are sourced from the Horizon payments endpoint and normalised into
+   * {@link TransactionRecord} objects. Client-side filters are applied after
+   * the Horizon response so that `limit` reflects the number of records
+   * **returned to the caller** (post-filter), not the raw Horizon page size.
+   *
+   * @param accountId - The Stellar public key (`G...`) to query.
+   * @param options - Optional filters, pagination cursor, and sort order.
+   * @returns A {@link TransactionHistoryPage} containing records and a cursor
+   *   for the next page.
+   *
+   * @example
+   * ```ts
+   * // Page 1
+   * const page1 = await client.getTransactionHistory('GB...', { limit: 20 });
+   *
+   * // Page 2
+   * const page2 = await client.getTransactionHistory('GB...', {
+   *   limit: 20,
+   *   cursor: page1.nextCursor,
+   * });
+   * ```
+   */
+  public async getTransactionHistory(
+    accountId: string,
+    options: TransactionHistoryOptions = {},
+  ): Promise<TransactionHistoryPage> {
+    const {
+      type,
+      startDate,
+      endDate,
+      limit = 20,
+      cursor,
+      order = 'desc',
+    } = options;
+
+    const clampedLimit = Math.min(Math.max(1, limit), 200);
+
+    // Fetch from Horizon — request more than needed so client-side filtering
+    // doesn't leave the caller with fewer records than expected on sparse pages.
+    const horizonLimit = Math.min(clampedLimit * 3, 200);
+
+    let query = this.server
+      .payments()
+      .forAccount(accountId)
+      .limit(horizonLimit)
+      .order(order);
+
+    if (cursor) {
+      query = query.cursor(cursor);
+    }
+
+    const response = await query.call();
+    const raw: any[] = response.records ?? [];
+
+    // Normalise
+    let records = raw.map(normaliseOperation);
+
+    // Filter by type
+    if (type) {
+      records = records.filter((r) => r.type === type);
+    }
+
+    // Filter by date range
+    if (startDate) {
+      const start = toDate(startDate).getTime();
+      records = records.filter(
+        (r) => new Date(r.createdAt).getTime() >= start,
+      );
+    }
+
+    if (endDate) {
+      const end = toDate(endDate).getTime();
+      records = records.filter(
+        (r) => new Date(r.createdAt).getTime() <= end,
+      );
+    }
+
+    // Trim to requested limit
+    const page = records.slice(0, clampedLimit);
+
+    // Build next-page cursor from the last raw Horizon record (pre-filter)
+    // so that subsequent calls continue from where Horizon left off.
+    const lastRaw = raw[raw.length - 1];
+    const nextCursor =
+      raw.length > 0 && page.length === clampedLimit
+        ? lastRaw.paging_token
+        : undefined;
+
+    return {
+      records: page,
+      nextCursor,
+      count: page.length,
+    };
   }
 }


### PR DESCRIPTION
## Summary
Adds transaction history tracking to the SDK InvoiceClient with filtering, pagination, and CSV export support.

## Related Issue
Closes #574 

## Complexity
<!-- Check one -->
- [v ] Medium (new feature, non-breaking change)

## Changes Made
<!-- Bulleted list of key changes -->
- Added `getTransactionHistory()` to `InvoiceClient` fetching from Horizon payments endpoint
- Filter by transaction type and date range (startDate / endDate)
- Cursor-based pagination with `limit`, `cursor`, and `order` options
- Added `exportTransactionsToCsv()` utility (RFC 4180 compliant)

## Test Coverage
<!-- Paste relevant test output showing coverage -->
```
Tests: 23 passed, 23 total
Time: 19.17s```

## Security Considerations
<!-- Any security implications? Contract upgrade impact? Access control changes? -->
No security implications. Read-only Horizon API calls, no contract interaction.

## Checklist
- [v ] Tests pass locally (`cargo test`)
- [ v] New functionality has test coverage
- [ ] `cargo fmt` applied
- [ ] `cargo clippy` warnings resolved
- [ v] Public functions have doc comments
- [ ] Breaking changes documented in PR description
- [v ] Issue linked (Closes #)
